### PR TITLE
fix: bundle all built-in providers and optional integrations into base deps

### DIFF
--- a/docs/YAML_SPEC.md
+++ b/docs/YAML_SPEC.md
@@ -354,10 +354,9 @@ model:
   temperature: 0.2
 ```
 
-For Gemini, set `GEMINI_API_KEY` in your environment and install the provider
-extra with `pip install "agent-engine[gemini]"`. Any Gemini model your key can
-access may be used via `name`. `max_tokens` maps to Gemini's `max_output_tokens`.
-Secrets must never be stored in YAML.
+For Gemini, set `GEMINI_API_KEY` in your environment. Any Gemini model your key
+can access may be used via `name`. `max_tokens` maps to Gemini's
+`max_output_tokens`. Secrets must never be stored in YAML.
 
 OpenAI:
 
@@ -368,9 +367,8 @@ model:
   temperature: 0.2
 ```
 
-For OpenAI, set `OPENAI_API_KEY` in your environment and install the provider
-extra with `pip install "agent-engine[openai]"`. Any OpenAI model your key can
-access may be used via `name`. Secrets must never be stored in YAML.
+For OpenAI, set `OPENAI_API_KEY` in your environment. Any OpenAI model your key
+can access may be used via `name`. Secrets must never be stored in YAML.
 
 ### Fallback Models
 

--- a/docs/observability.mdx
+++ b/docs/observability.mdx
@@ -46,23 +46,9 @@ That's the entire integration. No YAML, no code, no flag. Both keys must be pres
   Using a self-hosted Langfuse instance instead of Langfuse Cloud? Add `LANGFUSE_HOST` alongside the two keys above — it's read by the underlying Langfuse SDK the same way.
 </Note>
 
-### Install the langfuse package
-
-The `langfuse` Python package is an **optional dependency** — it's not installed in the base image or the default `pip install` of the engine. Add it wherever your deployment installs dependencies:
-
-```text requirements.txt
-langfuse
-```
-
-The bundled Docker image installs `requirements.txt` automatically when running `serve` (see [Quickstart](/docs/quickstart)). For local development:
-
-```bash
-pip install "agent-engine[langfuse]"
-```
-
 ### What happens if it's misconfigured
 
-If the two keys are set but the `langfuse` package isn't installed, or the client fails to initialize for any reason, Extra logs a warning and **the engine keeps running without tracing** — a broken or missing Langfuse setup never breaks your agents.
+If the two keys are set but the Langfuse client fails to initialize for any reason, Extra logs a warning and **the engine keeps running without tracing** — a broken Langfuse setup never breaks your agents.
 
 <Note>
   This is the opposite failure mode from [runtime hooks](/docs/runtime-hooks), which are fail-closed by default for anything security-critical. Observability failing open is deliberate — losing traces is acceptable; losing service to your customers is not.

--- a/docs/yaml-spec.mdx
+++ b/docs/yaml-spec.mdx
@@ -100,9 +100,9 @@ model:
 
 For Bedrock, `region` can be omitted if `AWS_REGION` or `AWS_DEFAULT_REGION` is set. Credentials follow the standard AWS chain — profile, environment variables, or an IAM role.
 
-For Gemini, set `GEMINI_API_KEY` in your environment (`export GEMINI_API_KEY="..."`) and install the provider extra with `pip install "agent-engine[gemini]"`. Choose any Gemini model your key can access via `name`. Secrets must never be stored in YAML.
+For Gemini, set `GEMINI_API_KEY` in your environment (`export GEMINI_API_KEY="..."`). Choose any Gemini model your key can access via `name`. Secrets must never be stored in YAML.
 
