### PR TITLE
docs: remove stray character in CLAUDE.md heading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Declarative platform for building AI agent systems. See `docs/` for architecture details and `tasks/` for current work.
 
-w## Naming
+## Naming
 
 The product/brand name is **Extra** (matches the GitHub repo, docs site, and `docs.json`). `agent-engine` is only the PyPI/package name of the core engine; `agentctl` and `agent-manager` are the CLI/console scripts. Don't call the product "Agent Engine" in user-facing copy (README, docs landing page) — use "Extra".
 


### PR DESCRIPTION
Fix a leftover 'w' that prefixed the '## Naming' heading, so the heading renders correctly.