### PR TITLE
feat: scaffold missing prompt files during generate and validate them at startup (#18)

### DIFF
--- a/src/agent_engine/core/plugin_stubs.py
+++ b/src/agent_engine/core/plugin_stubs.py
@@ -12,6 +12,8 @@ conservative — it reports only what it can positively identify:
 
 - a function/method whose body is just ``raise NotImplementedError``
   (optionally preceded by a docstring) is a stub;
+- a prompt file whose content is the sentinel ``<!-- STUB: fill in this prompt -->``
+  is a stub;
 - a missing plugin file for something the spec declares is an error;
 - anything else (dynamic definitions, methods inherited from bases other
   than the conventional ``shared.py``, unparseable files) is skipped and
@@ -51,6 +53,7 @@ class _Scanner:
         self._base_dir = base_dir
         self._seen_tools: set[str] = set()
         self._seen_mcp_auth: set[str] = set()
+        self._seen_prompts: set[str] = set()
         self.has_protected = False
         self.errors: list[ValidationError] = []
 
@@ -61,6 +64,7 @@ class _Scanner:
             self._check_tools(node.node)
             self._check_resolvers(node.node)
             self._check_mcp_auth(node.node)
+        self._check_prompts(node)
         for child in node.children:
             self.walk(child)
 
@@ -127,6 +131,34 @@ class _Scanner:
                 self._error(
                     f"mcps.{mcp.id}.auth",
                     f"MCP auth 'get_headers' for '{mcp.id}' is not implemented (generated stub)",
+                )
+
+    # -- prompts ---------------------------------------------------------
+
+    def _check_prompts(self, node: GraphNode) -> None:
+        prompts = node.node.get_prompts()
+        for field_name in ("system", "user", "orchestrator"):
+            path_str = getattr(prompts, field_name, None)
+            if not path_str or path_str in self._seen_prompts:
+                continue
+            self._seen_prompts.add(path_str)
+            path = self._base_dir / path_str
+            if not path.is_file():
+                self._error(
+                    f"{node.node.id}.prompts.{field_name}",
+                    f"Prompt file not found: {path_str} — {_GENERATE_HINT}",
+                )
+                continue
+
+            try:
+                content = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            if "<!-- STUB: fill in this prompt -->" in content:
+                self._error(
+                    f"{node.node.id}.prompts.{field_name}",
+                    f"Prompt '{path_str}' is declared but not implemented (generated stub)",
                 )
 
     # -- access ----------------------------------------------------------

--- a/src/agent_engine/core/validator.py
+++ b/src/agent_engine/core/validator.py
@@ -25,30 +25,6 @@ class SystemSpecValidator:
     def _validate_node(
         self, node: GraphNode, base_dir: Path, errors: list[ValidationError]
     ) -> None:
-        prompts = node.node.get_prompts()
-
-        for field_name in ("system", "user"):
-            path_str = getattr(prompts, field_name, None)
-            if path_str and not (base_dir / path_str).is_file():
-                errors.append(
-                    ValidationError(
-                        field=f"{node.node.id}.prompts.{field_name}",
-                        message=f"Prompt file not found: {path_str}",
-                    )
-                )
-
-        if (
-            isinstance(node.node, OrchestratorSpec)
-            and node.node.prompts.orchestrator
-            and not (base_dir / node.node.prompts.orchestrator).is_file()
-        ):
-            errors.append(
-                ValidationError(
-                    field=f"{node.node.id}.prompts.orchestrator",
-                    message=f"Prompt file not found: {node.node.prompts.orchestrator}",
-                )
-            )
-
         if node.node.protected and not (base_dir / "plugins" / "access.py").is_file():
             errors.append(
                 ValidationError(
@@ -56,3 +32,4 @@ class SystemSpecValidator:
                     message="plugins/access.py is required for protected nodes",
                 )
             )
+

--- a/src/agent_engine/generate/generator.py
+++ b/src/agent_engine/generate/generator.py
@@ -19,7 +19,7 @@ class GenerateResult:
 
 
 class Generator:
-    """Generates plugin stubs for tools and resolvers declared in the spec.
+    """Generates plugin stubs for tools, resolvers, and prompt files declared in the spec.
 
     Never overwrites existing files — only creates missing stubs.
 
@@ -42,7 +42,7 @@ class Generator:
         tools_dir = base_dir / "plugins" / "tools"
         tools_dir.mkdir(parents=True, exist_ok=True)
         for tool_id, description in tool_ids.items():
-            self._write(tools_dir / f"{tool_id}.py", _tool_stub(tool_id, description), result)
+            self._write(tools_dir / f"{tool_id}.py", _tool_stub(tool_id, description), result, base_dir)
 
         resolvers_dir = base_dir / "plugins" / "resolvers"
         resolvers_dir.mkdir(parents=True, exist_ok=True)
@@ -52,6 +52,7 @@ class Generator:
                 resolvers_dir / "shared.py",
                 _shared_resolver_stub(shared_ids),
                 result,
+                base_dir,
             )
 
         for agent_id, agent_only_ids in agent_resolver_ids.items():
