### PR TITLE
fix: publish multi-arch container image (linux/amd64 + linux/arm64) — closes #37

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -41,7 +47,11 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.tag_name }}
             ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY pyproject.toml README.md ./
-RUN pip install --no-cache-dir .
-
 COPY src/ ./src/
-RUN pip install --no-cache-dir --no-deps .
+RUN pip install --no-cache-dir .
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY pyproject.toml README.md ./
-COPY src/ ./src/
 RUN pip install --no-cache-dir .
+
+COPY src/ ./src/
+RUN pip install --no-cache-dir --no-deps .
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Problem
The publish-container job in .github/workflows/release-please.yml builds
and pushes a single linux/amd64 image with no platforms set and no QEMU or
Buildx setup. Developers on Apple Silicon (arm64) and other ARM hosts are forced
to emulate the amd64 image via Docker Desktop's QEMU layer on every pull —
slower startup, slower runtime, on every machine, every time.

Solution
Configure the release workflow to build and publish a true multi-arch manifest
(linux/amd64 + linux/arm64) under the same tag. An arm64 host now pulls its
native build directly. The QEMU emulation cost is moved from every developer's
machine on every pull to the CI runner, once per release.

Changes
.github/workflows/release-please.yml
Add docker/setup-qemu-action@v3 — enables QEMU for cross-arch builds on the
amd64 GitHub runner.
Add docker/setup-buildx-action@v3 — switches to the docker-container
BuildKit driver required for multi-platform manifest pushes.
Set platforms: linux/amd64,linux/arm64 on docker/build-push-action@v6.
Set provenance: false — suppresses SLSA attestation manifests so the GHCR
manifest list stays clean (just the two arch entries).
Add cache-from: type=gha + cache-to: type=gha,mode=max — caches all
intermediate BuildKit layers in GitHub Actions, keeping subsequent release
build times reasonable despite QEMU-emulated cross-compilation.


Closes #37

