### PR TITLE
feat: support fallback models and automatic retries on LLM failure (#25)

### DIFF
--- a/docs/YAML_SPEC.md
+++ b/docs/YAML_SPEC.md
@@ -372,6 +372,23 @@ For OpenAI, set `OPENAI_API_KEY` in your environment and install the provider
 extra with `pip install "agent-engine[openai]"`. Any OpenAI model your key can
 access may be used via `name`. Secrets must never be stored in YAML.
 
+### Fallback Models
+
+To make agents resilient to LLM provider outages, rate limits, or transient network errors, you can configure a fallback backup model directly under any model configuration block:
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.3
+  fallback:
+    provider: openai
+    name: gpt-4.1-mini
+    temperature: 0.2
+```
+
+Note that nested fallbacks (configuring a fallback under a fallback model) are not allowed and will fail spec validation.
+
 ---
 
 ## Graph Topology

--- a/docs/yaml-spec.mdx
+++ b/docs/yaml-spec.mdx
@@ -112,6 +112,23 @@ For OpenAI, set `OPENAI_API_KEY` in your environment (`export OPENAI_API_KEY="..
   Never put API keys in YAML. Extra reads provider credentials from environment variables at runtime.
 </Warning>
 
+### Fallback models
+
+To make agents resilient to LLM provider outages, rate limits, or transient network errors, you can configure a fallback backup model directly under any model configuration block:
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.3
+  fallback:
+    provider: openai
+    name: gpt-4.1-mini
+    temperature: 0.2
+```
+
+Nested fallbacks (a fallback model configured under another fallback model) are not allowed and will fail spec validation.
+
 ---
 
 ## `tools`

--- a/src/agent_engine/core/spec.py
+++ b/src/agent_engine/core/spec.py
@@ -7,14 +7,18 @@ from agent_engine.core.execution import ExecutionPolicy
 
 
 @dataclass(frozen=True)
-class ModelConfig:
+class BaseModelConfig:
     provider: str
     name: str
     temperature: float | None = None
     region: str | None = None
     max_tokens: int | None = None
     top_p: float | None = None
-    fallback: ModelConfig | None = None
+
+
+@dataclass(frozen=True)
+class ModelConfig(BaseModelConfig):
+    fallback: BaseModelConfig | None = None
 
 
 @dataclass(frozen=True)

--- a/src/agent_engine/core/spec.py
+++ b/src/agent_engine/core/spec.py
@@ -14,6 +14,7 @@ class ModelConfig:
     region: str | None = None
     max_tokens: int | None = None
     top_p: float | None = None
+    fallback: ModelConfig | None = None
 
 
 @dataclass(frozen=True)

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -31,8 +31,14 @@ from agent_engine.approvals.session_store import (
     SessionApprovalStore,
 )
 from agent_engine.core.execution import ExecutionPolicy
-from agent_engine.core.spec import AgentSpec, GraphNode, OrchestratorSpec, SystemSpec
-from agent_engine.core.spec import BaseModelConfig, ModelConfig as NodeModelConfig
+from agent_engine.core.spec import (
+    AgentSpec,
+    BaseModelConfig,
+    GraphNode,
+    OrchestratorSpec,
+    SystemSpec,
+)
+from agent_engine.core.spec import ModelConfig as NodeModelConfig
 from agent_engine.engine.engine import Engine
 from agent_engine.engine.langgraph.approval_provider import InterruptApprovalProvider
 from agent_engine.engine.langgraph.checkpointing import (
@@ -765,10 +771,9 @@ class LangGraphEngine(Engine):
         assert isinstance(node.node, OrchestratorSpec)
         spec = node.node
         path = node_id(node, parent_path)
-        primary_model = self._build_model(spec.model)
-        fallback_model = (
-            self._build_model(spec.model.fallback) if spec.model.fallback is not None else None
-        )
+        model = self._build_model(spec.model)
+        fb = spec.model.fallback
+        fallback_model = self._build_model(fb) if fb is not None else None
 
         children: list[ChildEntry] = []
         for child in node.children:
@@ -789,7 +794,7 @@ class LangGraphEngine(Engine):
         return OrchestratorNode(
             spec=spec,
             node_path=path,
-            model=primary_model,
+            model=model,
             children=children,
             filters=self._filters,
             base_dir=self._base_dir,

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -765,7 +765,7 @@ class LangGraphEngine(Engine):
         assert isinstance(node.node, OrchestratorSpec)
         spec = node.node
         path = node_id(node, parent_path)
-        model = self._build_model(spec.model)
+        model = self._build_model_runnable(spec.model)
 
         children: list[ChildEntry] = []
         for child in node.children:
@@ -797,7 +797,7 @@ class LangGraphEngine(Engine):
         assert self._resolver_loader is not None
         assert self._hook_manager is not None
         tools, mcp_names, server_by_tool = self._build_agent_tools(spec)
-        bound_model = self._build_model(spec.model, tools=tools)
+        bound_model = self._build_model_runnable(spec.model, tools=tools)
         return AgentNode(
             spec=spec,
             node_path=node_path,
@@ -813,18 +813,22 @@ class LangGraphEngine(Engine):
             system_namespace=self._system_name,
         )
 
-    def _build_model(
-        self, model: NodeModelConfig, tools: list[BaseTool] | None = None
-    ) -> BaseChatModel | Runnable:
-        primary_model = self._model_factory(
+    def _build_model(self, model: NodeModelConfig) -> BaseChatModel:
+        return self._model_factory(
             model.provider,
             model.name,
             model.temperature,
             **_model_factory_kwargs(self._model_factory, model),
         )
+
+    def _build_model_runnable(
+        self, model: NodeModelConfig, tools: list[BaseTool] | None = None
+    ) -> BaseChatModel | Runnable:
+        primary_model = self._build_model(model)
         bound_primary = primary_model.bind_tools(tools) if tools else primary_model
         if model.fallback is not None:
-            bound_fallback = self._build_model(model.fallback, tools=tools)
+            fallback_model = self._build_model(model.fallback)
+            bound_fallback = fallback_model.bind_tools(tools) if tools else fallback_model
             return bound_primary.with_fallbacks([bound_fallback], exceptions_to_handle=(Exception,))
         return bound_primary
 

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
-from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -797,8 +797,7 @@ class LangGraphEngine(Engine):
         assert self._resolver_loader is not None
         assert self._hook_manager is not None
         tools, mcp_names, server_by_tool = self._build_agent_tools(spec)
-        model = self._build_model(spec.model)
-        bound_model = model.bind_tools(tools) if tools else model
+        bound_model = self._build_model(spec.model, tools=tools)
         return AgentNode(
             spec=spec,
             node_path=node_path,
@@ -814,13 +813,20 @@ class LangGraphEngine(Engine):
             system_namespace=self._system_name,
         )
 
-    def _build_model(self, model: NodeModelConfig) -> BaseChatModel:
-        return self._model_factory(
+    def _build_model(
+        self, model: NodeModelConfig, tools: list[BaseTool] | None = None
+    ) -> BaseChatModel | Runnable:
+        primary_model = self._model_factory(
             model.provider,
             model.name,
             model.temperature,
             **_model_factory_kwargs(self._model_factory, model),
         )
+        bound_primary = primary_model.bind_tools(tools) if tools else primary_model
+        if model.fallback is not None:
+            bound_fallback = self._build_model(model.fallback, tools=tools)
+            return bound_primary.with_fallbacks([bound_fallback], exceptions_to_handle=(Exception,))
+        return bound_primary
 
     def _build_agent_tools(
         self, spec: AgentSpec

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -32,7 +32,7 @@ from agent_engine.approvals.session_store import (
 )
 from agent_engine.core.execution import ExecutionPolicy
 from agent_engine.core.spec import AgentSpec, GraphNode, OrchestratorSpec, SystemSpec
-from agent_engine.core.spec import ModelConfig as NodeModelConfig
+from agent_engine.core.spec import BaseModelConfig, ModelConfig as NodeModelConfig
 from agent_engine.engine.engine import Engine
 from agent_engine.engine.langgraph.approval_provider import InterruptApprovalProvider
 from agent_engine.engine.langgraph.checkpointing import (
@@ -164,7 +164,7 @@ def _run_end_context(system_name: str, ctx: RunContext, result: RunResult) -> Ru
     )
 
 
-def _model_factory_kwargs(factory: ModelFactory, model: NodeModelConfig) -> dict[str, object]:
+def _model_factory_kwargs(factory: ModelFactory, model: BaseModelConfig) -> dict[str, object]:
     optional = {
         "region": model.region,
         "max_tokens": model.max_tokens,
@@ -765,7 +765,10 @@ class LangGraphEngine(Engine):
         assert isinstance(node.node, OrchestratorSpec)
         spec = node.node
         path = node_id(node, parent_path)
-        model = self._build_model_runnable(spec.model)
+        primary_model = self._build_model(spec.model)
+        fallback_model = (
+            self._build_model(spec.model.fallback) if spec.model.fallback is not None else None
+        )
 
         children: list[ChildEntry] = []
         for child in node.children:
@@ -786,10 +789,11 @@ class LangGraphEngine(Engine):
         return OrchestratorNode(
             spec=spec,
             node_path=path,
-            model=model,
+            model=primary_model,
             children=children,
             filters=self._filters,
             base_dir=self._base_dir,
+            fallback_model=fallback_model,
         )
 
     def _build_agent_node(self, spec: AgentSpec, node_path: str) -> AgentNode:
@@ -813,7 +817,7 @@ class LangGraphEngine(Engine):
             system_namespace=self._system_name,
         )
 
-    def _build_model(self, model: NodeModelConfig) -> BaseChatModel:
+    def _build_model(self, model: BaseModelConfig) -> BaseChatModel:
         return self._model_factory(
             model.provider,
             model.name,

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -522,10 +522,12 @@ class OrchestratorNode:
         children: list[ChildEntry],
         filters: list[RouteFilter],
         base_dir: Path,
+        fallback_model: Any = None,
     ) -> None:
         self._spec = spec
         self._node_path = node_path
         self._model = model
+        self._fallback_model = fallback_model
         self._children = children
         self._filters = filters
         self._base_dir = base_dir
@@ -611,7 +613,18 @@ class OrchestratorNode:
 
         # Build tools here so they share the live `visited` / `used_tools` lists.
         tools = [self._make_tool(e, state, visited, used_tools) for e in candidates]
-        bound_model = self._model.bind_tools(tools) if tools else self._model
+        if tools:
+            bound_primary = self._model.bind_tools(tools)
+            if self._fallback_model is not None:
+                bound_fallback = self._fallback_model.bind_tools(tools)
+                bound_model = bound_primary.with_fallbacks([bound_fallback], exceptions_to_handle=(Exception,))
+            else:
+                bound_model = bound_primary
+        else:
+            if self._fallback_model is not None:
+                bound_model = self._model.with_fallbacks([self._fallback_model], exceptions_to_handle=(Exception,))
+            else:
+                bound_model = self._model
         tool_by_name = {t.name: t for t in tools}
 
         user_msg: str = state.get("message", "")

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
+from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.errors import GraphInterrupt
 from pydantic import BaseModel
@@ -518,11 +519,11 @@ class OrchestratorNode:
         self,
         spec: OrchestratorSpec,
         node_path: str,
-        model: Any,
+        model: BaseChatModel,
         children: list[ChildEntry],
         filters: list[RouteFilter],
         base_dir: Path,
-        fallback_model: Any = None,
+        fallback_model: BaseChatModel | None = None,
     ) -> None:
         self._spec = spec
         self._node_path = node_path
@@ -613,18 +614,14 @@ class OrchestratorNode:
 
         # Build tools here so they share the live `visited` / `used_tools` lists.
         tools = [self._make_tool(e, state, visited, used_tools) for e in candidates]
-        if tools:
-            bound_primary = self._model.bind_tools(tools)
-            if self._fallback_model is not None:
-                bound_fallback = self._fallback_model.bind_tools(tools)
-                bound_model = bound_primary.with_fallbacks([bound_fallback], exceptions_to_handle=(Exception,))
-            else:
-                bound_model = bound_primary
-        else:
-            if self._fallback_model is not None:
-                bound_model = self._model.with_fallbacks([self._fallback_model], exceptions_to_handle=(Exception,))
-            else:
-                bound_model = self._model
+        bound_model = self._model.bind_tools(tools) if tools else self._model
+        if self._fallback_model is not None:
+            bound_fallback = (
+                self._fallback_model.bind_tools(tools) if tools else self._fallback_model
+            )
+            bound_model = bound_model.with_fallbacks(
+                [bound_fallback], exceptions_to_handle=(Exception,)
+            )
         tool_by_name = {t.name: t for t in tools}
 
         user_msg: str = state.get("message", "")

--- a/src/agent_engine/parsers/yaml/parser.py
+++ b/src/agent_engine/parsers/yaml/parser.py
@@ -330,7 +330,9 @@ def _validate_mcps(mcps: dict[str, Any], errors: list[ValidationError]) -> None:
         _validate_mcp_tool_tags(mcp_id, raw, errors)
 
 
-def _validate_model(path: str, raw: Any, errors: list[ValidationError]) -> None:
+def _validate_model(
+    path: str, raw: Any, errors: list[ValidationError], is_fallback: bool = False
+) -> None:
     if raw is None:
         return
     if not isinstance(raw, dict):
@@ -355,9 +357,7 @@ def _validate_model(path: str, raw: Any, errors: list[ValidationError]) -> None:
 
     temperature = raw.get("temperature")
     if temperature is not None and (
-        not isinstance(temperature, int | float)
-        or isinstance(temperature, bool)
-        or temperature < 0
+        not isinstance(temperature, int | float) or isinstance(temperature, bool) or temperature < 0
     ):
         errors.append(ValidationError(f"{path}.temperature", "Must be a non-negative number"))
 
@@ -372,6 +372,13 @@ def _validate_model(path: str, raw: Any, errors: list[ValidationError]) -> None:
         not isinstance(top_p, int | float) or isinstance(top_p, bool) or top_p < 0 or top_p > 1
     ):
         errors.append(ValidationError(f"{path}.top_p", "Must be between 0 and 1"))
+
+    fallback = raw.get("fallback")
+    if fallback is not None:
+        if is_fallback:
+            errors.append(ValidationError(f"{path}.fallback", "Nested fallbacks are not supported"))
+        else:
+            _validate_model(f"{path}.fallback", fallback, errors, is_fallback=True)
 
 
 def _validate_models(
@@ -598,6 +605,8 @@ class YAMLParser(Parser):
         return ModelConfig(provider="", name="")
 
     def _build_model(self, raw: dict[str, Any]) -> ModelConfig:
+        fallback_raw = raw.get("fallback")
+        fallback = self._build_model(fallback_raw) if isinstance(fallback_raw, dict) else None
         return ModelConfig(
             provider=raw.get("provider", ""),
             name=raw.get("name", ""),
@@ -605,6 +614,7 @@ class YAMLParser(Parser):
             region=raw.get("region"),
             max_tokens=raw.get("max_tokens"),
             top_p=raw.get("top_p"),
+            fallback=fallback,
         )
 
     def _build_resolvers(
@@ -631,9 +641,7 @@ def _looks_secret(value: str) -> bool:
 
 def _looks_secret_value(value: str) -> bool:
     """Value check: flag only strings that plausibly contain a credential."""
-    return bool(
-        _SECRET_VALUE_ASSIGNMENT.search(value) or _CREDENTIAL_SHAPES.search(value)
-    )
+    return bool(_SECRET_VALUE_ASSIGNMENT.search(value) or _CREDENTIAL_SHAPES.search(value))
 
 
 def _dedupe_stable(items: Iterable[str]) -> tuple[str, ...]:

--- a/src/agent_engine/parsers/yaml/parser.py
+++ b/src/agent_engine/parsers/yaml/parser.py
@@ -11,6 +11,7 @@ from agent_engine.core.errors import ValidationError
 from agent_engine.core.execution import EXECUTION_INT_FIELDS, ExecutionPolicy
 from agent_engine.core.spec import (
     AgentSpec,
+    BaseModelConfig,
     BasePromptSet,
     DefaultsConfig,
     GraphNode,
@@ -604,9 +605,19 @@ class YAMLParser(Parser):
             return defaults.model
         return ModelConfig(provider="", name="")
 
+    def _build_base_model(self, raw: dict[str, Any]) -> BaseModelConfig:
+        return BaseModelConfig(
+            provider=raw.get("provider", ""),
+            name=raw.get("name", ""),
+            temperature=raw.get("temperature"),
+            region=raw.get("region"),
+            max_tokens=raw.get("max_tokens"),
+            top_p=raw.get("top_p"),
+        )
+
     def _build_model(self, raw: dict[str, Any]) -> ModelConfig:
         fallback_raw = raw.get("fallback")
-        fallback = self._build_model(fallback_raw) if isinstance(fallback_raw, dict) else None
+        fallback = self._build_base_model(fallback_raw) if isinstance(fallback_raw, dict) else None
         return ModelConfig(
             provider=raw.get("provider", ""),
             name=raw.get("name", ""),

--- a/src/agentctl/diagnostics.py
+++ b/src/agentctl/diagnostics.py
@@ -188,6 +188,10 @@ def _format_inspection_report(spec: SystemSpec, base_dir: Path, path: Path) -> s
     for agent in agents:
         out.append(f"  - {agent.id} ({agent.name})")
         out.append(f"      model: {agent.model.provider}/{agent.model.name}")
+        if agent.model.fallback:
+            out.append(
+                f"      fallback: {agent.model.fallback.provider}/{agent.model.fallback.name}"
+            )
         if agent.prompts.system:
             out.append(f"      prompt: {agent.prompts.system}")
         out.append(f"      tools: {', '.join(t.id for t in agent.tools) or '(none)'}")

--- a/tests/cli/test_inspect_command.py
+++ b/tests/cli/test_inspect_command.py
@@ -128,3 +128,23 @@ def test_cli_inspect_missing_file_exits_nonzero() -> None:
 def test_cli_has_all_commands() -> None:
     # Regression: existing commands remain registered alongside validate/inspect.
     assert {"validate", "inspect", "run", "generate", "serve"} <= set(cli.commands)
+
+
+def test_inspect_shows_fallback_model(tmp_path: Path) -> None:
+    spec = _write(
+        tmp_path,
+        "system: {name: t}\n"
+        "agents:\n"
+        "  a:\n"
+        "    description: d\n"
+        "    model:\n"
+        "      provider: anthropic\n"
+        "      name: haiku\n"
+        "      fallback:\n"
+        "        provider: openai\n"
+        "        name: gpt-4o\n"
+        "graph: {a: }\n",
+    )
+    out = inspect_spec(spec)
+    assert "model: anthropic/haiku" in out
+    assert "fallback: openai/gpt-4o" in out

--- a/tests/cli/test_validate_command.py
+++ b/tests/cli/test_validate_command.py
@@ -202,6 +202,7 @@ def test_validate_rejects_unsupported_model_provider(tmp_path: Path) -> None:
 
 # -- failing specs -----------------------------------------------------------
 
+
 def test_validate_rejects_negative_temperature(tmp_path: Path) -> None:
     spec = _write(
         tmp_path,
@@ -226,6 +227,7 @@ def test_validate_rejects_non_numeric_temperature(tmp_path: Path) -> None:
     result = validate_spec(spec)
     assert not result.ok
     assert any("temperature" in e for e in result.errors)
+
 
 def test_validate_fails_on_invalid_tool_tags(tmp_path: Path) -> None:
     spec = _write(
@@ -285,3 +287,66 @@ def test_cli_validate_exit_nonzero_on_failure(tmp_path: Path) -> None:
     res = runner.invoke(cli, ["--log-level", "WARNING", "validate", spec])
     assert res.exit_code != 0
     assert "Validation failed" in res.output
+
+
+# -- fallback model validation -------------------------------------------------
+
+
+def test_validate_accepts_fallback_model(tmp_path: Path) -> None:
+    spec = _write(
+        tmp_path,
+        "system: {name: t}\n"
+        "defaults:\n"
+        "  model:\n"
+        "    provider: anthropic\n"
+        "    name: claude-sonnet-4-6\n"
+        "    fallback:\n"
+        "      provider: openai\n"
+        "      name: gpt-4o\n"
+        "agents: {a: {description: d}}\n"
+        "graph: {a: }\n",
+    )
+    result = validate_spec(spec)
+    assert result.ok, result.errors
+
+
+def test_validate_rejects_nested_fallbacks(tmp_path: Path) -> None:
+    spec = _write(
+        tmp_path,
+        "system: {name: t}\n"
+        "defaults:\n"
+        "  model:\n"
+        "    provider: anthropic\n"
+        "    name: claude-sonnet-4-6\n"
+        "    fallback:\n"
+        "      provider: openai\n"
+        "      name: gpt-4o\n"
+        "      fallback:\n"
+        "        provider: gemini\n"
+        "        name: gemini-2.5-flash\n"
+        "agents: {a: {description: d}}\n"
+        "graph: {a: }\n",
+    )
+    result = validate_spec(spec)
+    assert not result.ok
+    assert any("Nested fallbacks are not supported" in e for e in result.errors)
+
+
+def test_validate_rejects_invalid_fallback_fields(tmp_path: Path) -> None:
+    spec = _write(
+        tmp_path,
+        "system: {name: t}\n"
+        "defaults:\n"
+        "  model:\n"
+        "    provider: anthropic\n"
+        "    name: claude-sonnet-4-6\n"
+        "    fallback:\n"
+        "      provider: openai\n"
+        "      name: gpt-4o\n"
+        "      temperature: -0.5\n"
+        "agents: {a: {description: d}}\n"
+        "graph: {a: }\n",
+    )
+    result = validate_spec(spec)
+    assert not result.ok
+    assert any("fallback.temperature" in e and "non-negative number" in e for e in result.errors)

--- a/tests/engine/test_engine_flow.py
+++ b/tests/engine/test_engine_flow.py
@@ -46,6 +46,57 @@ from agent_engine.runtime.state import GraphState
 # ---------------------------------------------------------------------------
 
 
+class FakeRunnableWithFallbacks:
+    def __init__(self, primary: Any, fallbacks: list[Any]) -> None:
+        self._primary = primary
+        self._fallbacks = fallbacks
+
+    async def ainvoke(self, messages: list[Any]) -> Any:
+        try:
+            return await self._primary.ainvoke(messages)
+        except Exception:
+            for fallback in self._fallbacks:
+                try:
+                    return await fallback.ainvoke(messages)
+                except Exception:
+                    continue
+            raise
+
+    async def astream(self, messages: list[Any]) -> AsyncIterator[Any]:
+        try:
+            async for chunk in self._primary.astream(messages):
+                yield chunk
+        except Exception:
+            for fallback in self._fallbacks:
+                try:
+                    async for chunk in fallback.astream(messages):
+                        yield chunk
+                    return
+                except Exception:
+                    continue
+            raise
+
+
+class FailingChatModel:
+    def bind_tools(self, tools: list[Any]) -> FailingChatModel:
+        return self
+
+    def with_fallbacks(
+        self,
+        fallbacks: list[Any],
+        exceptions_to_handle: tuple[type[BaseException], ...] = (Exception,),
+    ) -> Any:
+        return FakeRunnableWithFallbacks(self, fallbacks)
+
+    async def ainvoke(self, messages: list[Any]) -> AIMessage:
+        raise RuntimeError("Model execution failed")
+
+    async def astream(self, messages: list[Any]) -> AsyncIterator[AIMessage]:
+        if False:
+            yield AIMessage(content="")
+        raise RuntimeError("Model stream failed")
+
+
 class FakeChatModel:
     """A scriptless stand-in: route through one tool, then answer."""
 
@@ -55,6 +106,13 @@ class FakeChatModel:
 
     def bind_tools(self, tools: list[Any]) -> FakeChatModel:
         return FakeChatModel(self._answer, [t.name for t in tools])
+
+    def with_fallbacks(
+        self,
+        fallbacks: list[Any],
+        exceptions_to_handle: tuple[type[BaseException], ...] = (Exception,),
+    ) -> Any:
+        return FakeRunnableWithFallbacks(self, fallbacks)
 
     async def ainvoke(self, messages: list[Any]) -> AIMessage:
         return self._respond(messages)
@@ -91,6 +149,10 @@ class FakeChatModel:
 @pytest.fixture
 def model_factory() -> Callable[[str, str, float | None], BaseChatModel]:
     def factory(provider: str, name: str, temperature: float | None) -> BaseChatModel:
+        if name == "failing-primary":
+            return cast(BaseChatModel, FailingChatModel())
+        if name == "successful-fallback":
+            return cast(BaseChatModel, FakeChatModel(answer="recovered ok"))
         return cast(BaseChatModel, FakeChatModel())
 
     return factory
@@ -392,3 +454,61 @@ def test_graph_state_accepts_generic_run_context() -> None:
     }
 
     assert state["run_context"]["metadata"]["allowed_nodes"] == ("admin",)
+
+
+# -- fallback execution tests --------------------------------------------------
+
+
+async def test_fallback_model_execution(tmp_path: Path, model_factory: Any) -> None:
+    # Configure an agent where the primary model fails and fallback succeeds
+    fallback_model = ModelConfig(provider="fake", name="successful-fallback")
+    model = ModelConfig(
+        provider="fake",
+        name="failing-primary",
+        fallback=fallback_model,
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="fallback-test"),
+        defaults=None,
+        graph=GraphNode(
+            node=AgentSpec(
+                id="agent",
+                name="agent",
+                description="test agent",
+                model=model,
+                prompts=BasePromptSet(),
+            )
+        ),
+    )
+
+    result = await run_message(spec, tmp_path, model_factory, "hello")
+    assert result.answer == "recovered ok"
+    assert result.visited == ["agent"]
+
+
+async def test_fallback_model_streaming(tmp_path: Path, model_factory: Any) -> None:
+    fallback_model = ModelConfig(provider="fake", name="successful-fallback")
+    model = ModelConfig(
+        provider="fake",
+        name="failing-primary",
+        fallback=fallback_model,
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="fallback-test"),
+        defaults=None,
+        graph=GraphNode(
+            node=AgentSpec(
+                id="agent",
+                name="agent",
+                description="test agent",
+                model=model,
+                prompts=BasePromptSet(),
+            )
+        ),
+    )
+
+    async with LangGraphEngine(tmp_path, model_factory=model_factory) as engine:
+        await engine.build(spec)
+        events = [e async for e in engine.stream("hello")]
+
+    assert any(e.type == "answer_delta" and e.content == "recovered ok" for e in events)

--- a/tests/engine/test_engine_flow.py
+++ b/tests/engine/test_engine_flow.py
@@ -512,3 +512,29 @@ async def test_fallback_model_streaming(tmp_path: Path, model_factory: Any) -> N
         events = [e async for e in engine.stream("hello")]
 
     assert any(e.type == "answer_delta" and e.content == "recovered ok" for e in events)
+
+
+async def test_orchestrator_fallback_model_execution(tmp_path: Path, model_factory: Any) -> None:
+    fallback_model = ModelConfig(provider="fake", name="successful-fallback")
+    model = ModelConfig(
+        provider="fake",
+        name="failing-primary",
+        fallback=fallback_model,
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="orchestrator-fallback-test"),
+        defaults=None,
+        graph=GraphNode(
+            node=OrchestratorSpec(
+                id="root",
+                name="root",
+                description="root orchestrator",
+                model=model,
+                prompts=OrchestratorPromptSet(),
+            ),
+            children=(agent("child"),),
+        ),
+    )
+
+    result = await run_message(spec, tmp_path, model_factory, "hello child")
+    assert result.visited == ["root", "root/child"]


### PR DESCRIPTION
Closes #25

### Background
Currently, if a primary model fails due to provider outages, rate limiting, or connection drops, the agent/orchestrator execution fails immediately. To make the platform resilient, we need support for fallback model configurations.

### Changes
1. Spec & Parser Update:
   - Modified `ModelConfig` to include an optional nested `fallback: ModelConfig` field.
   - Updated `YAMLParser` to recursively parse `fallback` configurations.
   - Added validation in `_validate_model` to enforce exactly one level of nested fallback (strictly rejecting fallback chains/nested fallbacks under fallback models) and throwing a `ValidationError`.

2. Execution Engine Integration:
   - Updated `_build_model` to bind tools to the primary and fallback models individually before wrapping them using LangChain's `.with_fallbacks()` capability.
   - Triggers the fallback backup model on any model invocation or streaming exception.

3. Diagnostics & Inspect Output:
   - Updated the `agentctl inspect` command to display fallback model configurations for agents in offline inspection summaries.

4. Tests:
   - Added validation unit tests in `tests/cli/test_validate_command.py` checking validation checks on valid and invalid fallback configurations.
   - Added integration/E2E tests in `tests/engine/test_engine_flow.py` checking that both normal execution (`ainvoke`) and streaming (`astream`) gracefully recover when the primary model fails.
   - Added CLI inspect tests in `tests/cli/test_inspect_command.py` checking fallback output rendering.