@@ -60,6 +61,7 @@ class Generator:
                 resolvers_dir / f"{agent_id}.py",
                 _agent_resolver_stub(agent_only_ids, has_shared),
                 result,
+                base_dir,
             )
 
         if has_protected:
@@ -67,13 +69,14 @@ class Generator:
                 base_dir / "plugins" / "access.py",
                 _access_stub(),
                 result,
+                base_dir,
             )
 
         if mcp_plugin_ids:
             mcp_auth_dir = base_dir / "plugins" / "mcp_auth"
             mcp_auth_dir.mkdir(parents=True, exist_ok=True)
             for mcp_id in mcp_plugin_ids:
-                self._write(mcp_auth_dir / f"{mcp_id}.py", _mcp_auth_stub(mcp_id), result)
+                self._write(mcp_auth_dir / f"{mcp_id}.py", _mcp_auth_stub(mcp_id), result, base_dir)
 
         hook_methods = _collect_hook_methods(spec)
         if hook_methods:
@@ -87,7 +90,13 @@ class Generator:
                     hooks_dir / f"{plugin_id}.py",
                     _hook_plugin_stub(plugin_id, methods),
                     result,
+                    base_dir,
                 )
+        prompt_paths = _collect_prompts(spec.graph)
+        for path_str in prompt_paths:
+            path = base_dir / path_str
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._write(path, "<!-- STUB: fill in this prompt -->\n", result, base_dir)
 
         self._sync_manifest(
             base_dir / "plugins",
@@ -142,14 +151,17 @@ class Generator:
             resolvers=resolver_refs,
             tools=tool_refs,
         )
-        (result.created if created else result.skipped).append(MANIFEST_NAME)
+        base_dir = plugins_root.parent
+        rel_manifest = manifest_path.relative_to(base_dir)
+        (result.created if created else result.skipped).append(str(rel_manifest))
 
-    def _write(self, path: Path, content: str, result: GenerateResult) -> None:
+    def _write(self, path: Path, content: str, result: GenerateResult, base_dir: Path) -> None:
+        rel_path = path.relative_to(base_dir)
         if path.exists():
-            result.skipped.append(str(path.name))
+            result.skipped.append(str(rel_path))
             return
         path.write_text(content, encoding="utf-8")
-        result.created.append(str(path.name))
+        result.created.append(str(rel_path))
 
 
 def _collect(
@@ -316,3 +328,26 @@ def _hook_plugin_stub(plugin_id: str, methods: list[str]) -> str:
         "        # Read that data from event.run_context and event.payload.\n\n"
         f"{method_blocks}"
     )
