### PR TITLE
fix: pin numpy<2.2 in dev extras so mypy passes on fresh installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.6",
     "mypy>=1.10",
+    # numpy is only a transitive dependency (via langchain-aws), but numpy >= 2.2
+    # ships stubs that use PEP 695 `type` statements, which mypy rejects under
+    # python_version = "3.11" and aborts the whole run (`make typecheck` fails on
+    # a fresh install). Pin below 2.2 for dev environments until the mypy target
+    # moves to 3.12+.
+    "numpy<2.2",
 ]
 # Provider integrations are optional — install the one your YAML's
 # `model.provider` references. `init_chat_model` imports it lazily.


### PR DESCRIPTION
## Summary
A fresh `make install` today pulls numpy 2.5.x (transitive dependency via `langchain-aws`). numpy >= 2.2 ships stubs that use PEP 695 `type` statements, which mypy rejects under the project's `python_version = "3.11"` setting and aborts the entire run — so `make check` fails out of the box for new contributors. This pins numpy below 2.2 in the **dev extra only**; runtime dependencies are unaffected.

## Files changed
- `pyproject.toml` — added `numpy<2.2` to `[project.optional-dependencies].dev` with an explanatory comment.

## Why a pin and not a mypy override
Per-module overrides (`follow_imports = skip`, `ignore_errors`) were tried first and do **not** help — mypy still parses the stub file and the syntax error is a blocker. Bumping `python_version` to 3.12 would fix it too, but would stop validating the project's own 3.11 compatibility (`requires-python >= 3.11`), so it felt like a maintainer decision. The pin can be dropped when the mypy target moves to 3.12+.

## Commands run
- `make check` — **pass** (ruff clean, mypy clean, 339 tests passed)
- Reproduced the failure first with numpy 2.5.1, then verified the fix on a reinstall (numpy 2.1.3 resolved automatically).

## Out of scope
- No CI workflow currently runs `make check` on PRs — happy to propose that as a follow-up task per `tasks/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)