-For OpenAI, set `OPENAI_API_KEY` in your environment (`export OPENAI_API_KEY="..."`) and install the provider extra with `pip install "agent-engine[openai]"`. Choose any OpenAI model your key can access via `name`. See the [OpenAI API docs](https://platform.openai.com/docs/api-reference) for model names. Secrets must never be stored in YAML.
+For OpenAI, set `OPENAI_API_KEY` in your environment (`export OPENAI_API_KEY="..."`). Choose any OpenAI model your key can access via `name`. See the [OpenAI API docs](https://platform.openai.com/docs/api-reference) for model names. Secrets must never be stored in YAML.
 
 <Warning>
   A node-level `model` is a **full replacement**, not a merge with `defaults.model`. If you override the model on an agent, specify every field — `provider`, `name`, and any others you need. Partial overrides won't inherit missing fields from `defaults`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,18 @@ dependencies = [
     "mcp>=1.27,<2",
     "langchain-mcp-adapters>=0.1",
     "python-dotenv>=1.0",
-    "langchain-anthropic (>=1.4.5,<2.0.0)",
-    "langchain-aws>=0.2",
+    "pydantic-settings>=2.0",
+    "click>=8.0",
     "sqlmodel>=0.0.16",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.19",
     "alembic>=1.13",
+    "langchain-anthropic>=1.4.5,<2.0.0",
+    "langchain-aws>=0.2",
+    "langchain-openai>=0.3",
+    "langchain-google-genai>=2.0",
+    "langfuse>=2.0",
+    "asyncpg>=0.29",
 ]
 
 [project.optional-dependencies]
@@ -72,16 +78,6 @@ dev = [
     # moves to 3.12+.
     "numpy<2.2",
 ]
-# Provider integrations are optional — install the one your YAML's
-# `model.provider` references. `init_chat_model` imports it lazily.
-anthropic = ["langchain-anthropic>=0.3"]
-openai = ["langchain-openai>=0.3"]
-bedrock = ["langchain-aws>=0.2"]
-gemini = ["langchain-google-genai>=2.0"]
-langfuse = ["langfuse>=2.0"]
-# PostgreSQL backend for agent_manager: pip install ".[postgres]" + set
-# DATABASE_URL=postgresql+asyncpg://...
-postgres = ["asyncpg>=0.29"]
 
 # CLI entrypoint. `agentctl` is the working CLI name used throughout the docs
 # (see docs/ARCHITECTURE.md and docs/ROADMAP.md); `agent-platform` is provided as


### PR DESCRIPTION
## Summary
- `pip install .` (what the Dockerfile and a bare `pip install agent-engine` both run) only installed the base `dependencies` list; `langchain-openai`, `langchain-google-genai`, `langfuse`, and `asyncpg` were declared only as optional extras, so `provider: openai`/`gemini`, Langfuse tracing, and the Postgres backend silently required a manual extra/`requirements.txt` addition even for a stock deployment with no custom tool code.
- Moved `langchain-anthropic`, `langchain-aws`, `langchain-openai`, `langchain-google-genai`, `langfuse`, and `asyncpg` into base `dependencies` so a plain `docker build`/`pip install .` ships every built-in provider and optional integration out of the box. Also removed a pre-existing duplicate/inconsistent declaration of `langchain-anthropic`/`langchain-aws` (both base dep and extra, with different version pins).
- Added `pydantic-settings` and `click` as explicit direct dependencies — both are imported directly (`agent_manager/config.py`, `agentctl/main.py`, `agentctl/chat.py`, `agent_manager/cli.py`) but were previously only present transitively via `mcp`/`uvicorn`.
- Updated `docs/observability.mdx`, `docs/yaml-spec.mdx`, `docs/YAML_SPEC.md` to drop now-false "install the optional extra" instructions.
- `requirements.txt` (auto-installed by `entrypoint.sh` at container start) and `plugins.toml` are unchanged — they remain the correct mechanism for a user's own tool/plugin code dependencies, which the platform can't predict or bundle.

## Test plan
- [x] `make check` — 532 tests, lint, mypy all pass
- [x] `docker build .` with a plain (no-extras) install, then `docker run` importing `langchain_anthropic`, `langchain_aws`, `langchain_openai`, `langchain_google_genai`, `langfuse`, `asyncpg` inside the built container — all succeed
- [x] `build_chat_model` exercised for all four providers locally — no "missing package" errors, only expected missing-API-key errors for openai/gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)