### PR TITLE
fix: Docker entrypoint can't launch agent-manager (documented widget quickstart is broken)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "serve" ] && [ -f /workspace/requirements.txt ]; then
+if { [ "$1" = "serve" ] || [ "$1" = "agent-manager" ]; } && [ -f /workspace/requirements.txt ]; then
     echo "Installing user dependencies..." >&2
     pip install -q -r /workspace/requirements.txt
+fi
+
+# `agent-manager` is its own console script (the conversation/widget server),
+# not an agentctl subcommand — dispatch to it directly.
+if [ "$1" = "agent-manager" ]; then
+    exec "$@"
 fi
 
 exec agentctl "$@"


### PR DESCRIPTION
## Summary
The quickstart's widget step (`docs/quickstart.mdx`) instructs running `docker run ... agent-manager --config agents.yml --port 8100`, but `entrypoint.sh` unconditionally `exec agentctl "$@"` — so the container runs `agentctl agent-manager ...` and dies with *No such command*. The embeddable chat widget is therefore unreachable from the published image.

## Files changed
- `entrypoint.sh` — dispatch on `$1`: `agent-manager` (its own console script per `pyproject.toml` `[project.scripts]`) is exec'd directly; all other commands still route through `agentctl`. The optional `/workspace/requirements.txt` install now also runs for `agent-manager`, since plugin deps are needed by that server too.

## Verification
Simulated the entrypoint with stub `agentctl`/`agent-manager` binaries on PATH:
- `serve --config agents.yml` → `agentctl serve --config agents.yml` (unchanged)
- `validate agents.yml` → `agentctl validate agents.yml` (unchanged)
- `agent-manager --config agents.yml --port 8100` → dispatches to the `agent-manager` console script (fixed)
- `sh -n` syntax check passes

## Out of scope
Dockerfile hardening (non-root USER, HEALTHCHECK, .dockerignore) — happy to follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)