### PR TITLE
fix(generate): derive the plugin package from import_roots, not the folder name

### DIFF
--- a/src/agent_engine/generate/generator.py
+++ b/src/agent_engine/generate/generator.py
@@ -126,8 +126,13 @@ class Generator:
         hook plugin classes. The runtime reads only [hooks.plugins] to resolve
         managed hook ids; other sections are documentation/generation metadata.
         """
-        manifest_path, created = ensure_plugins_manifest_exists(plugins_root)
-        pkg = manifest_package(manifest_path)
+        # The runtime imports plugin refs relative to plugins.import_roots, so
+        # the manifest's package prefix must be derived from the same roots.
+        import_roots = _resolved_import_roots(spec, plugins_root.parent)
+        manifest_path, created = ensure_plugins_manifest_exists(
+            plugins_root, import_roots=import_roots
+        )
+        pkg = manifest_package(manifest_path, import_roots)
 
         resolver_refs: dict[str, str] = {}
         if shared_ids:
@@ -352,3 +357,18 @@ def _collect_prompts(node: GraphNode) -> list[str]:
 
     walk(node)
     return paths
+
+
+def _resolved_import_roots(spec: SystemSpec, base_dir: Path) -> list[Path]:
+    """Resolve the spec's declared import roots, ignoring unusable ones.
+
+    Generation must not fail because a root does not exist yet — the directory
+    may be about to be scaffolded. An unresolvable root simply does not
+    contribute to the package prefix.
+    """
+    roots: list[Path] = []
+    for root in spec.plugins.import_roots:
+        candidate = (base_dir / root).resolve()
+        if candidate.is_dir():
+            roots.append(candidate)
+    return roots

--- a/src/agent_engine/generate/manifest.py
+++ b/src/agent_engine/generate/manifest.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import re
 import tomllib
+from collections.abc import Sequence
 from pathlib import Path
 
 from agent_engine.runtime.hooks.models import HOOK_POINTS
@@ -49,12 +50,16 @@ class PluginManifestError(RuntimeError):
 
 
 def ensure_plugins_manifest_exists(
-    plugin_root: Path, *, package: str | None = None
+    plugin_root: Path, *, package: str | None = None, import_roots: Sequence[Path] = ()
 ) -> tuple[Path, bool]:
     """Ensure ``plugin_root``, its ``__init__.py``, and ``plugins.toml`` exist.
 
     Returns ``(manifest_path, created)`` where ``created`` is True only when the
     manifest was newly written. An existing manifest is never overwritten.
+
+    ``import_roots`` are the resolved ``plugins.import_roots`` from the spec;
+    they decide the package prefix written into a new manifest so the generated
+    refs import at runtime.
     """
     plugin_root.mkdir(parents=True, exist_ok=True)
     init_file = plugin_root / "__init__.py"
@@ -65,7 +70,7 @@ def ensure_plugins_manifest_exists(
     path = plugin_root / MANIFEST_NAME
     if path.exists():
         return path, False
-    pkg = package or _derive_package(plugin_root)
+    pkg = package or _derive_package(plugin_root, import_roots)
     path.write_text(_render(_default_manifest(pkg)), encoding="utf-8")
     logger.info("created plugin manifest %s", path)
     return path, True
@@ -85,13 +90,18 @@ def hook_plugin_refs(path: Path) -> dict[str, str]:
     return {str(key): str(value) for key, value in plugins.items()}
 
 
-def manifest_package(path: Path) -> str:
-    """Return the manifest's declared package name (or derive from the path)."""
+def manifest_package(path: Path, import_roots: Sequence[Path] = ()) -> str:
+    """Return the manifest's declared package name (or derive it).
+
+    A manifest written by an earlier version may carry a package prefix that
+    does not import; its declared name still wins here, because rewriting it
+    could break a project that fixed the value by hand.
+    """
     if path.exists():
         name = load_manifest(path).get("package", {}).get("name")
         if isinstance(name, str) and name:
             return name