+
+
+def _collect_prompts(node: GraphNode) -> list[str]:
+    """Walk the graph and collect all declared prompt paths (system, user, orchestrator).
+
+    Deduplicates paths so the same file declared by multiple nodes is only
+    scaffolded once — consistent with how _collect() deduplicates tool/resolver IDs.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    def walk(n: GraphNode) -> None:
+        prompts = n.node.get_prompts()
+        for field_name in ("system", "user", "orchestrator"):
+            path_str = getattr(prompts, field_name, None)
+            if path_str and path_str not in seen:
+                seen.add(path_str)
+                paths.append(path_str)
+        for child in n.children:
+            walk(child)
+
+    walk(node)
+    return paths

--- a/tests/core/test_plugin_stub_scan.py
+++ b/tests/core/test_plugin_stub_scan.py
@@ -294,3 +294,145 @@ def test_validator_includes_stub_errors(tmp_path: Path) -> None:
     errors = SystemSpecValidator().validate(spec, tmp_path)
 
     assert any("not implemented" in e.message for e in errors)
+
+
+# -- prompts --------------------------------------------------------------------
+
+
+def test_stub_prompts_are_reported(tmp_path: Path) -> None:
+    # 1. Test Agent stub prompts
+    write(tmp_path, "prompts/a/system.md", "<!-- STUB: fill in this prompt -->")
+    write(tmp_path, "prompts/a/user.md", "some real user prompt")
+
+    agent_node = GraphNode(
+        node=AgentSpec(
+            id="a",
+            name="a",
+            description="a agent",
+            model=_MODEL,
+            prompts=BasePromptSet(system="prompts/a/system.md", user="prompts/a/user.md"),
+        )
+    )
+
+    # 2. Test Orchestrator stub prompts
+    write(tmp_path, "prompts/orch.md", "<!-- STUB: fill in this prompt -->")
+    orch_node = GraphNode(
+        node=OrchestratorSpec(
+            id="orch",
+            name="orch",
+            description="orch orchestrator",
+            model=_MODEL,
+            prompts=OrchestratorPromptSet(orchestrator="prompts/orch.md"),
+        ),
+        children=(agent_node,),
+    )
+
+    spec = system(orch_node)
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 2
+    assert any("a.prompts.system" in e and "is declared but not implemented" in e for e in errors)
+    assert any(
+        "orch.prompts.orchestrator" in e and "is declared but not implemented" in e for e in errors
+    )
+
+
+def test_implemented_prompts_pass(tmp_path: Path) -> None:
+    write(tmp_path, "prompts/a/system.md", "some real system prompt")
+    write(tmp_path, "prompts/a/user.md", "some real user prompt")
+
+    agent_node = GraphNode(
+        node=AgentSpec(
+            id="a",
+            name="a",
+            description="a agent",
+            model=_MODEL,
+            prompts=BasePromptSet(system="prompts/a/system.md", user="prompts/a/user.md"),
+        )
+    )
+
+    spec = system(agent_node)
+    assert scan(spec, tmp_path) == []
+
+
+def test_duplicate_prompt_path_reported_once(tmp_path: Path) -> None:
+    """The same prompt file path declared by two nodes must only generate
+    one error — consistent with how shared tools are reported once."""
+    write(tmp_path, "prompts/shared.md", "<!-- STUB: fill in this prompt -->")
+    shared_prompt = BasePromptSet(system="prompts/shared.md")
+
+    spec = system(
+        GraphNode(
+            node=OrchestratorSpec(
+                id="root",
+                name="root",
+                description="root",
+                model=_MODEL,
+                prompts=OrchestratorPromptSet(),
+            ),
+            children=(
+                GraphNode(
+                    node=AgentSpec(
+                        id="a",
+                        name="a",
+                        description="a",
+                        model=_MODEL,
+                        prompts=shared_prompt,
+                    )
+                ),
+                GraphNode(
+                    node=AgentSpec(
+                        id="b",
+                        name="b",
+                        description="b",
+                        model=_MODEL,
+                        prompts=shared_prompt,
+                    )
+                ),
+            ),
+        )
+    )
+    errors = scan(spec, tmp_path)
+    assert len(errors) == 1
+
+
+def test_stub_user_prompt_is_reported(tmp_path: Path) -> None:
+    """Error for an unimplemented user prompt must be correctly reported."""
+    write(tmp_path, "prompts/a/user.md", "<!-- STUB: fill in this prompt -->")
+    spec = system(
+        GraphNode(
+            node=AgentSpec(
+                id="a",
+                name="a",
+                description="a agent",
+                model=_MODEL,
+                prompts=BasePromptSet(user="prompts/a/user.md"),
+            )
+        )
+    )
+    errors = scan(spec, tmp_path)
+    assert len(errors) == 1
+    assert any("a.prompts.user" in e and "is declared but not implemented" in e for e in errors)
+
+
+def test_missing_prompt_file_is_reported_with_hint(tmp_path: Path) -> None:
+    """Missing prompt file must be reported with the run generate hint."""
+    spec = system(
+        GraphNode(
+            node=AgentSpec(
+                id="a",
+                name="a",
+                description="a agent",
+                model=_MODEL,
+                prompts=BasePromptSet(system="prompts/a/system.md"),
+            )
+        )
+    )
+    errors = scan(spec, tmp_path)
+    assert len(errors) == 1
+    assert any(
+        "a.prompts.system" in e and "Prompt file not found: prompts/a/system.md — run `agentctl generate` to create the stub" in e
+        for e in errors
+    )
+
+

--- a/tests/generate/test_plugins_manifest.py
+++ b/tests/generate/test_plugins_manifest.py
@@ -14,6 +14,8 @@ from agent_engine.core.spec import (
     HooksConfig,
     HookSpec,
     ModelConfig,
+    OrchestratorPromptSet,
+    OrchestratorSpec,
     ResolverSpec,
     SystemMeta,
     SystemSpec,
@@ -192,7 +194,7 @@ def test_generate_creates_manifest_with_refs(tmp_path: Path) -> None:
 
     manifest = tmp_path / "plugins" / MANIFEST_NAME
     assert manifest.is_file()
-    assert MANIFEST_NAME in result.created
+    assert f"plugins/{MANIFEST_NAME}" in result.created
 
     data = _read(manifest)
     assert data["tools"]["book_flight"].endswith(".plugins.tools.book_flight:book_flight")
@@ -216,4 +218,101 @@ def test_generate_is_idempotent_and_preserves_manifest(tmp_path: Path) -> None:
     result = Generator().generate(_spec_with_plugins(), tmp_path)
 
     assert manifest.read_text() == snapshot  # no churn
-    assert MANIFEST_NAME in result.skipped  # existed, not recreated
+    assert f"plugins/{MANIFEST_NAME}" in result.skipped  # existed, not recreated
+
+
+def test_generator_creates_missing_prompt_stubs(tmp_path: Path) -> None:
+    # Setup spec with an orchestrator routing to an agent, both having missing prompts
+    agent = AgentSpec(
+        id="flights",
+        name="flights",
+        description="books flights",
+        model=_MODEL,
+        prompts=BasePromptSet(system="prompts/flights/system.md", user="prompts/flights/user.md"),
+    )
+    orch = OrchestratorSpec(
+        id="router",
+        name="router",
+        description="routes to flights",
+        model=_MODEL,
+        prompts=OrchestratorPromptSet(orchestrator="prompts/router.md"),
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="gen-test"),
+        defaults=None,
+        graph=GraphNode(node=orch, children=(GraphNode(node=agent),)),
+    )
+
+    result = Generator().generate(spec, tmp_path)
+
+    # Verify stubs created
+    sys_prompt = tmp_path / "prompts" / "flights" / "system.md"
+    user_prompt = tmp_path / "prompts" / "flights" / "user.md"
+    orch_prompt = tmp_path / "prompts" / "router.md"
+
+    assert sys_prompt.is_file()
+    assert user_prompt.is_file()
+    assert orch_prompt.is_file()
+
+    assert sys_prompt.read_text() == "<!-- STUB: fill in this prompt -->\n"
+    assert user_prompt.read_text() == "<!-- STUB: fill in this prompt -->\n"
+    assert orch_prompt.read_text() == "<!-- STUB: fill in this prompt -->\n"
+
+    # Verify result records
+    assert "prompts/flights/system.md" in result.created
+    assert "prompts/flights/user.md" in result.created
+    assert "prompts/router.md" in result.created
+
+
+def test_generator_does_not_overwrite_existing_prompt(tmp_path: Path) -> None:
+    """Never-overwrite rule: an existing prompt file must be left untouched."""
+    real_content = "You are a real, implemented flight-booking assistant.\n"
+    prompt_path = tmp_path / "prompts" / "flights" / "system.md"
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text(real_content, encoding="utf-8")
+
+    agent = AgentSpec(
+        id="flights",
+        name="flights",
+        description="books flights",
+        model=_MODEL,
+        prompts=BasePromptSet(system="prompts/flights/system.md"),
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="gen-test"),
+        defaults=None,
+        graph=GraphNode(node=agent),
+    )
+
+    result = Generator().generate(spec, tmp_path)
+
+    assert prompt_path.read_text() == real_content  # untouched
+    assert "prompts/flights/system.md" in result.skipped
+    assert "prompts/flights/system.md" not in result.created
+
+
+def test_generator_deduplicates_shared_prompt_path(tmp_path: Path) -> None:
+    """A prompt path referenced by two agents must be scaffolded only once
+    and appear in result.created exactly once — not in both created and skipped."""
+    shared_prompt = BasePromptSet(system="prompts/shared/system.md")
+    agent_a = AgentSpec(id="a", name="a", description="a", model=_MODEL, prompts=shared_prompt)
+    agent_b = AgentSpec(id="b", name="b", description="b", model=_MODEL, prompts=shared_prompt)
+    orch = OrchestratorSpec(
+        id="root", name="root", description="root", model=_MODEL, prompts=OrchestratorPromptSet()
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="gen-test"),
+        defaults=None,
+        graph=GraphNode(node=orch, children=(GraphNode(node=agent_a), GraphNode(node=agent_b))),
+    )
+
+    result = Generator().generate(spec, tmp_path)
+
+    # File must exist and contain the sentinel
+    p = tmp_path / "prompts" / "shared" / "system.md"
+    assert p.is_file()
+    assert p.read_text() == "<!-- STUB: fill in this prompt -->\n"
+
+    # Must appear in created exactly once, never in skipped
+    assert result.created.count("prompts/shared/system.md") == 1
+    assert "prompts/shared/system.md" not in result.skipped


### PR DESCRIPTION
Closes #18

### Background
Previously, prompt files declared in the system specification YAML were not scaffolded by `agentctl generate` when missing. This resulted in `SystemSpecValidator` failing with a hard "Prompt file not found" error during startup without offering a stub, unlike tools, resolvers, and hooks.

### Changes

1. Scaffold Missing Prompts (`src/agent_engine/generate/generator.py`):
   - Walks the spec graph and collects all declared prompt paths (`system`, `user`, and `orchestrator`).
   - Creates parent directories and writes missing prompt files using the sentinel content `<!-- STUB: fill in this prompt -->` under the "create if missing, never overwrite" rule.
   - Deduplicates prompt paths so shared templates are only written and reported once.

2. Validate Unimplemented Stubs (`src/agent_engine/core/plugin_stubs.py`):
   - Extended the startup scanner to inspect the contents of declared prompt files.
   - Flags prompt files containing the sentinel string as unimplemented, matching the style of other stub validation errors.
   - Safely ignores unreadable files (leaving them for the runtime loader to report) and correctly skips validation on files that don't exist yet to avoid double-reporting.

3. Tests (`tests/`):
   - Added generator tests verifying stub creation, idempotency (existing files are untouched), and deduplication.
   - Added scanner tests ensuring prompt stubs for all fields (`system`, `user`, `orchestrator`) are caught at startup.
