### PR TITLE
docs: document agent-level auto field for HITL

### DIFF
--- a/docs/yaml-spec.mdx
+++ b/docs/yaml-spec.mdx
@@ -374,6 +374,7 @@ agents:
 | `tools` | No | Tool ids this agent is allowed to call. |
 | `mcps` | No | MCP server ids this agent has access to. |
 | `protected` | No | `true` to gate this node behind [access control](#access-control). |
+| `auto` | No | `true` skips human approval for this agent's tool calls (default `false`, every call requires approval). [Human-in-the-Loop](/docs/human-in-the-loop). |
 
 An agent only ever sees the tools, MCP servers, and resolvers it explicitly lists — nothing is shared by default.
 


### PR DESCRIPTION
## Summary
- Adds the missing `auto` field to the `agents` field table in `docs/yaml-spec.mdx`
- Links to the existing Human-in-the-Loop page for full detail instead of duplicating it

## Test plan
- [ ] Docs build/preview renders the updated table correctly