### PR TITLE
feat: startup validation fails on declared-but-unimplemented plugin stubs

### DIFF
--- a/examples/enterprise-knowledge-assistant/plugins/tools/build_learning_plan.py
+++ b/examples/enterprise-knowledge-assistant/plugins/tools/build_learning_plan.py
@@ -1,4 +1,26 @@
 def build_learning_plan(input: dict) -> str:
-    """Build a personalized learning roadmap from the collected research findings.
-"""
-    raise NotImplementedError
+    """Build a personalized learning roadmap from the collected research
+    findings.
+
+    Expects ``topics`` (ordered list of things to learn) and optionally
+    ``experience_level`` and ``weeks`` (total duration). Returns a phased
+    markdown roadmap the learning planner presents to the user.
+    """
+    topics = [str(t) for t in input.get("topics") or []]
+    if not topics:
+        return "No topics provided. Call with {'topics': [...], 'weeks': 4}."
+
+    level = str(input.get("experience_level") or "beginner")
+    weeks = max(int(input.get("weeks") or len(topics)), 1)
+    per_topic = max(weeks // len(topics), 1)
+
+    lines = [f"# Learning plan ({level}, ~{weeks} weeks)", ""]
+    week = 1
+    for topic in topics:
+        end = min(week + per_topic - 1, weeks)
+        span = f"Week {week}" if end == week else f"Weeks {week}-{end}"
+        lines.append(f"- **{span}:** {topic}")
+        week = end + 1
+    lines.append("")
+    lines.append("Adjust pace as needed — each phase builds on the previous one.")
+    return "\n".join(lines)

--- a/examples/enterprise-knowledge-assistant/plugins/tools/generate_decision_matrix.py
+++ b/examples/enterprise-knowledge-assistant/plugins/tools/generate_decision_matrix.py
@@ -1,4 +1,32 @@
 def generate_decision_matrix(input: dict) -> str:
-    """Generate a structured comparison matrix between technologies using repository analysis and official documentation.
-"""
-    raise NotImplementedError
+    """Generate a structured comparison matrix between technologies using
+    repository analysis and official documentation.
+
+    Expects ``options`` (list of technology names) and optionally
+    ``criteria`` (list of comparison dimensions) and ``scores`` (mapping of
+    "option/criterion" to a short note). Returns a markdown table the
+    comparison agent can present or refine.
+    """
+    options = [str(o) for o in input.get("options") or []]
+    if not options:
+        return "No options provided. Call with {'options': [...], 'criteria': [...]}."
+
+    criteria = [str(c) for c in input.get("criteria") or []] or [
+        "Maturity",
+        "Ecosystem",
+        "Learning curve",
+        "Performance",
+    ]
+    scores: dict = input.get("scores") or {}
+
+    header = "| Criterion | " + " | ".join(options) + " |"
+    separator = "| --- " * (len(options) + 1) + "|"
+    rows = [
+        "| "
+        + criterion
+        + " | "
+        + " | ".join(str(scores.get(f"{option}/{criterion}", "n/a")) for option in options)
+        + " |"
+        for criterion in criteria
+    ]
+    return "\n".join([header, separator, *rows])

--- a/src/agent_engine/core/plugin_stubs.py
+++ b/src/agent_engine/core/plugin_stubs.py
@@ -1,0 +1,208 @@
+"""Startup detection of generated-but-unimplemented plugin functions.
+
+``agentctl generate`` writes plugin stubs whose bodies are a single
+``raise NotImplementedError``. A forgotten stub imports cleanly and only
+explodes mid-request — the failure meets the user instead of the
+developer. This module lets validation surface every unimplemented
+plugin up front, in one consolidated report at startup.
+
+Detection is purely static: plugin files are parsed (``ast``), never
+executed, so scanning has no side effects. The scan is deliberately
+conservative — it reports only what it can positively identify:
+
+- a function/method whose body is just ``raise NotImplementedError``
+  (optionally preceded by a docstring) is a stub;
+- a missing plugin file for something the spec declares is an error;
+- anything else (dynamic definitions, methods inherited from bases other
+  than the conventional ``shared.py``, unparseable files) is skipped and
+  left for the runtime loaders to diagnose.
+"""
+
+from __future__ import annotations
+
+import ast
+from enum import Enum
+from pathlib import Path
+
+from agent_engine.core.errors import ValidationError
+from agent_engine.core.spec import AgentSpec, GraphNode, SystemSpec
+
+_GENERATE_HINT = "run `agentctl generate` to create the stub"
+
+
+def scan_unimplemented_plugins(spec: SystemSpec, base_dir: Path) -> list[ValidationError]:
+    """Return one error per declared-but-unimplemented plugin function."""
+    scanner = _Scanner(base_dir)
+    scanner.walk(spec.graph)
+    if scanner.has_protected:
+        scanner.check_access()
+    return scanner.errors
+
+
+class _Verdict(Enum):
+    IMPLEMENTED = "implemented"
+    STUB = "stub"
+    NO_FILE = "no_file"
+    NO_FUNCTION = "no_function"
+
+
+class _Scanner:
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+        self._seen_tools: set[str] = set()
+        self._seen_mcp_auth: set[str] = set()
+        self.has_protected = False
+        self.errors: list[ValidationError] = []
+
+    def walk(self, node: GraphNode) -> None:
+        if node.node.protected:
+            self.has_protected = True
+        if isinstance(node.node, AgentSpec):
+            self._check_tools(node.node)
+            self._check_resolvers(node.node)
+            self._check_mcp_auth(node.node)
+        for child in node.children:
+            self.walk(child)
+
+    # -- tools -----------------------------------------------------------
+
+    def _check_tools(self, agent: AgentSpec) -> None:
+        for tool in agent.tools:
+            if tool.id in self._seen_tools:
+                continue
+            self._seen_tools.add(tool.id)
+            rel = Path("plugins") / "tools" / f"{tool.id}.py"
+            verdict = _stub_verdict(self._base_dir / rel, tool.id)
+            if verdict is _Verdict.NO_FILE:
+                self._error(
+                    f"tools.{tool.id}",
+                    f"Tool plugin not found: {rel} — {_GENERATE_HINT}",
+                )
+            elif verdict is _Verdict.STUB:
+                self._error(
+                    f"tools.{tool.id}",
+                    f"Tool '{tool.id}' is declared but not implemented (generated stub): {rel}",
+                )
+
+    # -- resolvers -------------------------------------------------------
+
+    def _check_resolvers(self, agent: AgentSpec) -> None:
+        if not agent.resolvers:
+            return
+        agent_rel = Path("plugins") / "resolvers" / f"{agent.id}.py"
+        agent_path = self._base_dir / agent_rel
+        if not agent_path.is_file():
+            self._error(
+                f"{agent.id}.resolvers",
+                f"Resolver plugin not found: {agent_rel} — {_GENERATE_HINT}",
+            )
+            return
+        shared_path = self._base_dir / "plugins" / "resolvers" / "shared.py"
+        for resolver in agent.resolvers:
+            verdict = _stub_verdict(agent_path, resolver.id, class_name="Resolver")
+            if verdict is _Verdict.NO_FUNCTION:
+                # Fall back to the conventional shared base class.
+                verdict = _stub_verdict(shared_path, resolver.id, class_name="SharedResolver")
+            if verdict is _Verdict.STUB:
+                self._error(
+                    f"{agent.id}.resolvers.{resolver.id}",
+                    f"Resolver '{resolver.id}' is declared but not implemented (generated stub)",
+                )
+
+    # -- MCP auth --------------------------------------------------------
+
+    def _check_mcp_auth(self, agent: AgentSpec) -> None:
+        for mcp in agent.mcps:
+            if not mcp.auth or mcp.id in self._seen_mcp_auth:
+                continue
+            self._seen_mcp_auth.add(mcp.id)
+            rel = Path("plugins") / "mcp_auth" / f"{mcp.id}.py"
+            verdict = _stub_verdict(self._base_dir / rel, "get_headers")
+            if verdict is _Verdict.NO_FILE:
+                self._error(
+                    f"mcps.{mcp.id}.auth",
+                    f"MCP auth plugin not found: {rel} — {_GENERATE_HINT}",
+                )
+            elif verdict is _Verdict.STUB:
+                self._error(
+                    f"mcps.{mcp.id}.auth",
+                    f"MCP auth 'get_headers' for '{mcp.id}' is not implemented (generated stub)",
+                )
+
+    # -- access ----------------------------------------------------------
+
+    def check_access(self) -> None:
+        # File existence for protected nodes is already validated by
+        # SystemSpecValidator; only a positively identified stub is added here.
+        path = self._base_dir / "plugins" / "access.py"
+        verdict = _stub_verdict(path, "can_access", class_name="AccessResolver")
+        if verdict is _Verdict.STUB:
+            self._error(
+                "plugins.access",
+                "AccessResolver.can_access is not implemented (generated stub) — "
+                "every protected node will be hidden for every caller",
+            )
+
+    def _error(self, field: str, message: str) -> None:
+        self.errors.append(ValidationError(field, message))
+
+
+# -- static stub detection ---------------------------------------------------
+
+
+def _stub_verdict(path: Path, function_name: str, class_name: str | None = None) -> _Verdict:
+    """Statically classify a plugin function without executing it.
+
+    Files that fail to parse are treated as implemented — the runtime
+    loader reports those with a better error.
+    """
+    if not path.is_file():
+        return _Verdict.NO_FILE
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return _Verdict.IMPLEMENTED
+    fn = _find_function(tree, function_name, class_name)
+    if fn is None:
+        return _Verdict.NO_FUNCTION
+    return _Verdict.STUB if _is_stub_body(fn) else _Verdict.IMPLEMENTED
+
+
+def _find_function(
+    tree: ast.Module, name: str, class_name: str | None
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    body: list[ast.stmt] = tree.body
+    if class_name is not None:
+        cls = next(
+            (n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == class_name),
+            None,
+        )
+        if cls is None:
+            return None
+        body = cls.body
+    return next(
+        (
+            n
+            for n in body
+            if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef) and n.name == name
+        ),
+        None,
+    )
+
+
+def _is_stub_body(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when the body is just ``raise NotImplementedError`` (± docstring)."""
+    body = fn.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    if len(body) != 1 or not isinstance(body[0], ast.Raise):
+        return False
+    exc = body[0].exc
+    if isinstance(exc, ast.Call):
+        exc = exc.func
+    return isinstance(exc, ast.Name) and exc.id == "NotImplementedError"

--- a/src/agent_engine/core/validator.py
+++ b/src/agent_engine/core/validator.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 from pathlib import Path
 
 from agent_engine.core.errors import ValidationError
+from agent_engine.core.plugin_stubs import scan_unimplemented_plugins
 from agent_engine.core.spec import GraphNode, OrchestratorSpec, SystemSpec
 
 
 class SystemSpecValidator:
-    """Engine-level validation: prompt files exist, access plugin present for protected nodes."""
+    """Engine-level validation: prompt files exist, access plugin present for
+    protected nodes, and no declared plugin is a generated-but-unimplemented stub."""
 
     def validate(self, spec: SystemSpec, base_dir: Path) -> list[ValidationError]:
         errors: list[ValidationError] = []
         self._walk(spec.graph, base_dir, errors)
+        errors.extend(scan_unimplemented_plugins(spec, base_dir))
         return errors
 
     def _walk(self, node: GraphNode, base_dir: Path, errors: list[ValidationError]) -> None:

--- a/tests/core/test_plugin_stub_scan.py
+++ b/tests/core/test_plugin_stub_scan.py
@@ -1,0 +1,296 @@
+"""Tests for the startup scan of generated-but-unimplemented plugin stubs.
+
+The scan is static (AST) — plugin files are parsed, never executed — so these
+tests write real plugin files into tmp_path and assert on the errors returned.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_engine.core.plugin_stubs import scan_unimplemented_plugins
+from agent_engine.core.spec import (
+    AgentSpec,
+    BasePromptSet,
+    GraphNode,
+    MCPSpec,
+    ModelConfig,
+    OrchestratorPromptSet,
+    OrchestratorSpec,
+    ResolverSpec,
+    SystemMeta,
+    SystemSpec,
+    ToolSpec,
+)
+from agent_engine.core.validator import SystemSpecValidator
+
+_MODEL = ModelConfig(provider="fake", name="fake", temperature=None)
+
+
+def agent(
+    node_id: str,
+    *,
+    tools: tuple[ToolSpec, ...] = (),
+    resolvers: tuple[ResolverSpec, ...] = (),
+    mcps: tuple[MCPSpec, ...] = (),
+    protected: bool = False,
+) -> GraphNode:
+    spec = AgentSpec(
+        id=node_id,
+        name=node_id,
+        description=f"{node_id} agent",
+        model=_MODEL,
+        protected=protected,
+        prompts=BasePromptSet(),
+        tools=tools,
+        resolvers=resolvers,
+        mcps=mcps,
+    )
+    return GraphNode(node=spec)
+
+
+def orchestrator(node_id: str, children: list[GraphNode]) -> GraphNode:
+    spec = OrchestratorSpec(
+        id=node_id,
+        name=node_id,
+        description=f"{node_id} orchestrator",
+        model=_MODEL,
+        prompts=OrchestratorPromptSet(),
+    )
+    return GraphNode(node=spec, children=tuple(children))
+
+
+def system(graph: GraphNode) -> SystemSpec:
+    return SystemSpec(meta=SystemMeta(name="test-system"), defaults=None, graph=graph)
+
+
+def write(base: Path, rel: str, text: str) -> None:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+STUB_TOOL = (
+    "def {name}(input: dict) -> str:\n"
+    '    """Does a thing."""\n'
+    "    raise NotImplementedError\n"
+)
+REAL_TOOL = "def {name}(input: dict) -> str:\n    return 'done'\n"
+
+
+def scan(spec: SystemSpec, base: Path) -> list[str]:
+    return [f"{e.field}: {e.message}" for e in scan_unimplemented_plugins(spec, base)]
+
+
+# -- tools --------------------------------------------------------------------
+
+
+def test_stub_tool_is_reported(tmp_path: Path) -> None:
+    write(tmp_path, "plugins/tools/lookup.py", STUB_TOOL.format(name="lookup"))
+    spec = system(agent("a", tools=(ToolSpec("lookup", "looks up"),)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "not implemented" in errors[0]
+    assert "lookup" in errors[0]
+
+
+def test_implemented_tool_passes(tmp_path: Path) -> None:
+    write(tmp_path, "plugins/tools/lookup.py", REAL_TOOL.format(name="lookup"))
+    spec = system(agent("a", tools=(ToolSpec("lookup", "looks up"),)))
+
+    assert scan(spec, tmp_path) == []
+
+
+def test_missing_tool_file_is_reported(tmp_path: Path) -> None:
+    spec = system(agent("a", tools=(ToolSpec("lookup", "looks up"),)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "not found" in errors[0]
+
+
+def test_shared_tool_reported_once(tmp_path: Path) -> None:
+    write(tmp_path, "plugins/tools/lookup.py", STUB_TOOL.format(name="lookup"))
+    spec = system(
+        orchestrator(
+            "root",
+            [
+                agent("a", tools=(ToolSpec("lookup", "looks up"),)),
+                agent("b", tools=(ToolSpec("lookup", "looks up"),)),
+            ],
+        )
+    )
+
+    assert len(scan(spec, tmp_path)) == 1
+
+
+# -- resolvers ------------------------------------------------------------------
+
+
+def test_stub_resolver_is_reported(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/resolvers/a.py",
+        "class Resolver:\n"
+        "    def user_name(self, ctx: dict) -> str:\n"
+        "        raise NotImplementedError\n",
+    )
+    spec = system(agent("a", resolvers=(ResolverSpec(id="user_name", scope="agent"),)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "user_name" in errors[0]
+
+
+def test_resolver_implemented_in_shared_base_passes(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/resolvers/shared.py",
+        "class SharedResolver:\n"
+        "    def user_name(self, ctx: dict) -> str:\n"
+        "        return 'guy'\n",
+    )
+    write(
+        tmp_path,
+        "plugins/resolvers/a.py",
+        "from shared import SharedResolver\n\n"
+        "class Resolver(SharedResolver):\n"
+        "    pass\n",
+    )
+    spec = system(agent("a", resolvers=(ResolverSpec(id="user_name", scope="shared"),)))
+
+    assert scan(spec, tmp_path) == []
+
+
+def test_stub_resolver_in_shared_base_is_reported(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/resolvers/shared.py",
+        "class SharedResolver:\n"
+        "    def user_name(self, ctx: dict) -> str:\n"
+        "        raise NotImplementedError\n",
+    )
+    write(
+        tmp_path,
+        "plugins/resolvers/a.py",
+        "from shared import SharedResolver\n\n"
+        "class Resolver(SharedResolver):\n"
+        "    pass\n",
+    )
+    spec = system(agent("a", resolvers=(ResolverSpec(id="user_name", scope="shared"),)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "user_name" in errors[0]
+
+
+def test_missing_resolver_file_is_reported(tmp_path: Path) -> None:
+    spec = system(agent("a", resolvers=(ResolverSpec(id="user_name", scope="agent"),)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "not found" in errors[0]
+
+
+def test_unknown_method_is_skipped_not_flagged(tmp_path: Path) -> None:
+    # Method may come from a base class the scan can't see — stay silent.
+    write(
+        tmp_path,
+        "plugins/resolvers/a.py",
+        "from mylib import CustomBase\n\n"
+        "class Resolver(CustomBase):\n"
+        "    pass\n",
+    )
+    spec = system(agent("a", resolvers=(ResolverSpec(id="user_name", scope="agent"),)))
+
+    assert scan(spec, tmp_path) == []
+
+
+# -- access ---------------------------------------------------------------------
+
+
+def test_stub_access_resolver_is_reported_for_protected_nodes(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/access.py",
+        "class AccessResolver:\n"
+        "    def can_access(self, ctx: dict, node_id: str) -> bool:\n"
+        "        raise NotImplementedError\n",
+    )
+    spec = system(orchestrator("root", [agent("admin", protected=True)]))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "can_access" in errors[0]
+
+
+def test_implemented_access_resolver_passes(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/access.py",
+        "class AccessResolver:\n"
+        "    def can_access(self, ctx: dict, node_id: str) -> bool:\n"
+        "        return True\n",
+    )
+    spec = system(orchestrator("root", [agent("admin", protected=True)]))
+
+    assert scan(spec, tmp_path) == []
+
+
+def test_stub_access_resolver_ignored_without_protected_nodes(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/access.py",
+        "class AccessResolver:\n"
+        "    def can_access(self, ctx: dict, node_id: str) -> bool:\n"
+        "        raise NotImplementedError\n",
+    )
+    spec = system(agent("a"))
+
+    assert scan(spec, tmp_path) == []
+
+
+# -- MCP auth ---------------------------------------------------------------------
+
+
+def test_stub_mcp_auth_is_reported(tmp_path: Path) -> None:
+    write(
+        tmp_path,
+        "plugins/mcp_auth/orders.py",
+        "async def get_headers() -> dict[str, str]:\n"
+        '    """Auth headers."""\n'
+        "    raise NotImplementedError\n",
+    )
+    mcp = MCPSpec(id="orders", url="https://mcp.example.com/mcp", auth=True)
+    spec = system(agent("a", mcps=(mcp,)))
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "orders" in errors[0]
+
+
+def test_mcp_without_auth_not_scanned(tmp_path: Path) -> None:
+    mcp = MCPSpec(id="orders", url="https://mcp.example.com/mcp", auth=False)
+    spec = system(agent("a", mcps=(mcp,)))
+
+    assert scan(spec, tmp_path) == []
+
+
+# -- wiring through SystemSpecValidator -------------------------------------------
+
+
+def test_validator_includes_stub_errors(tmp_path: Path) -> None:
+    write(tmp_path, "plugins/tools/lookup.py", STUB_TOOL.format(name="lookup"))
+    spec = system(agent("a", tools=(ToolSpec("lookup", "looks up"),)))
+
+    errors = SystemSpecValidator().validate(spec, tmp_path)
+
+    assert any("not implemented" in e.message for e in errors)


### PR DESCRIPTION
## Summary
Per the suggestion from @asaf — validate at startup that every plugin function the YAML declares was actually implemented, instead of letting forgotten `agentctl generate` stubs explode one-by-one mid-request against real users.

```
✗ [tools.get_order_status] Tool 'get_order_status' is declared but not implemented (generated stub): plugins/tools/get_order_status.py
✗ [planner.resolvers.user_name] Resolver 'user_name' is declared but not implemented (generated stub)
✗ [plugins.access] AccessResolver.can_access is not implemented (generated stub) — every protected node will be hidden for every caller
```

The failure meets the developer at startup — never the user at runtime. (Complements #9's runtime fail-closed: loud at boot, quiet in production.)

## How it works
- **Static only:** plugin files are parsed with `ast`, never executed — zero side effects. A stub is a body that is exactly `raise NotImplementedError` (± docstring).
- **Conservative:** only positively identified stubs and missing files are reported. Dynamic definitions, methods inherited from bases other than the conventional `shared.py`, and unparseable files are skipped (runtime loaders diagnose those better).
- **One choke point:** wired into `SystemSpecValidator`, so `agentctl validate/run/chat` and both API servers all get it.
- **Coverage:** tools, per-agent + shared resolvers, `AccessResolver.can_access` (only when protected nodes exist), and `mcp_auth` `get_headers` (only when `auth: true`).

## Found real cases immediately
Both custom tools in the flagship example (`generate_decision_matrix`, `build_learning_plan`) were still generated stubs — the new scan caught them. Implemented both as small deterministic demo tools so the example validates and actually works end-to-end.

## Files changed
- `src/agent_engine/core/plugin_stubs.py` — new scan module
- `src/agent_engine/core/validator.py` — 2-line wiring
- `tests/core/test_plugin_stub_scan.py` — 15 tests (stub/implemented/missing per plugin kind, shared-base inheritance both ways, dedupe, no-false-positive on unknown bases, validator wiring)
- `examples/enterprise-knowledge-assistant/plugins/tools/*` — demo implementations

## Architecture rules respected
Validate-before-compile layering preserved; scan lives in `core`, no runtime changes; YAML stays declarative; nothing executed during validation.

## Commands run
`make check` — pass (ruff, mypy, **367 tests passed**, 15 new). Flagship example: `agentctl validate` ✓.

## Out of scope / follow-ups
- Hook plugin methods (need `plugins.toml` resolution) — happy to add as a follow-up.
- If you'd prefer stubs to be a *warning* rather than an error in some dev flows, the severity decision is one line — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)