### PR TITLE
fix: AccessFilter fails open (run crash) when the access resolver raises

### DIFF
--- a/src/agent_engine/engine/langgraph/filters.py
+++ b/src/agent_engine/engine/langgraph/filters.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Protocol, TypeVar
+
+logger = logging.getLogger(__name__)
 
 
 class Filterable(Protocol):
@@ -43,7 +46,25 @@ class AccessFilter(RouteFilter):
         self._resolver = _load_access_resolver(base_dir)
 
     def filter(self, ctx: dict[str, Any], candidates: list[T]) -> list[T]:
-        return [c for c in candidates if not c.protected or self._resolver.can_access(ctx, c.id)]
+        return [c for c in candidates if not c.protected or self._can_access(ctx, c.id)]
+
+    def _can_access(self, ctx: dict[str, Any], node_id: str) -> bool:
+        """Ask the resolver, failing closed: a raising resolver hides the node.
+
+        The documented contract (docs/SIDECAR_CONTEXT_AUTH.md) is that a
+        protected node is hidden when ``can_access`` returns false *or raises*.
+        Letting the exception propagate would fail the whole run — or worse,
+        an unimplemented resolver stub would crash instead of denying access.
+        """
+        try:
+            return bool(self._resolver.can_access(ctx, node_id))
+        except Exception:
+            logger.warning(
+                "access resolver raised for protected node '%s'; hiding it (fail closed)",
+                node_id,
+                exc_info=True,
+            )
+            return False
 
 
 def _load_access_resolver(base_dir: Path) -> Any:

--- a/tests/engine/test_engine_flow.py
+++ b/tests/engine/test_engine_flow.py
@@ -277,6 +277,44 @@ async def test_protected_child_denied_when_run_context_missing_custom_data(
     assert result.visited == ["root", "root/public"]
 
 
+def write_raising_access(base_dir: Path, *, exc: str) -> None:
+    plugins = base_dir / "plugins"
+    plugins.mkdir(parents=True, exist_ok=True)
+    (plugins / "access.py").write_text(
+        "class AccessResolver:\n"
+        "    def can_access(self, ctx: dict, node_id: str) -> bool:\n"
+        f"        raise {exc}\n",
+        encoding="utf-8",
+    )
+
+
+async def test_protected_child_hidden_when_resolver_raises(
+    tmp_path: Path, model_factory: Any
+) -> None:
+    # Contract (docs/SIDECAR_CONTEXT_AUTH.md): if can_access returns false OR
+    # RAISES, the node is hidden — the run must not fail open or crash.
+    write_raising_access(tmp_path, exc="RuntimeError('policy backend down')")
+    spec = system(orchestrator("root", [agent("public"), agent("admin", protected=True)]))
+
+    result = await run_message(spec, tmp_path, model_factory, "go to admin please")
+
+    assert "root/admin" not in result.visited
+    assert result.visited == ["root", "root/public"]
+
+
+async def test_unimplemented_resolver_stub_denies_instead_of_crashing(
+    tmp_path: Path, model_factory: Any
+) -> None:
+    # A generated-but-unimplemented plugins/access.py raises NotImplementedError;
+    # protected nodes must be denied, not take the whole run down.
+    write_raising_access(tmp_path, exc="NotImplementedError")
+    spec = system(orchestrator("root", [agent("public"), agent("admin", protected=True)]))
+
+    result = await run_message(spec, tmp_path, model_factory, "admin task")
+
+    assert result.visited == ["root", "root/public"]
+
+
 async def test_stream_passes_run_context_to_access_filter(
     tmp_path: Path, model_factory: Any
 ) -> None:


### PR DESCRIPTION
## Summary
`docs/SIDECAR_CONTEXT_AUTH.md` documents the contract: *"If `can_access` returns false **or raises**, the node is hidden."* The second half wasn't implemented — an exception from `can_access` propagated out of `AccessFilter.filter` and failed the whole run with a 500. Notably, the stub that `agentctl generate` produces for `plugins/access.py` raises `NotImplementedError`, so a generated-but-not-yet-implemented resolver crashed every run that reached an orchestrator with a protected child, instead of failing safe.

## Files changed
- `src/agent_engine/engine/langgraph/filters.py` — resolver call wrapped in `_can_access`: any exception hides the protected node (fail closed) and logs a warning with traceback. Result is also coerced with `bool(...)`.
- `tests/engine/test_engine_flow.py` — two new flow tests: a resolver raising `RuntimeError` and the generated `NotImplementedError` stub both deny the protected node while the run completes through public nodes.

## Architecture rules respected
Change is confined to the filter layer; no contract change — this implements the already-documented contract. Behavior for non-protected candidates is untouched.

## Commands run
`make check` — pass (ruff clean, mypy clean, **341 tests passed** including the 2 new ones).

## Out of scope
Protected nodes that are not children of an orchestrator are never filtered at all (only `OrchestratorNode._filter_children` applies the filter) — that's a deeper Phase-6 gap I can propose as a task if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)