-    return _derive_package(path.parent)
+    return _derive_package(path.parent, import_roots)
 
 
 def update_manifest(
@@ -156,11 +166,30 @@ def update_manifest(
 # -- internals --------------------------------------------------------------
 
 
-def _derive_package(plugin_root: Path) -> str:
-    parent, name = plugin_root.parent.name, plugin_root.name
-    if name.isidentifier() and parent.isidentifier():
-        return f"{parent}.{name}"
-    return name if name.isidentifier() else "plugins"
+def _derive_package(plugin_root: Path, import_roots: Sequence[Path] = ()) -> str:
+    """Return the package name that matches how the runtime imports it.
+
+    The engine puts ``plugins.import_roots`` on ``sys.path``, so the package is
+    ``plugin_root`` expressed relative to whichever declared root contains it.
+    For the documented ``import_roots: ["."]`` layout — ``plugins/`` beside
+    ``agents.yml`` — that is simply ``plugins``.
+
+    Falls back to the directory's own name when no root contains it (callers
+    without a spec). Deriving a prefix from the *parent* directory name would
+    only be right if the import root were the directory above the example, and
+    produced refs that could not be imported at all when the example directory
+    happened to be a valid Python identifier.
+    """
+    resolved = plugin_root.resolve()
+    for import_root in import_roots:
+        try:
+            relative = resolved.relative_to(import_root.resolve())
+        except ValueError:
+            continue  # plugin_root is not under this root
+        parts = relative.parts
+        if parts and all(part.isidentifier() for part in parts):
+            return ".".join(parts)
+    return plugin_root.name if plugin_root.name.isidentifier() else "plugins"
 
 
 def _default_manifest(pkg: str) -> dict:

--- a/tests/generate/test_plugins_manifest.py
+++ b/tests/generate/test_plugins_manifest.py
@@ -16,6 +16,7 @@ from agent_engine.core.spec import (
     ModelConfig,
     OrchestratorPromptSet,
     OrchestratorSpec,
+    PluginsConfig,
     ResolverSpec,
     SystemMeta,
     SystemSpec,
@@ -75,10 +76,28 @@ def test_existing_manifest_is_not_overwritten(tmp_path: Path) -> None:
     assert path.read_text() == before  # untouched
 
 
-def test_derives_package_from_path(tmp_path: Path) -> None:
-    root = tmp_path / "examples" / "plugins"
+def test_derives_package_from_import_root(tmp_path: Path) -> None:
+    """The package is the plugin dir relative to the import root on sys.path."""
+    example = tmp_path / "examples" / "starter"
+    root = example / "plugins"
+    path, _ = ensure_plugins_manifest_exists(root, import_roots=(example,))
+    assert manifest_package(path, (example,)) == "plugins"
+
+
+def test_derives_nested_package_when_import_root_is_higher(tmp_path: Path) -> None:
+    """A root above the example makes the example itself part of the package."""
+    examples = tmp_path / "examples"
+    root = examples / "starter" / "plugins"
+    path, _ = ensure_plugins_manifest_exists(root, import_roots=(examples,))
+    assert manifest_package(path, (examples,)) == "starter.plugins"
+
+
+def test_derives_package_from_dir_name_without_import_roots(tmp_path: Path) -> None:
+    """With no roots to measure against, use the directory's own name — never
+    the parent's, which would produce a prefix that does not import."""
+    root = tmp_path / "starter" / "plugins"
     path, _ = ensure_plugins_manifest_exists(root)
-    assert manifest_package(path) == "examples.plugins"
+    assert manifest_package(path) == "plugins"
 
 
 # -- update_manifest ---------------------------------------------------------
@@ -166,7 +185,7 @@ def test_hook_plugin_refs_loads_plugins_table(tmp_path: Path) -> None:
 # -- Generator integration ---------------------------------------------------
 
 
-def _spec_with_plugins() -> SystemSpec:
+def _spec_with_plugins(import_roots: tuple[str, ...] = ()) -> SystemSpec:
     agent = AgentSpec(
         id="flights",
         name="flights",
@@ -186,6 +205,7 @@ def _spec_with_plugins() -> SystemSpec:
                 HookSpec("before_mcp_request", plugin="mcp_auth", method="before_mcp_request"),
             )
         ),
+        plugins=PluginsConfig(import_roots=import_roots),
     )
 
 
@@ -197,11 +217,12 @@ def test_generate_creates_manifest_with_refs(tmp_path: Path) -> None:
     assert f"plugins/{MANIFEST_NAME}" in result.created
 
     data = _read(manifest)
-    assert data["tools"]["book_flight"].endswith(".plugins.tools.book_flight:book_flight")
-    assert data["resolvers"]["shared"].endswith(".plugins.resolvers.shared:SharedResolver")
-    assert data["resolvers"]["flights"].endswith(".plugins.resolvers.flights:Resolver")
+    # Refs are rooted at `plugins`, matching what the runtime puts on sys.path.
+    assert data["tools"]["book_flight"] == "plugins.tools.book_flight:book_flight"
+    assert data["resolvers"]["shared"] == "plugins.resolvers.shared:SharedResolver"
+    assert data["resolvers"]["flights"] == "plugins.resolvers.flights:Resolver"
     assert data["hooks"]["after_tool_call"] == ["pkg.hooks.audit:record"]
-    assert data["hooks"]["plugins"]["mcp_auth"].endswith(".plugins.hooks.mcp_auth:McpAuthHook")
+    assert data["hooks"]["plugins"]["mcp_auth"] == "plugins.hooks.mcp_auth:McpAuthHook"
     # Regression: resolver/tool stubs are still generated.
     assert (tmp_path / "plugins" / "tools" / "book_flight.py").is_file()
     assert (tmp_path / "plugins" / "resolvers" / "flights.py").is_file()
@@ -316,3 +337,47 @@ def test_generator_deduplicates_shared_prompt_path(tmp_path: Path) -> None:
     # Must appear in created exactly once, never in skipped
     assert result.created.count("prompts/shared/system.md") == 1
     assert "prompts/shared/system.md" not in result.skipped
+
+
+# -- regression: generated refs must actually import --------------------------
+
+
+def _hook_ref(base_dir: Path) -> str:
+    data = tomllib.loads((base_dir / "plugins" / MANIFEST_NAME).read_text(encoding="utf-8"))
+    return str(data["hooks"]["plugins"]["mcp_auth"])
+
+
+def test_package_prefix_ignores_the_example_directory_name(tmp_path: Path) -> None:
+    """A plugin dir whose parent is a valid identifier must not gain a prefix.
+
+    The package was previously derived from the parent directory name, so an
+    example in ``starter/`` produced ``starter.plugins.hooks...`` — which does
+    not import, because ``import_roots: ["."]`` puts ``starter/`` itself on
+    sys.path. An example in a hyphenated directory accidentally avoided this.
+    """
+    base_dir = tmp_path / "starter"  # a valid Python identifier
+    base_dir.mkdir()
+
+    Generator().generate(_spec_with_plugins(import_roots=(".",)), base_dir)
+
+    assert _hook_ref(base_dir) == "plugins.hooks.mcp_auth:McpAuthHook"
+
+
+def test_generated_hook_ref_is_importable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end guard: import the ref exactly as the runtime would."""
+    import importlib
+    import sys
+
+    base_dir = tmp_path / "starter"
+    base_dir.mkdir()
+    Generator().generate(_spec_with_plugins(import_roots=(".",)), base_dir)
+
+    # The engine puts each import root on sys.path before importing plugins.
+    monkeypatch.syspath_prepend(str(base_dir))
+    for name in [n for n in sys.modules if n == "plugins" or n.startswith("plugins.")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    module_path, _, class_name = _hook_ref(base_dir).partition(":")
+    module = importlib.import_module(module_path)
+
+    assert hasattr(module, class_name)


### PR DESCRIPTION
## The bug

`agentctl generate` derives the manifest's package prefix from the plugin directory's **parent** name:

```python
# manifest.py:_derive_package  (before)
parent, name = plugin_root.parent.name, plugin_root.name
if name.isidentifier() and parent.isidentifier():
    return f"{parent}.{name}"          # -> "myagent.plugins"
```

But the runtime imports plugins relative to `plugins.import_roots`, which the engine puts on `sys.path`. For the documented layout — `plugins/` beside `agents.yml`, `import_roots: ["."]` — that root **is** the example directory, so the package is `plugins`. There is no `myagent` package anywhere; `myagent` is the root itself.

So the generator writes refs that cannot be imported, and the next `validate` or `run` fails outright.

**Why it went unnoticed:** the only example exercising hooks lives in `examples/enterprise-knowledge-assistant`. Hyphens make that an invalid Python identifier, so `parent.isidentifier()` is False and it falls into the `"plugins"` fallback — correct by accident. The bug fires as soon as someone names an example directory something Python-legal, which is the normal thing to do.

## Reproduce

```bash
mkdir -p myagent && cat > myagent/agents.yaml <<'EOF'
system:
  name: Repro
plugins:
  import_roots: ["."]
hooks:
  on_run_start:
    - plugin: audit
      method: run_started
agents:
  helper:
    description: does things
    prompts:
      system: prompts/helper/system.md
graph:
  helper:
EOF

agentctl generate --config myagent/agents.yaml
grep 'audit =' myagent/plugins/plugins.toml
echo x > myagent/prompts/helper/system.md      # satisfy the prompt stub check
agentctl validate myagent/agents.yaml
```

**Before**

```
audit = "myagent.plugins.hooks.audit:AuditHook"

✗ hooks: Failed to load hook for 'on_run_start' (ref='audit'):
  cannot import hook plugin 'audit' module 'myagent.plugins.hooks.audit':
  No module named 'myagent'
```

**After**

```
audit = "plugins.hooks.audit:AuditHook"

✓ validation passed
```

Rename `myagent` to `my-agent` on `main` and it works — that hyphen is the only thing standing between the current code and this failure.

## The fix

Compute the package as the plugin directory relative to whichever declared import root contains it — the same rule the runtime uses. `import_roots` is threaded from the spec (which `Generator.generate` already has) into `ensure_plugins_manifest_exists` and `manifest_package`.

Behaviour worth calling out:

- `import_roots: ["."]` → `plugins` (the common case, and the one that was broken).
- `import_roots: [".."]` → `starter.plugins`. The nested prefix is still reachable — it just has to be *declared* now rather than inferred from a directory name.
- No roots, or none containing the directory → falls back to the directory's own name, never the parent's.
- **Existing manifests are untouched.** A declared `[package] name` still wins, so a project that corrected the value by hand keeps it, and no one gets a surprise rewrite on their next `generate`.
- Roots that do not resolve are skipped rather than raising — generation must not fail because a directory has yet to be scaffolded.

## Tests

Five tests cover it; **all five fail on `main`**, and the last one fails with the exact production error (`ModuleNotFoundError: No module named 'starter'`):

| Test | What it pins |
| --- | --- |
| `test_derives_package_from_import_root` | `import_roots: ["."]` → `plugins` |
| `test_derives_nested_package_when_import_root_is_higher` | a higher root → `starter.plugins` |
| `test_derives_package_from_dir_name_without_import_roots` | no roots → own name, not the parent's |
| `test_package_prefix_ignores_the_example_directory_name` | the regression: identifier-named parent gains no prefix |
| `test_generated_hook_ref_is_importable` | end-to-end — imports the generated ref exactly as the runtime does |

Two existing tests asserted the old prefix (`test_derives_package_from_path`, and an `.endswith(".plugins.tools…")` assertion that only passed *because* of the spurious dot). Both updated to assert the correct value exactly.

536 tests pass, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)