### PR TITLE
test(fixtures): add self-contained openai-default test system YAML

### DIFF
--- a/tests/fixtures/plugins/__init__.py
+++ b/tests/fixtures/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Client extension package (hooks, resolvers, tools)."""

--- a/tests/fixtures/plugins/plugins.toml
+++ b/tests/fixtures/plugins/plugins.toml
@@ -1,0 +1,41 @@
+# plugins.toml — unified manifest for this client extension package.
+#
+# ONE manifest for ALL client extension code: hooks, resolvers, and tools.
+# It is a catalog/generation companion. The runtime reads only [hooks.plugins]
+# to resolve managed hook ids; resolvers and tools load by file path.
+# `agentctl generate` creates this file if missing and merges new entries in
+# without overwriting manual edits.
+#
+# SECURITY: never put secrets here. Only import refs and metadata — no tokens,
+# client secrets, HMAC keys, or Authorization values.
+
+[package]
+name = "fixtures.plugins"
+description = "Client extension package for hooks, resolvers, and tools."
+
+[paths]
+hooks = "fixtures.plugins.hooks"
+resolvers = "fixtures.plugins.resolvers"
+tools = "fixtures.plugins.tools"
+
+[hooks]
+on_engine_start = []
+on_engine_stop = []
+on_run_start = []
+on_run_end = []
+on_run_error = []
+before_tool_call = []
+after_tool_call = []
+transform_tool_result = []
+on_tool_error = []
+before_mcp_request = []
+after_mcp_response = []
+
+[hooks.plugins]
+
+[resolvers]
+greeting_agent = "fixtures.plugins.resolvers.greeting_agent:Resolver"
+shared = "fixtures.plugins.resolvers.shared:SharedResolver"
+
+[tools]
+echo_tool = "fixtures.plugins.tools.echo_tool:echo_tool"

--- a/tests/fixtures/plugins/resolvers/greeting_agent.py
+++ b/tests/fixtures/plugins/resolvers/greeting_agent.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from shared import SharedResolver
+
+
+class Resolver(SharedResolver):
+    def __init__(self) -> None:
+        super().__init__()

--- a/tests/fixtures/plugins/resolvers/shared.py
+++ b/tests/fixtures/plugins/resolvers/shared.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+class SharedResolver:
+    def __init__(self) -> None:
+        pass
+
+    def current_date(self, ctx: dict) -> str:
+        """Returns the value for {{current_date}}"""
+        return "2026-07-19"
+
+    def user_name(self, ctx: dict) -> str:
+        """Returns the value for {{user_name}}"""
+        return "Tester"

--- a/tests/fixtures/plugins/tools/echo_tool.py
+++ b/tests/fixtures/plugins/tools/echo_tool.py
@@ -1,0 +1,5 @@
+def echo_tool(input: dict) -> str:
+    """Echo back the input text. Used to verify tool wiring end to end.
+"""
+    text = input.get("text", "")
+    return f"echo: {text}"

--- a/tests/fixtures/prompts/echo_agent/system.md
+++ b/tests/fixtures/prompts/echo_agent/system.md
@@ -1,0 +1,3 @@
+# Echo Agent — system
+
+You echo the user's input back to them using the `echo_tool` tool.

--- a/tests/fixtures/prompts/greeting_agent/system.md
+++ b/tests/fixtures/prompts/greeting_agent/system.md
@@ -1,0 +1,4 @@
+# Greeting Agent — system
+
+You handle greetings and small talk. Be friendly, brief, and use the
+`current_date` and `user_name` context when natural.

--- a/tests/fixtures/prompts/root_router/orchestrator.md
+++ b/tests/fixtures/prompts/root_router/orchestrator.md
@@ -1,0 +1,7 @@
+# Root Router — orchestrator
+
+You are the entry point of the test system. Read the user's request and route it
+to the most appropriate child specialist:
+
+- `greeting_agent` for greetings and small talk.
+- `echo_agent` for requests that ask to repeat or echo text.

--- a/tests/fixtures/prompts/root_router/system.md
+++ b/tests/fixtures/prompts/root_router/system.md
@@ -1,0 +1,4 @@
+# Root Router — system
+
+You route each incoming request to a single child specialist. Do not answer
+directly; delegate to `greeting_agent` or `echo_agent`.

--- a/tests/fixtures/test_system.yaml
+++ b/tests/fixtures/test_system.yaml
@@ -1,0 +1,71 @@
+system:
+  name: "Test Agent System"
+
+# Pick the provider you have a key for: anthropic | openai | gemini | bedrock.
+# Set the matching key in a ".env" file next to this config (see .env.example).
+#   - openai   -> OPENAI_API_KEY      (example below)
+#   - anthropic-> ANTHROPIC_API_KEY
+#   - gemini   -> GEMINI_API_KEY
+#   - bedrock  -> AWS_REGION + ambient AWS creds
+defaults:
+  model:
+    provider: openai
+    name: gpt-4o-mini
+    temperature: 0.0
+
+execution:
+  max_iterations: 10
+  max_tool_calls: 5
+  max_tool_calls_per_agent: 3
+  max_child_agent_calls: 4
+  allow_duplicate_tool_calls: false
+
+tools:
+  echo_tool:
+    description: >
+      Echo back the input text. Used to verify tool wiring end to end.
+
+resolvers:
+  current_date:
+    scope: shared
+
+  user_name:
+    scope: shared
+
+orchestrators:
+  root_router:
+    name: "Root Router"
+    description: >
+      Entry point. Routes the user request to the appropriate specialist.
+    model:
+      provider: openai
+      name: gpt-4o
+      temperature: 0.0
+    prompts:
+      orchestrator: prompts/root_router/orchestrator.md
+      system: prompts/root_router/system.md
+
+agents:
+  greeting_agent:
+    name: "Greeting Agent"
+    description: >
+      Handles simple greetings and small talk.
+    prompts:
+      system: prompts/greeting_agent/system.md
+    resolvers:
+      - current_date
+      - user_name
+
+  echo_agent:
+    name: "Echo Agent"
+    description: >
+      Demonstrates tool usage by echoing user input.
+    prompts:
+      system: prompts/echo_agent/system.md
+    tools:
+      - echo_tool
+
+graph:
+  root_router:
+    greeting_agent:
+    echo_agent:


### PR DESCRIPTION
## Summary
Add a minimal, validating agent system under `tests/fixtures/` for exercising the platform without the flagship example.

- `tests/fixtures/test_system.yaml`: root orchestrator routing to `greeting_agent` and `echo_agent`, with a shared resolver and an `echo_tool`.
- Defaults to the **openai** provider so it runs without an Anthropic key (any of `anthropic`/`openai`/`gemini`/`bedrock` is selectable via `provider:`).
- Prompts, resolver stubs, and the `echo_tool` stub are implemented so `agentctl validate` passes fully offline.

## Why
Gives users a small, self-contained config to learn/run the product. Provider selection is already documented in `docs/YAML_SPEC.md:323-373`; this fixture just makes the openai path runnable out of the box.

## Notes
- `package-lock.json` change was intentionally excluded (unrelated to this fixture).
- No LLM key is required for `agentctl validate`; running `agentctl run/serve` needs a provider key in the environment.

🤖 Generated with [Kilo](https://kilo.ai)