### PR TITLE
feat(widget): bouncing-dots loading that survives thread switches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@
 # to main. Single Python version per pyproject.toml (requires-python >=3.11);
 # no matrix, no caching tuning — see the issue's non-goals.
 #
-# To make this a required status check, protect `main` in the repo settings
-# and require the "check" job (maintainer action, not part of this file).
+# The `widget` job covers the embeddable chat widget: TypeScript typecheck,
+# bundle freshness, and the Playwright browser suite.
+#
+# To make these required status checks, protect `main` in the repo settings
+# and require the "check" and "widget" jobs (maintainer action, not part of
+# this file).
 
 name: CI
 
@@ -40,3 +44,45 @@ jobs:
 
       - name: Validate flagship example (offline)
         run: make validate
+
+  widget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      # The e2e suite serves the widget from a uvicorn app (playwright.config.ts).
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: |
+          npm ci
+          make install
+
+      - name: Typecheck (widget + e2e)
+        run: |
+          npm run typecheck:widget
+          npm run typecheck:e2e
+
+      # widget.js is committed and is what the browser loads, so a stale bundle
+      # would let e2e pass against source that was never built.
+      - name: Bundle matches source
+        run: |
+          npm run build:widget
+          git diff --exit-code -- src/agent_manager/api/static/widget.js
+
+      - name: Widget self-check
+        run: npm run test:widget
+
+      - name: Browser tests
+        run: |
+          npx playwright install --with-deps chromium
+          npx playwright test

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -52407,29 +52407,6 @@ var X = createLucideIcon("x", __iconNode12);
 // src/agent_manager/api/static/widget/react/AgentChatApp.tsx
 var import_react10 = __toESM(require_react(), 1);
 
-// src/agent_manager/api/static/widget/storage/conversationStorage.ts
-function conversationStorageKey(endpoint, userId) {
-  return `agent-chat:${endpoint}:${userId}`;
-}
-function getStoredConversationId(endpoint, userId, storage = localStorage) {
-  return storage.getItem(conversationStorageKey(endpoint, userId));
-}
-function setStoredConversationId(endpoint, userId, conversationId, storage = localStorage) {
-  storage.setItem(conversationStorageKey(endpoint, userId), conversationId);
-}
-function removeStoredConversationId(endpoint, userId, storage = localStorage) {
-  storage.removeItem(conversationStorageKey(endpoint, userId));
-}
-function getOrCreateUserId(endpoint, storage = localStorage) {
-  const key = `agent-chat:user:${endpoint}`;
-  let id = storage.getItem(key);
-  if (!id) {
-    id = crypto.randomUUID();
-    storage.setItem(key, id);
-  }
-  return id;
-}
-
 // src/agent_manager/api/static/widget/react/shadcnAiElements.tsx
 var import_react8 = __toESM(require_react(), 1);
 
@@ -53049,6 +53026,31 @@ function upsertTool(tools, next2) {
 
 // src/agent_manager/api/static/widget/react/useConversation.ts
 var import_react9 = __toESM(require_react(), 1);
+
+// src/agent_manager/api/static/widget/storage/conversationStorage.ts
+function conversationStorageKey(endpoint, userId) {
+  return `agent-chat:${endpoint}:${userId}`;
+}
+function getStoredConversationId(endpoint, userId, storage = localStorage) {
+  return storage.getItem(conversationStorageKey(endpoint, userId));
+}
+function setStoredConversationId(endpoint, userId, conversationId, storage = localStorage) {
+  storage.setItem(conversationStorageKey(endpoint, userId), conversationId);
+}
+function removeStoredConversationId(endpoint, userId, storage = localStorage) {
+  storage.removeItem(conversationStorageKey(endpoint, userId));
+}
+function getOrCreateUserId(endpoint, storage = localStorage) {
+  const key = `agent-chat:user:${endpoint}`;
+  let id = storage.getItem(key);
+  if (!id) {
+    id = crypto.randomUUID();
+    storage.setItem(key, id);
+  }
+  return id;
+}
+
+// src/agent_manager/api/static/widget/react/useConversation.ts
 var isUnusableConversation = (error) => error instanceof AgentChatHttpError && (error.status === 404 || error.status === 403);
 function useConversation(client, endpoint, userId) {
   const startConversation = (0, import_react9.useCallback)(async () => {
@@ -53063,12 +53065,11 @@ function useConversation(client, endpoint, userId) {
   );
   const replace2 = (0, import_react9.useCallback)(
     async (staleId, onReplaced) => {
-      removeStoredConversationId(endpoint, userId);
-      const fresh = await startConversation();
+      const fresh = await client.createConversation();
       onReplaced?.(staleId, fresh);
       return fresh;
     },
-    [endpoint, userId, startConversation]
+    [client]
   );
   const send = (0, import_react9.useCallback)(
     async (conversationId, text10, onReplaced) => {
@@ -53172,11 +53173,21 @@ function AgentChatApp({
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
   const launcherRef = (0, import_react10.useRef)(null);
   const inputRef = (0, import_react10.useRef)(null);
-  const adoptConversation = (0, import_react10.useCallback)((staleId, freshId) => {
-    setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
-    setActiveId((current) => current === staleId ? freshId : current);
+  const activeIdRef = (0, import_react10.useRef)(activeId);
+  const selectThread = (0, import_react10.useCallback)((conversationId) => {
+    activeIdRef.current = conversationId;
+    setActiveId(conversationId);
   }, []);
   const conversation = useConversation(client, config.endpoint, userId);
+  const adoptConversation = (0, import_react10.useCallback)(
+    (staleId, freshId) => {
+      setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
+      if (activeIdRef.current !== staleId) return;
+      selectThread(freshId);
+      conversation.switchTo(freshId);
+    },
+    [conversation, selectThread]
+  );
   const refreshUsage = (0, import_react10.useCallback)(
     async (cid) => {
       const next2 = await conversation.loadUsage(cid);
@@ -53200,10 +53211,10 @@ function AgentChatApp({
     setLoaded(true);
     const cid = conversation.peekId();
     if (!cid) return;
-    setActiveId(cid);
+    selectThread(cid);
     await loadThread(cid);
     await refreshUsage(cid);
-  }, [conversation, loaded, loadThread, refreshUsage]);
+  }, [conversation, loaded, loadThread, refreshUsage, selectThread]);
   (0, import_react10.useEffect)(() => {
     if (inline) void loadHistory();
   }, [inline, loadHistory]);
@@ -53228,19 +53239,19 @@ function AgentChatApp({
     async (conversationId) => {
       conversation.switchTo(conversationId);
       setThreadsOpen(false);
-      setActiveId(conversationId);
+      selectThread(conversationId);
       if (!(conversationId in entriesById)) await loadThread(conversationId);
       await refreshUsage(conversationId);
       inputRef.current?.focus({ preventScroll: true });
     },
-    [conversation, entriesById, loadThread, refreshUsage]
+    [conversation, entriesById, loadThread, refreshUsage, selectThread]
   );
   const startNewThread = (0, import_react10.useCallback)(() => {
     conversation.startNew();
     setThreadsOpen(false);
-    setActiveId("");
+    selectThread("");
     inputRef.current?.focus({ preventScroll: true });
-  }, [conversation]);
+  }, [conversation, selectThread]);
   const replaceEntry = (0, import_react10.useCallback)(
     (cid, id, entry) => putEntries(cid, (prev) => prev.map((current) => current.id === id ? entry : current)),
     [putEntries]
@@ -53271,8 +53282,8 @@ function AgentChatApp({
   );
   const submit = (0, import_react10.useCallback)(
     async (text10) => {
-      const cid = await conversation.ensureId();
-      setActiveId(cid);
+      const cid = activeIdRef.current || await conversation.ensureId();
+      selectThread(cid);
       const pending = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
       setSending(true);
@@ -53303,6 +53314,7 @@ function AgentChatApp({
       putEntries,
       refreshUsage,
       replaceEntry,
+      selectThread,
       sendWithoutStreaming
     ]
   );
@@ -53361,7 +53373,7 @@ function AgentChatApp({
                   {
                     open: threadsOpen,
                     threads,
-                    activeId: getStoredConversationId(config.endpoint, userId),
+                    activeId,
                     onSelect: openThread,
                     onNew: startNewThread,
                     onClose: () => setThreadsOpen(false)

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53050,65 +53050,71 @@ function upsertTool(tools, next2) {
 // src/agent_manager/api/static/widget/react/useConversation.ts
 var import_react9 = __toESM(require_react(), 1);
 var isUnusableConversation = (error) => error instanceof AgentChatHttpError && (error.status === 404 || error.status === 403);
-function useConversation(client, endpoint, userId) {
+function useConversation(client, endpoint, userId, onReplaced) {
   const startConversation = (0, import_react9.useCallback)(async () => {
     const created = await client.createConversation();
     setStoredConversationId(endpoint, userId, created);
     return created;
   }, [client, endpoint, userId]);
-  const peekId = (0, import_react9.useCallback)(
-    () => getStoredConversationId(endpoint, userId),
-    [endpoint, userId]
-  );
+  const peekId = (0, import_react9.useCallback)(() => getStoredConversationId(endpoint, userId), [endpoint, userId]);
   const ensureId = (0, import_react9.useCallback)(
     async () => getStoredConversationId(endpoint, userId) ?? startConversation(),
     [endpoint, userId, startConversation]
   );
-  const restartId = (0, import_react9.useCallback)(async () => {
-    removeStoredConversationId(endpoint, userId);
-    return startConversation();
-  }, [endpoint, userId, startConversation]);
+  const replace2 = (0, import_react9.useCallback)(
+    async (staleId) => {
+      removeStoredConversationId(endpoint, userId);
+      const fresh = await startConversation();
+      onReplaced?.(staleId, fresh);
+      return fresh;
+    },
+    [endpoint, userId, startConversation, onReplaced]
+  );
   const send = (0, import_react9.useCallback)(
-    async (text10) => {
+    async (conversationId, text10) => {
       try {
-        return await client.sendMessage(await ensureId(), text10);
+        return await client.sendMessage(conversationId, text10);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await restartId(), text10);
+        return client.sendMessage(await replace2(conversationId), text10);
       }
     },
-    [client, ensureId, restartId]
+    [client, replace2]
   );
   const stream = (0, import_react9.useCallback)(
-    async function* (text10) {
+    async function* (conversationId, text10) {
       try {
-        yield* client.streamMessage(await ensureId(), text10);
+        yield* client.streamMessage(conversationId, text10);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await restartId(), text10);
+        yield* client.streamMessage(await replace2(conversationId), text10);
       }
     },
-    [client, ensureId, restartId]
+    [client, replace2]
   );
-  const loadHistory = (0, import_react9.useCallback)(async () => {
-    const stored = getStoredConversationId(endpoint, userId);
-    if (!stored) return [];
-    try {
-      return await client.getMessages(stored);
-    } catch (error) {
-      if (isUnusableConversation(error)) removeStoredConversationId(endpoint, userId);
-      return [];
-    }
-  }, [client, endpoint, userId]);
-  const loadUsage = (0, import_react9.useCallback)(async () => {
-    const stored = getStoredConversationId(endpoint, userId);
-    if (!stored) return null;
-    try {
-      return await client.getUsage(stored);
-    } catch {
-      return null;
-    }
-  }, [client, endpoint, userId]);
+  const loadHistory = (0, import_react9.useCallback)(
+    async (conversationId) => {
+      try {
+        return await client.getMessages(conversationId);
+      } catch (error) {
+        if (isUnusableConversation(error) && peekId() === conversationId) {
+          removeStoredConversationId(endpoint, userId);
+        }
+        return [];
+      }
+    },
+    [client, endpoint, userId, peekId]
+  );
+  const loadUsage = (0, import_react9.useCallback)(
+    async (conversationId) => {
+      try {
+        return await client.getUsage(conversationId);
+      } catch {
+        return null;
+      }
+    },
+    [client]
+  );
   const listThreads = (0, import_react9.useCallback)(() => client.listConversations().catch(() => []), [client]);
   const switchTo = (0, import_react9.useCallback)(
     (conversationId) => setStoredConversationId(endpoint, userId, conversationId),
@@ -53154,28 +53160,37 @@ function AgentChatApp({
   titleId
 }) {
   const inline = config.mode === "inline";
-  const conversation = useConversation(client, config.endpoint, userId);
   const [open, setOpen] = (0, import_react10.useState)(inline);
   const [loaded, setLoaded] = (0, import_react10.useState)(false);
   const [sending, setSending] = (0, import_react10.useState)(false);
   const [entriesById, setEntriesById] = (0, import_react10.useState)({});
+  const [usageById, setUsageById] = (0, import_react10.useState)({});
   const [activeId, setActiveId] = (0, import_react10.useState)("");
   const entries = entriesById[activeId] ?? [];
-  const [usage, setUsage] = (0, import_react10.useState)(null);
+  const usage = usageById[activeId] ?? null;
   const [threads, setThreads] = (0, import_react10.useState)([]);
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
   const launcherRef = (0, import_react10.useRef)(null);
   const inputRef = (0, import_react10.useRef)(null);
-  const refreshUsage = (0, import_react10.useCallback)(async () => {
-    setUsage(await conversation.loadUsage());
-  }, [conversation]);
+  const onReplaced = (0, import_react10.useCallback)((staleId, freshId) => {
+    setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
+    setActiveId((current) => current === staleId ? freshId : current);
+  }, []);
+  const conversation = useConversation(client, config.endpoint, userId, onReplaced);
+  const refreshUsage = (0, import_react10.useCallback)(
+    async (cid) => {
+      const next2 = await conversation.loadUsage(cid);
+      setUsageById((prev) => ({ ...prev, [cid]: next2 }));
+    },
+    [conversation]
+  );
   const putEntries = (0, import_react10.useCallback)(
     (cid, update) => setEntriesById((prev) => ({ ...prev, [cid]: update(prev[cid] ?? []) })),
     []
   );
   const loadThread = (0, import_react10.useCallback)(
     async (cid) => {
-      const history = await conversation.loadHistory();
+      const history = await conversation.loadHistory(cid);
       putEntries(cid, () => history.map(toEntry));
     },
     [conversation, putEntries]
@@ -53187,7 +53202,7 @@ function AgentChatApp({
     if (!cid) return;
     setActiveId(cid);
     await loadThread(cid);
-    await refreshUsage();
+    await refreshUsage(cid);
   }, [conversation, loaded, loadThread, refreshUsage]);
   (0, import_react10.useEffect)(() => {
     if (inline) void loadHistory();
@@ -53215,7 +53230,7 @@ function AgentChatApp({
       setThreadsOpen(false);
       setActiveId(conversationId);
       if (!(conversationId in entriesById)) await loadThread(conversationId);
-      await refreshUsage();
+      await refreshUsage(conversationId);
       inputRef.current?.focus({ preventScroll: true });
     },
     [conversation, entriesById, loadThread, refreshUsage]
@@ -53224,7 +53239,6 @@ function AgentChatApp({
     conversation.startNew();
     setThreadsOpen(false);
     setActiveId("");
-    setUsage(null);
     inputRef.current?.focus({ preventScroll: true });
   }, [conversation]);
   const replaceEntry = (0, import_react10.useCallback)(
@@ -53234,7 +53248,7 @@ function AgentChatApp({
   const sendWithoutStreaming = (0, import_react10.useCallback)(
     async (cid, text10, entryId) => {
       try {
-        const answer = await conversation.send(text10);
+        const answer = await conversation.send(cid, text10);
         replaceEntry(cid, entryId, {
           id: entryId,
           role: "ai",
@@ -53258,7 +53272,7 @@ function AgentChatApp({
       setSending(true);
       try {
         let entry = pending;
-        for await (const event of conversation.stream(text10)) {
+        for await (const event of conversation.stream(cid, text10)) {
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
         }
@@ -53268,7 +53282,7 @@ function AgentChatApp({
         await sendWithoutStreaming(cid, text10, pending.id);
       } finally {
         setSending(false);
-        void refreshUsage();
+        void refreshUsage(cid);
       }
     },
     [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming]

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53050,7 +53050,7 @@ function upsertTool(tools, next2) {
 // src/agent_manager/api/static/widget/react/useConversation.ts
 var import_react9 = __toESM(require_react(), 1);
 var isUnusableConversation = (error) => error instanceof AgentChatHttpError && (error.status === 404 || error.status === 403);
-function useConversation(client, endpoint, userId, onReplaced) {
+function useConversation(client, endpoint, userId) {
   const startConversation = (0, import_react9.useCallback)(async () => {
     const created = await client.createConversation();
     setStoredConversationId(endpoint, userId, created);
@@ -53062,32 +53062,32 @@ function useConversation(client, endpoint, userId, onReplaced) {
     [endpoint, userId, startConversation]
   );
   const replace2 = (0, import_react9.useCallback)(
-    async (staleId) => {
+    async (staleId, onReplaced) => {
       removeStoredConversationId(endpoint, userId);
       const fresh = await startConversation();
       onReplaced?.(staleId, fresh);
       return fresh;
     },
-    [endpoint, userId, startConversation, onReplaced]
+    [endpoint, userId, startConversation]
   );
   const send = (0, import_react9.useCallback)(
-    async (conversationId, text10) => {
+    async (conversationId, text10, onReplaced) => {
       try {
         return await client.sendMessage(conversationId, text10);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await replace2(conversationId), text10);
+        return client.sendMessage(await replace2(conversationId, onReplaced), text10);
       }
     },
     [client, replace2]
   );
   const stream = (0, import_react9.useCallback)(
-    async function* (conversationId, text10) {
+    async function* (conversationId, text10, onReplaced) {
       try {
         yield* client.streamMessage(conversationId, text10);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await replace2(conversationId), text10);
+        yield* client.streamMessage(await replace2(conversationId, onReplaced), text10);
       }
     },
     [client, replace2]
@@ -53172,11 +53172,11 @@ function AgentChatApp({
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
   const launcherRef = (0, import_react10.useRef)(null);
   const inputRef = (0, import_react10.useRef)(null);
-  const onReplaced = (0, import_react10.useCallback)((staleId, freshId) => {
+  const adoptConversation = (0, import_react10.useCallback)((staleId, freshId) => {
     setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
     setActiveId((current) => current === staleId ? freshId : current);
   }, []);
-  const conversation = useConversation(client, config.endpoint, userId, onReplaced);
+  const conversation = useConversation(client, config.endpoint, userId);
   const refreshUsage = (0, import_react10.useCallback)(
     async (cid) => {
       const next2 = await conversation.loadUsage(cid);
@@ -53247,9 +53247,14 @@ function AgentChatApp({
   );
   const sendWithoutStreaming = (0, import_react10.useCallback)(
     async (cid, text10, entryId) => {
+      let target = cid;
+      const retarget = (staleId, freshId) => {
+        target = freshId;
+        adoptConversation(staleId, freshId);
+      };
       try {
-        const answer = await conversation.send(cid, text10);
-        replaceEntry(cid, entryId, {
+        const answer = await conversation.send(cid, text10, retarget);
+        replaceEntry(target, entryId, {
           id: entryId,
           role: "ai",
           text: answer.answer,
@@ -53258,10 +53263,11 @@ function AgentChatApp({
         });
         onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
       } catch {
-        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
+        replaceEntry(target, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
       }
+      return target;
     },
-    [conversation, onAnswer, replaceEntry]
+    [adoptConversation, conversation, onAnswer, replaceEntry]
   );
   const submit = (0, import_react10.useCallback)(
     async (text10) => {
@@ -53270,22 +53276,35 @@ function AgentChatApp({
       const pending = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
       setSending(true);
+      let target = cid;
+      const retarget = (staleId, freshId) => {
+        target = freshId;
+        adoptConversation(staleId, freshId);
+      };
       try {
         let entry = pending;
-        for await (const event of conversation.stream(cid, text10)) {
+        for await (const event of conversation.stream(cid, text10, retarget)) {
           entry = reduceStreamEvent(entry, event);
-          replaceEntry(cid, pending.id, entry);
+          replaceEntry(target, pending.id, entry);
         }
-        replaceEntry(cid, pending.id, { ...entry, typing: false });
+        replaceEntry(target, pending.id, { ...entry, typing: false });
         onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
       } catch {
-        await sendWithoutStreaming(cid, text10, pending.id);
+        target = await sendWithoutStreaming(target, text10, pending.id);
       } finally {
         setSending(false);
-        void refreshUsage(cid);
+        void refreshUsage(target);
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming]
+    [
+      adoptConversation,
+      conversation,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry,
+      sendWithoutStreaming
+    ]
   );
   const toggle = () => void (open ? closeChat() : openChat());
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53012,20 +53012,19 @@ var TOOL_STATUS = {
 function reduceStreamEvent(entry, event) {
   switch (event.type) {
     case "answer_delta":
-      return { ...entry, text: entry.text + (event.content ?? ""), typing: false };
+      return { ...entry, text: entry.text + (event.content ?? "") };
     case "route":
-      return { ...entry, route: event.route ?? entry.route, typing: false };
+      return { ...entry, route: event.route ?? entry.route };
     case "tool_started":
     case "tool_succeeded":
     case "tool_failed":
-      return { ...entry, tools: upsertTool(entry.tools ?? [], toToolRecord(event)), typing: false };
+      return { ...entry, tools: upsertTool(entry.tools ?? [], toToolRecord(event)) };
     case "final":
       return {
         ...entry,
         text: event.content ?? entry.text,
         route: event.route ?? entry.route,
-        tools: event.used_tools ?? entry.tools,
-        typing: false
+        tools: event.used_tools ?? entry.tools
       };
     case "error":
       throw new Error(event.error || "stream failed");
@@ -53057,6 +53056,10 @@ function useConversation(client, endpoint, userId) {
     setStoredConversationId(endpoint, userId, created);
     return created;
   }, [client, endpoint, userId]);
+  const peekId = (0, import_react9.useCallback)(
+    () => getStoredConversationId(endpoint, userId),
+    [endpoint, userId]
+  );
   const ensureId = (0, import_react9.useCallback)(
     async () => getStoredConversationId(endpoint, userId) ?? startConversation(),
     [endpoint, userId, startConversation]
@@ -53116,8 +53119,18 @@ function useConversation(client, endpoint, userId) {
     [endpoint, userId]
   );
   return (0, import_react9.useMemo)(
-    () => ({ send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew }),
-    [send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew]
+    () => ({
+      peekId,
+      ensureId,
+      send,
+      stream,
+      loadHistory,
+      loadUsage,
+      listThreads,
+      switchTo,
+      startNew
+    }),
+    [peekId, ensureId, send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew]
   );
 }
 
@@ -53145,7 +53158,9 @@ function AgentChatApp({
   const [open, setOpen] = (0, import_react10.useState)(inline);
   const [loaded, setLoaded] = (0, import_react10.useState)(false);
   const [sending, setSending] = (0, import_react10.useState)(false);
-  const [entries, setEntries] = (0, import_react10.useState)([]);
+  const [entriesById, setEntriesById] = (0, import_react10.useState)({});
+  const [activeId, setActiveId] = (0, import_react10.useState)("");
+  const entries = entriesById[activeId] ?? [];
   const [usage, setUsage] = (0, import_react10.useState)(null);
   const [threads, setThreads] = (0, import_react10.useState)([]);
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
@@ -53154,13 +53169,26 @@ function AgentChatApp({
   const refreshUsage = (0, import_react10.useCallback)(async () => {
     setUsage(await conversation.loadUsage());
   }, [conversation]);
+  const putEntries = (0, import_react10.useCallback)(
+    (cid, update) => setEntriesById((prev) => ({ ...prev, [cid]: update(prev[cid] ?? []) })),
+    []
+  );
+  const loadThread = (0, import_react10.useCallback)(
+    async (cid) => {
+      const history = await conversation.loadHistory();
+      putEntries(cid, () => history.map(toEntry));
+    },
+    [conversation, putEntries]
+  );
   const loadHistory = (0, import_react10.useCallback)(async () => {
     if (loaded) return;
     setLoaded(true);
-    const history = await conversation.loadHistory();
-    if (history.length) setEntries(history.map(toEntry));
+    const cid = conversation.peekId();
+    if (!cid) return;
+    setActiveId(cid);
+    await loadThread(cid);
     await refreshUsage();
-  }, [conversation, loaded, refreshUsage]);
+  }, [conversation, loaded, loadThread, refreshUsage]);
   (0, import_react10.useEffect)(() => {
     if (inline) void loadHistory();
   }, [inline, loadHistory]);
@@ -53185,28 +53213,29 @@ function AgentChatApp({
     async (conversationId) => {
       conversation.switchTo(conversationId);
       setThreadsOpen(false);
-      const history = await conversation.loadHistory();
-      setEntries(history.map(toEntry));
+      setActiveId(conversationId);
+      if (!(conversationId in entriesById)) await loadThread(conversationId);
       await refreshUsage();
       inputRef.current?.focus({ preventScroll: true });
     },
-    [conversation, refreshUsage]
+    [conversation, entriesById, loadThread, refreshUsage]
   );
   const startNewThread = (0, import_react10.useCallback)(() => {
     conversation.startNew();
     setThreadsOpen(false);
-    setEntries([]);
+    setActiveId("");
     setUsage(null);
     inputRef.current?.focus({ preventScroll: true });
   }, [conversation]);
-  const replaceEntry = (0, import_react10.useCallback)((id, entry) => {
-    setEntries((prev) => prev.map((current) => current.id === id ? entry : current));
-  }, []);
+  const replaceEntry = (0, import_react10.useCallback)(
+    (cid, id, entry) => putEntries(cid, (prev) => prev.map((current) => current.id === id ? entry : current)),
+    [putEntries]
+  );
   const sendWithoutStreaming = (0, import_react10.useCallback)(
-    async (text10, entryId) => {
+    async (cid, text10, entryId) => {
       try {
         const answer = await conversation.send(text10);
-        replaceEntry(entryId, {
+        replaceEntry(cid, entryId, {
           id: entryId,
           role: "ai",
           text: answer.answer,
@@ -53215,32 +53244,34 @@ function AgentChatApp({
         });
         onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
       } catch {
-        replaceEntry(entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
+        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
       }
     },
     [conversation, onAnswer, replaceEntry]
   );
   const submit = (0, import_react10.useCallback)(
     async (text10) => {
+      const cid = await conversation.ensureId();
+      setActiveId(cid);
       const pending = { id: newId(), role: "ai", text: "", typing: true };
-      setEntries((prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
+      putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
       setSending(true);
       try {
         let entry = pending;
         for await (const event of conversation.stream(text10)) {
           entry = reduceStreamEvent(entry, event);
-          replaceEntry(pending.id, entry);
+          replaceEntry(cid, pending.id, entry);
         }
-        replaceEntry(pending.id, { ...entry, typing: false });
+        replaceEntry(cid, pending.id, { ...entry, typing: false });
         onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
       } catch {
-        await sendWithoutStreaming(text10, pending.id);
+        await sendWithoutStreaming(cid, text10, pending.id);
       } finally {
         setSending(false);
         void refreshUsage();
       }
     },
-    [conversation, onAnswer, refreshUsage, replaceEntry, sendWithoutStreaming]
+    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming]
   );
   const toggle = () => void (open ? closeChat() : openChat());
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(
@@ -53366,19 +53397,26 @@ function Launcher({
 }
 function ChatMessage({ entry }) {
   const from = entry.role === "user" ? "user" : "assistant";
-  if (entry.typing) {
-    return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from, typing: true, children: "..." });
-  }
   if (entry.error) {
     return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from, children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "msg-error", role: "alert", children: entry.text }) });
   }
   if (entry.role === "user") {
     return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from: "user", children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: entry.text }) });
   }
-  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Message, { from: "assistant", children: [
+  const thinking = Boolean(entry.typing) && !entry.text.trim();
+  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Message, { from: "assistant", typing: thinking, children: [
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(AgentActivity, { route: entry.route, tools: entry.tools }),
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageResponse, { children: entry.text }) }),
-    entry.text.trim() ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageActions, { text: entry.text }) : null
+    thinking ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(ThinkingDots, {}) : /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(import_jsx_runtime4.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageResponse, { children: entry.text }) }),
+      entry.text.trim() ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageActions, { text: entry.text }) : null
+    ] })
+  ] });
+}
+function ThinkingDots() {
+  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("span", { className: "thinking", "aria-hidden": true, children: [
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "thinking-dot" }),
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "thinking-dot" }),
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "thinking-dot" })
   ] });
 }
 function MessageActions({ text: text10 }) {
@@ -53669,6 +53707,15 @@ function styles(config) {
       color: #b91c1c; border-radius: 8px; padding: 10px 12px; font-size: 13.5px;
       line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2;
       -webkit-box-orient: vertical; overflow: hidden; }
+    .thinking { display: inline-flex; gap: 4px; color: #a1a1aa; }
+    .thinking-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor;
+      animation: aui-dot 1.4s ease-in-out infinite; }
+    .thinking-dot:nth-child(2) { animation-delay: .2s; }
+    .thinking-dot:nth-child(3) { animation-delay: .4s; }
+    @keyframes aui-dot {
+      0%, 100% { transform: scale(.8); opacity: .5; }
+      50% { transform: scale(1.2); opacity: 1; }
+    }
     .composer { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 8px;
       padding: 12px 14px; border-top: 1px solid #f0f0f1; }
     .input-wrap { min-width: 0; display: flex; border-radius: 20px; background: #fff;
@@ -53738,6 +53785,7 @@ function styles(config) {
       .msg-action svg { animation: none; }
       .budget-ring-value, .budget-bar-fill, .budget-popover { transition: none; }
       .thread-drawer { transition: none; }
+      .thinking-dot { animation: none; }
     }
     @media (max-width: 480px) {
       .panel:not(.inline) { width: 100vw; height: 100dvh; max-height: 100dvh;

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -84,12 +84,12 @@ export function AgentChatApp({
 
   // A vanished conversation is replaced mid-turn; carry its messages onto the
   // id the turn actually ran under so the view does not go blank.
-  const onReplaced = useCallback((staleId: string, freshId: string) => {
+  const adoptConversation = useCallback((staleId: string, freshId: string) => {
     setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
     setActiveId((current) => (current === staleId ? freshId : current));
   }, []);
 
-  const conversation = useConversation(client, config.endpoint, userId, onReplaced);
+  const conversation = useConversation(client, config.endpoint, userId);
 
   const refreshUsage = useCallback(
     async (cid: string) => {
@@ -174,11 +174,18 @@ export function AgentChatApp({
     [putEntries],
   );
 
+  /** Runs the turn without streaming and returns the conversation it landed in,
+   *  which is not `cid` if the conversation had to be replaced. */
   const sendWithoutStreaming = useCallback(
-    async (cid: string, text: string, entryId: string) => {
+    async (cid: string, text: string, entryId: string): Promise<string> => {
+      let target = cid;
+      const retarget = (staleId: string, freshId: string) => {
+        target = freshId;
+        adoptConversation(staleId, freshId);
+      };
       try {
-        const answer = await conversation.send(cid, text);
-        replaceEntry(cid, entryId, {
+        const answer = await conversation.send(cid, text, retarget);
+        replaceEntry(target, entryId, {
           id: entryId,
           role: "ai",
           text: answer.answer,
@@ -187,10 +194,11 @@ export function AgentChatApp({
         });
         onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
       } catch {
-        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
+        replaceEntry(target, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
       }
+      return target;
     },
-    [conversation, onAnswer, replaceEntry],
+    [adoptConversation, conversation, onAnswer, replaceEntry],
   );
 
   const submit = useCallback(
@@ -200,22 +208,38 @@ export function AgentChatApp({
       const pending: MessageEntry = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text }, pending]);
       setSending(true);
+      // Where this turn's output belongs. A recovered turn moves to a new
+      // conversation mid-flight, and everything after that point — streamed
+      // content, the fallback answer, the usage refresh — has to follow it.
+      let target = cid;
+      const retarget = (staleId: string, freshId: string) => {
+        target = freshId;
+        adoptConversation(staleId, freshId);
+      };
       try {
         let entry = pending;
-        for await (const event of conversation.stream(cid, text)) {
+        for await (const event of conversation.stream(cid, text, retarget)) {
           entry = reduceStreamEvent(entry, event);
-          replaceEntry(cid, pending.id, entry);
+          replaceEntry(target, pending.id, entry);
         }
-        replaceEntry(cid, pending.id, { ...entry, typing: false });
+        replaceEntry(target, pending.id, { ...entry, typing: false });
         onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
       } catch {
-        await sendWithoutStreaming(cid, text, pending.id);
+        target = await sendWithoutStreaming(target, text, pending.id);
       } finally {
         setSending(false);
-        void refreshUsage(cid);
+        void refreshUsage(target);
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming],
+    [
+      adoptConversation,
+      conversation,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry,
+      sendWithoutStreaming,
+    ],
   );
 
   const toggle = () => void (open ? closeChat() : openChat());

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -69,22 +69,35 @@ export function AgentChatApp({
   titleId,
 }: AgentChatAppProps) {
   const inline = config.mode === "inline";
-  const conversation = useConversation(client, config.endpoint, userId);
   const [open, setOpen] = useState(inline);
   const [loaded, setLoaded] = useState(false);
   const [sending, setSending] = useState(false);
   const [entriesById, setEntriesById] = useState<Record<string, MessageEntry[]>>({});
+  const [usageById, setUsageById] = useState<Record<string, TokenBudget | null>>({});
   const [activeId, setActiveId] = useState("");
   const entries = entriesById[activeId] ?? [];
-  const [usage, setUsage] = useState<TokenBudget | null>(null);
+  const usage = usageById[activeId] ?? null;
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [threadsOpen, setThreadsOpen] = useState(false);
   const launcherRef = useRef<HTMLButtonElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const refreshUsage = useCallback(async () => {
-    setUsage(await conversation.loadUsage());
-  }, [conversation]);
+  // A vanished conversation is replaced mid-turn; carry its messages onto the
+  // id the turn actually ran under so the view does not go blank.
+  const onReplaced = useCallback((staleId: string, freshId: string) => {
+    setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
+    setActiveId((current) => (current === staleId ? freshId : current));
+  }, []);
+
+  const conversation = useConversation(client, config.endpoint, userId, onReplaced);
+
+  const refreshUsage = useCallback(
+    async (cid: string) => {
+      const next = await conversation.loadUsage(cid);
+      setUsageById((prev) => ({ ...prev, [cid]: next }));
+    },
+    [conversation],
+  );
 
   const putEntries = useCallback(
     (cid: string, update: (prev: MessageEntry[]) => MessageEntry[]) =>
@@ -94,7 +107,7 @@ export function AgentChatApp({
 
   const loadThread = useCallback(
     async (cid: string) => {
-      const history = await conversation.loadHistory();
+      const history = await conversation.loadHistory(cid);
       putEntries(cid, () => history.map(toEntry));
     },
     [conversation, putEntries],
@@ -107,7 +120,7 @@ export function AgentChatApp({
     if (!cid) return;
     setActiveId(cid);
     await loadThread(cid);
-    await refreshUsage();
+    await refreshUsage(cid);
   }, [conversation, loaded, loadThread, refreshUsage]);
 
   useEffect(() => {
@@ -142,7 +155,7 @@ export function AgentChatApp({
       setActiveId(conversationId);
       // ponytail: in-session map owns in-flight streams, so only cold-load a thread we haven't opened yet.
       if (!(conversationId in entriesById)) await loadThread(conversationId);
-      await refreshUsage();
+      await refreshUsage(conversationId);
       inputRef.current?.focus({ preventScroll: true });
     },
     [conversation, entriesById, loadThread, refreshUsage],
@@ -152,7 +165,6 @@ export function AgentChatApp({
     conversation.startNew();
     setThreadsOpen(false);
     setActiveId("");
-    setUsage(null);
     inputRef.current?.focus({ preventScroll: true });
   }, [conversation]);
 
@@ -165,7 +177,7 @@ export function AgentChatApp({
   const sendWithoutStreaming = useCallback(
     async (cid: string, text: string, entryId: string) => {
       try {
-        const answer = await conversation.send(text);
+        const answer = await conversation.send(cid, text);
         replaceEntry(cid, entryId, {
           id: entryId,
           role: "ai",
@@ -190,7 +202,7 @@ export function AgentChatApp({
       setSending(true);
       try {
         let entry = pending;
-        for await (const event of conversation.stream(text)) {
+        for await (const event of conversation.stream(cid, text)) {
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
         }
@@ -200,7 +212,7 @@ export function AgentChatApp({
         await sendWithoutStreaming(cid, text, pending.id);
       } finally {
         setSending(false);
-        void refreshUsage();
+        void refreshUsage(cid);
       }
     },
     [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming],

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -73,7 +73,9 @@ export function AgentChatApp({
   const [open, setOpen] = useState(inline);
   const [loaded, setLoaded] = useState(false);
   const [sending, setSending] = useState(false);
-  const [entries, setEntries] = useState<MessageEntry[]>([]);
+  const [entriesById, setEntriesById] = useState<Record<string, MessageEntry[]>>({});
+  const [activeId, setActiveId] = useState("");
+  const entries = entriesById[activeId] ?? [];
   const [usage, setUsage] = useState<TokenBudget | null>(null);
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [threadsOpen, setThreadsOpen] = useState(false);
@@ -84,13 +86,29 @@ export function AgentChatApp({
     setUsage(await conversation.loadUsage());
   }, [conversation]);
 
+  const putEntries = useCallback(
+    (cid: string, update: (prev: MessageEntry[]) => MessageEntry[]) =>
+      setEntriesById((prev) => ({ ...prev, [cid]: update(prev[cid] ?? []) })),
+    [],
+  );
+
+  const loadThread = useCallback(
+    async (cid: string) => {
+      const history = await conversation.loadHistory();
+      putEntries(cid, () => history.map(toEntry));
+    },
+    [conversation, putEntries],
+  );
+
   const loadHistory = useCallback(async () => {
     if (loaded) return;
     setLoaded(true);
-    const history = await conversation.loadHistory();
-    if (history.length) setEntries(history.map(toEntry));
+    const cid = conversation.peekId();
+    if (!cid) return;
+    setActiveId(cid);
+    await loadThread(cid);
     await refreshUsage();
-  }, [conversation, loaded, refreshUsage]);
+  }, [conversation, loaded, loadThread, refreshUsage]);
 
   useEffect(() => {
     if (inline) void loadHistory();
@@ -121,31 +139,34 @@ export function AgentChatApp({
     async (conversationId: string) => {
       conversation.switchTo(conversationId);
       setThreadsOpen(false);
-      const history = await conversation.loadHistory();
-      setEntries(history.map(toEntry));
+      setActiveId(conversationId);
+      // ponytail: in-session map owns in-flight streams, so only cold-load a thread we haven't opened yet.
+      if (!(conversationId in entriesById)) await loadThread(conversationId);
       await refreshUsage();
       inputRef.current?.focus({ preventScroll: true });
     },
-    [conversation, refreshUsage],
+    [conversation, entriesById, loadThread, refreshUsage],
   );
 
   const startNewThread = useCallback(() => {
     conversation.startNew();
     setThreadsOpen(false);
-    setEntries([]);
+    setActiveId("");
     setUsage(null);
     inputRef.current?.focus({ preventScroll: true });
   }, [conversation]);
 
-  const replaceEntry = useCallback((id: string, entry: MessageEntry) => {
-    setEntries((prev) => prev.map((current) => (current.id === id ? entry : current)));
-  }, []);
+  const replaceEntry = useCallback(
+    (cid: string, id: string, entry: MessageEntry) =>
+      putEntries(cid, (prev) => prev.map((current) => (current.id === id ? entry : current))),
+    [putEntries],
+  );
 
   const sendWithoutStreaming = useCallback(
-    async (text: string, entryId: string) => {
+    async (cid: string, text: string, entryId: string) => {
       try {
         const answer = await conversation.send(text);
-        replaceEntry(entryId, {
+        replaceEntry(cid, entryId, {
           id: entryId,
           role: "ai",
           text: answer.answer,
@@ -154,7 +175,7 @@ export function AgentChatApp({
         });
         onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
       } catch {
-        replaceEntry(entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
+        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: GENERIC_ERROR, error: true });
       }
     },
     [conversation, onAnswer, replaceEntry],
@@ -162,25 +183,27 @@ export function AgentChatApp({
 
   const submit = useCallback(
     async (text: string) => {
+      const cid = await conversation.ensureId();
+      setActiveId(cid);
       const pending: MessageEntry = { id: newId(), role: "ai", text: "", typing: true };
-      setEntries((prev) => [...prev, { id: newId(), role: "user", text }, pending]);
+      putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text }, pending]);
       setSending(true);
       try {
         let entry = pending;
         for await (const event of conversation.stream(text)) {
           entry = reduceStreamEvent(entry, event);
-          replaceEntry(pending.id, entry);
+          replaceEntry(cid, pending.id, entry);
         }
-        replaceEntry(pending.id, { ...entry, typing: false });
+        replaceEntry(cid, pending.id, { ...entry, typing: false });
         onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
       } catch {
-        await sendWithoutStreaming(text, pending.id);
+        await sendWithoutStreaming(cid, text, pending.id);
       } finally {
         setSending(false);
         void refreshUsage();
       }
     },
-    [conversation, onAnswer, refreshUsage, replaceEntry, sendWithoutStreaming],
+    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming],
   );
 
   const toggle = () => void (open ? closeChat() : openChat());
@@ -314,14 +337,6 @@ function Launcher({
 function ChatMessage({ entry }: { entry: MessageEntry }) {
   const from = entry.role === "user" ? "user" : "assistant";
 
-  if (entry.typing) {
-    return (
-      <Message from={from} typing>
-        ...
-      </Message>
-    );
-  }
-
   if (entry.error) {
     return (
       <Message from={from}>
@@ -340,14 +355,32 @@ function ChatMessage({ entry }: { entry: MessageEntry }) {
     );
   }
 
+  const thinking = Boolean(entry.typing) && !entry.text.trim();
+
   return (
-    <Message from="assistant">
+    <Message from="assistant" typing={thinking}>
       <AgentActivity route={entry.route} tools={entry.tools} />
-      <MessageContent>
-        <MessageResponse>{entry.text}</MessageResponse>
-      </MessageContent>
-      {entry.text.trim() ? <MessageActions text={entry.text} /> : null}
+      {thinking ? (
+        <ThinkingDots />
+      ) : (
+        <>
+          <MessageContent>
+            <MessageResponse>{entry.text}</MessageResponse>
+          </MessageContent>
+          {entry.text.trim() ? <MessageActions text={entry.text} /> : null}
+        </>
+      )}
     </Message>
+  );
+}
+
+function ThinkingDots() {
+  return (
+    <span className="thinking" aria-hidden>
+      <span className="thinking-dot" />
+      <span className="thinking-dot" />
+      <span className="thinking-dot" />
+    </span>
   );
 }
 

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -10,7 +10,6 @@ import {
 import { type Ref, useCallback, useEffect, useRef, useState } from "react";
 
 import type { AgentChatClient } from "../api/AgentChatClient";
-import { getStoredConversationId } from "../storage/conversationStorage";
 import type {
   AgentChatAnswerDetail,
   AgentChatConfig,
@@ -82,14 +81,31 @@ export function AgentChatApp({
   const launcherRef = useRef<HTMLButtonElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // A vanished conversation is replaced mid-turn; carry its messages onto the
-  // id the turn actually ran under so the view does not go blank.
-  const adoptConversation = useCallback((staleId: string, freshId: string) => {
-    setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
-    setActiveId((current) => (current === staleId ? freshId : current));
+  // Recovery runs from async turn code that can outlive the view it started
+  // in, so it needs the thread on screen *now*, not the one captured when the
+  // turn began. Kept in step with `activeId` by `selectThread`.
+  const activeIdRef = useRef(activeId);
+  const selectThread = useCallback((conversationId: string) => {
+    activeIdRef.current = conversationId;
+    setActiveId(conversationId);
   }, []);
 
   const conversation = useConversation(client, config.endpoint, userId);
+
+  // A vanished conversation is replaced mid-turn; carry its messages onto the
+  // id the turn actually ran under so the view does not go blank.
+  const adoptConversation = useCallback(
+    (staleId: string, freshId: string) => {
+      setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
+      // Only the thread the user is looking at may move the selection. A turn
+      // recovered in the background must not drag storage — and so the next
+      // message — onto a conversation the user never opened.
+      if (activeIdRef.current !== staleId) return;
+      selectThread(freshId);
+      conversation.switchTo(freshId);
+    },
+    [conversation, selectThread],
+  );
 
   const refreshUsage = useCallback(
     async (cid: string) => {
@@ -118,10 +134,10 @@ export function AgentChatApp({
     setLoaded(true);
     const cid = conversation.peekId();
     if (!cid) return;
-    setActiveId(cid);
+    selectThread(cid);
     await loadThread(cid);
     await refreshUsage(cid);
-  }, [conversation, loaded, loadThread, refreshUsage]);
+  }, [conversation, loaded, loadThread, refreshUsage, selectThread]);
 
   useEffect(() => {
     if (inline) void loadHistory();
@@ -152,21 +168,21 @@ export function AgentChatApp({
     async (conversationId: string) => {
       conversation.switchTo(conversationId);
       setThreadsOpen(false);
-      setActiveId(conversationId);
+      selectThread(conversationId);
       // ponytail: in-session map owns in-flight streams, so only cold-load a thread we haven't opened yet.
       if (!(conversationId in entriesById)) await loadThread(conversationId);
       await refreshUsage(conversationId);
       inputRef.current?.focus({ preventScroll: true });
     },
-    [conversation, entriesById, loadThread, refreshUsage],
+    [conversation, entriesById, loadThread, refreshUsage, selectThread],
   );
 
   const startNewThread = useCallback(() => {
     conversation.startNew();
     setThreadsOpen(false);
-    setActiveId("");
+    selectThread("");
     inputRef.current?.focus({ preventScroll: true });
-  }, [conversation]);
+  }, [conversation, selectThread]);
 
   const replaceEntry = useCallback(
     (cid: string, id: string, entry: MessageEntry) =>
@@ -203,8 +219,10 @@ export function AgentChatApp({
 
   const submit = useCallback(
     async (text: string) => {
-      const cid = await conversation.ensureId();
-      setActiveId(cid);
+      // The thread on screen wins; storage is consulted only before anything
+      // has been selected, since a background recovery may have moved it.
+      const cid = activeIdRef.current || (await conversation.ensureId());
+      selectThread(cid);
       const pending: MessageEntry = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text }, pending]);
       setSending(true);
@@ -238,6 +256,7 @@ export function AgentChatApp({
       putEntries,
       refreshUsage,
       replaceEntry,
+      selectThread,
       sendWithoutStreaming,
     ],
   );
@@ -299,7 +318,7 @@ export function AgentChatApp({
           <ThreadDrawer
             open={threadsOpen}
             threads={threads}
-            activeId={getStoredConversationId(config.endpoint, userId)}
+            activeId={activeId}
             onSelect={openThread}
             onNew={startNewThread}
             onClose={() => setThreadsOpen(false)}

--- a/src/agent_manager/api/static/widget/react/streamReducer.ts
+++ b/src/agent_manager/api/static/widget/react/streamReducer.ts
@@ -9,20 +9,19 @@ const TOOL_STATUS: Record<string, string> = {
 export function reduceStreamEvent(entry: MessageEntry, event: StreamEvent): MessageEntry {
   switch (event.type) {
     case "answer_delta":
-      return { ...entry, text: entry.text + (event.content ?? ""), typing: false };
+      return { ...entry, text: entry.text + (event.content ?? "") };
     case "route":
-      return { ...entry, route: event.route ?? entry.route, typing: false };
+      return { ...entry, route: event.route ?? entry.route };
     case "tool_started":
     case "tool_succeeded":
     case "tool_failed":
-      return { ...entry, tools: upsertTool(entry.tools ?? [], toToolRecord(event)), typing: false };
+      return { ...entry, tools: upsertTool(entry.tools ?? [], toToolRecord(event)) };
     case "final":
       return {
         ...entry,
         text: event.content ?? entry.text,
         route: event.route ?? entry.route,
         tools: event.used_tools ?? entry.tools,
-        typing: false,
       };
     case "error":
       throw new Error(event.error || "stream failed");

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -23,8 +23,12 @@ import type {
 export interface Conversation {
   peekId(): string | null;
   ensureId(): Promise<string>;
-  send(conversationId: string, text: string): Promise<SendMessageResponse>;
-  stream(conversationId: string, text: string): AsyncGenerator<StreamEvent>;
+  send(
+    conversationId: string,
+    text: string,
+    onReplaced?: Retarget,
+  ): Promise<SendMessageResponse>;
+  stream(conversationId: string, text: string, onReplaced?: Retarget): AsyncGenerator<StreamEvent>;
   loadHistory(conversationId: string): Promise<ChatMessage[]>;
   loadUsage(conversationId: string): Promise<TokenBudget | null>;
   listThreads(): Promise<ThreadSummary[]>;
@@ -39,13 +43,15 @@ export interface Conversation {
 const isUnusableConversation = (error: unknown): boolean =>
   error instanceof AgentChatHttpError && (error.status === 404 || error.status === 403);
 
+/** Reports where a turn actually landed after its conversation vanished. The
+ *  caller must write the rest of the turn to `freshId`, not the id it started
+ *  with, or the answer is stored under a conversation that no longer exists. */
+export type Retarget = (staleId: string, freshId: string) => void;
+
 export function useConversation(
   client: AgentChatClient,
   endpoint: string,
   userId: string,
-  /** Told when a vanished conversation is replaced, so the caller can move that
-   *  thread's messages onto the id the turn actually ran under. */
-  onReplaced?: (staleId: string, freshId: string) => void,
 ): Conversation {
   const startConversation = useCallback(async () => {
     const created = await client.createConversation();
@@ -61,34 +67,38 @@ export function useConversation(
   );
 
   const replace = useCallback(
-    async (staleId: string) => {
+    async (staleId: string, onReplaced?: Retarget) => {
       removeStoredConversationId(endpoint, userId);
       const fresh = await startConversation();
       onReplaced?.(staleId, fresh);
       return fresh;
     },
-    [endpoint, userId, startConversation, onReplaced],
+    [endpoint, userId, startConversation],
   );
 
   const send = useCallback(
-    async (conversationId: string, text: string) => {
+    async (conversationId: string, text: string, onReplaced?: Retarget) => {
       try {
         return await client.sendMessage(conversationId, text);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await replace(conversationId), text);
+        return client.sendMessage(await replace(conversationId, onReplaced), text);
       }
     },
     [client, replace],
   );
 
   const stream = useCallback(
-    async function* (conversationId: string, text: string): AsyncGenerator<StreamEvent> {
+    async function* (
+      conversationId: string,
+      text: string,
+      onReplaced?: Retarget,
+    ): AsyncGenerator<StreamEvent> {
       try {
         yield* client.streamMessage(conversationId, text);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await replace(conversationId), text);
+        yield* client.streamMessage(await replace(conversationId, onReplaced), text);
       }
     },
     [client, replace],

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -15,6 +15,8 @@ import type {
 } from "../types";
 
 export interface Conversation {
+  peekId(): string | null;
+  ensureId(): Promise<string>;
   send(text: string): Promise<SendMessageResponse>;
   stream(text: string): AsyncGenerator<StreamEvent>;
   loadHistory(): Promise<ChatMessage[]>;
@@ -41,6 +43,11 @@ export function useConversation(
     setStoredConversationId(endpoint, userId, created);
     return created;
   }, [client, endpoint, userId]);
+
+  const peekId = useCallback(
+    () => getStoredConversationId(endpoint, userId),
+    [endpoint, userId],
+  );
 
   const ensureId = useCallback(
     async () => getStoredConversationId(endpoint, userId) ?? startConversation(),
@@ -110,7 +117,17 @@ export function useConversation(
   );
 
   return useMemo(
-    () => ({ send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew }),
-    [send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew],
+    () => ({
+      peekId,
+      ensureId,
+      send,
+      stream,
+      loadHistory,
+      loadUsage,
+      listThreads,
+      switchTo,
+      startNew,
+    }),
+    [peekId, ensureId, send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew],
   );
 }

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -14,13 +14,19 @@ import type {
   ThreadSummary,
 } from "../types";
 
+/** Every request names the conversation it belongs to.
+ *
+ * Storage only remembers which thread was selected last; it never decides where
+ * an in-flight request lands. Switching threads mid-request would otherwise
+ * redirect a reply that started in A into B.
+ */
 export interface Conversation {
   peekId(): string | null;
   ensureId(): Promise<string>;
-  send(text: string): Promise<SendMessageResponse>;
-  stream(text: string): AsyncGenerator<StreamEvent>;
-  loadHistory(): Promise<ChatMessage[]>;
-  loadUsage(): Promise<TokenBudget | null>;
+  send(conversationId: string, text: string): Promise<SendMessageResponse>;
+  stream(conversationId: string, text: string): AsyncGenerator<StreamEvent>;
+  loadHistory(conversationId: string): Promise<ChatMessage[]>;
+  loadUsage(conversationId: string): Promise<TokenBudget | null>;
   listThreads(): Promise<ThreadSummary[]>;
   switchTo(conversationId: string): void;
   startNew(): void;
@@ -37,6 +43,9 @@ export function useConversation(
   client: AgentChatClient,
   endpoint: string,
   userId: string,
+  /** Told when a vanished conversation is replaced, so the caller can move that
+   *  thread's messages onto the id the turn actually ran under. */
+  onReplaced?: (staleId: string, freshId: string) => void,
 ): Conversation {
   const startConversation = useCallback(async () => {
     const created = await client.createConversation();
@@ -44,65 +53,71 @@ export function useConversation(
     return created;
   }, [client, endpoint, userId]);
 
-  const peekId = useCallback(
-    () => getStoredConversationId(endpoint, userId),
-    [endpoint, userId],
-  );
+  const peekId = useCallback(() => getStoredConversationId(endpoint, userId), [endpoint, userId]);
 
   const ensureId = useCallback(
     async () => getStoredConversationId(endpoint, userId) ?? startConversation(),
     [endpoint, userId, startConversation],
   );
 
-  const restartId = useCallback(async () => {
-    removeStoredConversationId(endpoint, userId);
-    return startConversation();
-  }, [endpoint, userId, startConversation]);
+  const replace = useCallback(
+    async (staleId: string) => {
+      removeStoredConversationId(endpoint, userId);
+      const fresh = await startConversation();
+      onReplaced?.(staleId, fresh);
+      return fresh;
+    },
+    [endpoint, userId, startConversation, onReplaced],
+  );
 
   const send = useCallback(
-    async (text: string) => {
+    async (conversationId: string, text: string) => {
       try {
-        return await client.sendMessage(await ensureId(), text);
+        return await client.sendMessage(conversationId, text);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await restartId(), text);
+        return client.sendMessage(await replace(conversationId), text);
       }
     },
-    [client, ensureId, restartId],
+    [client, replace],
   );
 
   const stream = useCallback(
-    async function* (text: string): AsyncGenerator<StreamEvent> {
+    async function* (conversationId: string, text: string): AsyncGenerator<StreamEvent> {
       try {
-        yield* client.streamMessage(await ensureId(), text);
+        yield* client.streamMessage(conversationId, text);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await restartId(), text);
+        yield* client.streamMessage(await replace(conversationId), text);
       }
     },
-    [client, ensureId, restartId],
+    [client, replace],
   );
 
-  const loadHistory = useCallback(async () => {
-    const stored = getStoredConversationId(endpoint, userId);
-    if (!stored) return [];
-    try {
-      return await client.getMessages(stored);
-    } catch (error) {
-      if (isUnusableConversation(error)) removeStoredConversationId(endpoint, userId);
-      return [];
-    }
-  }, [client, endpoint, userId]);
+  const loadHistory = useCallback(
+    async (conversationId: string) => {
+      try {
+        return await client.getMessages(conversationId);
+      } catch (error) {
+        if (isUnusableConversation(error) && peekId() === conversationId) {
+          removeStoredConversationId(endpoint, userId);
+        }
+        return [];
+      }
+    },
+    [client, endpoint, userId, peekId],
+  );
 
-  const loadUsage = useCallback(async () => {
-    const stored = getStoredConversationId(endpoint, userId);
-    if (!stored) return null;
-    try {
-      return await client.getUsage(stored);
-    } catch {
-      return null;
-    }
-  }, [client, endpoint, userId]);
+  const loadUsage = useCallback(
+    async (conversationId: string) => {
+      try {
+        return await client.getUsage(conversationId);
+      } catch {
+        return null;
+      }
+    },
+    [client],
+  );
 
   const listThreads = useCallback(() => client.listConversations().catch(() => []), [client]);
 

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -68,12 +68,14 @@ export function useConversation(
 
   const replace = useCallback(
     async (staleId: string, onReplaced?: Retarget) => {
-      removeStoredConversationId(endpoint, userId);
-      const fresh = await startConversation();
+      // Deliberately does not touch storage. Recovery can run for a turn the
+      // user has since navigated away from, and only the caller knows which
+      // thread is on screen — it selects the replacement via `onReplaced`.
+      const fresh = await client.createConversation();
       onReplaced?.(staleId, fresh);
       return fresh;
     },
-    [endpoint, userId, startConversation],
+    [client],
   );
 
   const send = useCallback(

--- a/src/agent_manager/api/static/widget/styles/styles.ts
+++ b/src/agent_manager/api/static/widget/styles/styles.ts
@@ -142,6 +142,15 @@ export function styles(config: AgentChatConfig): string {
       color: #b91c1c; border-radius: 8px; padding: 10px 12px; font-size: 13.5px;
       line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2;
       -webkit-box-orient: vertical; overflow: hidden; }
+    .thinking { display: inline-flex; gap: 4px; color: #a1a1aa; }
+    .thinking-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor;
+      animation: aui-dot 1.4s ease-in-out infinite; }
+    .thinking-dot:nth-child(2) { animation-delay: .2s; }
+    .thinking-dot:nth-child(3) { animation-delay: .4s; }
+    @keyframes aui-dot {
+      0%, 100% { transform: scale(.8); opacity: .5; }
+      50% { transform: scale(1.2); opacity: 1; }
+    }
     .composer { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 8px;
       padding: 12px 14px; border-top: 1px solid #f0f0f1; }
     .input-wrap { min-width: 0; display: flex; border-radius: 20px; background: #fff;
@@ -211,6 +220,7 @@ export function styles(config: AgentChatConfig): string {
       .msg-action svg { animation: none; }
       .budget-ring-value, .budget-bar-fill, .budget-popover { transition: none; }
       .thread-drawer { transition: none; }
+      .thinking-dot { animation: none; }
     }
     @media (max-width: 480px) {
       .panel:not(.inline) { width: 100vw; height: 100dvh; max-height: 100dvh;

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -619,6 +619,64 @@ test("thinking dots persist when switching away from an in-flight thread and bac
   await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
 });
 
+test("a turn stays on its own conversation when the user switches threads mid-request", async ({
+  page,
+}) => {
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const usageCalls: string[] = [];
+
+  const calls = await mockConversationApi(page, {
+    threads: [
+      { conversation_id: "conv-other", title: "Other chat", last_message_at: "2026-06-01T00:00:00Z" },
+      { conversation_id: "conv-smoke", title: "Current chat", last_message_at: "2026-06-28T00:00:00Z" },
+    ],
+  });
+  await page.route("**/conversations/*/usage", async (route: Route) => {
+    usageCalls.push(new URL(route.request().url()).pathname);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ used_tokens: 0, max_tokens: null, percent: 0, severity: "normal" }),
+    });
+  });
+  // Hold the stream open until the user has switched away, then fail it: the
+  // widget retries the turn without streaming, and that retry must still go to
+  // the conversation the turn started in.
+  await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
+    await pending;
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "stream unavailable" }),
+    });
+  });
+  await page.route("**/conversations/conv-other/messages", async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "hello");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(true);
+
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+  await shadowClickText(page, ".thread-item", "Other chat");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
+
+  release();
+
+  await expect.poll(() => calls).toContain("POST /conversations/conv-smoke/messages");
+  expect(calls).not.toContain("POST /conversations/conv-other/messages");
+  await expect
+    .poll(() => usageCalls[usageCalls.length - 1])
+    .toBe("/conversations/conv-smoke/usage");
+});
+
 test("stale stored conversation is replaced before sending to the agent", async ({ page }) => {
   const calls = await mockConversationApiWithStaleConversation(page);
   await pinUser(page);

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -696,6 +696,79 @@ test("stale stored conversation is replaced before sending to the agent", async 
   expect(calls).toContain("POST /conversations/conv-fresh/messages/stream");
 });
 
+test("a turn whose conversation vanishes mid-request follows the replacement", async ({
+  page,
+}) => {
+  const usageCalls: string[] = [];
+  const calls: string[] = [];
+
+  // The conversation survives history loading — so it is still the active id at
+  // submit time — and only vanishes once the turn is under way.
+  await page.route("**/conversations/conv-gone/messages", async (route: Route) => {
+    calls.push(`${route.request().method()} /conversations/conv-gone/messages`);
+    await route.fulfill({
+      status: route.request().method() === "GET" ? 200 : 404,
+      contentType: "application/json",
+      body: route.request().method() === "GET" ? "[]" : JSON.stringify({ detail: "not found" }),
+    });
+  });
+  await page.route("**/conversations/conv-gone/messages/stream", async (route: Route) => {
+    calls.push("POST /conversations/conv-gone/messages/stream");
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "conversation not found" }),
+    });
+  });
+  await page.route("**/conversations/*/usage", async (route: Route) => {
+    usageCalls.push(new URL(route.request().url()).pathname);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ used_tokens: 7, max_tokens: 100, percent: 7, severity: "normal" }),
+    });
+  });
+  await page.route("**/conversations", async (route: Route) => {
+    calls.push(`${route.request().method()} /conversations`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body:
+        route.request().method() === "GET"
+          ? "[]"
+          : JSON.stringify({ conversation_id: "conv-reborn", session_id: "conv-reborn" }),
+    });
+  });
+  await page.route("**/conversations/conv-reborn/messages/stream", async (route: Route) => {
+    calls.push("POST /conversations/conv-reborn/messages/stream");
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: "Recovered answer", route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await pinUser(page);
+  await page.goto("/widget-demo.html");
+  await page.evaluate((key) => localStorage.setItem(key, "conv-gone"), CONVERSATION_KEY);
+
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "are you there");
+  await shadowClick(page, ".send");
+
+  // The answer has to land in the conversation the turn was moved to, not the
+  // one it started in — the view is showing the replacement by now.
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Recovered answer");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
+  expect(calls).toContain("POST /conversations/conv-gone/messages/stream");
+  expect(calls).toContain("POST /conversations/conv-reborn/messages/stream");
+  await expect.poll(() => usageCalls[usageCalls.length - 1]).toBe("/conversations/conv-reborn/usage");
+});
+
 test("script-only auto-mount creates one configured widget", async ({ page }) => {
   await mockConversationApi(page);
   await page.goto("/widget-demo-automount.html");

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -677,6 +677,186 @@ test("a turn stays on its own conversation when the user switches threads mid-re
     .toBe("/conversations/conv-smoke/usage");
 });
 
+test("background recovery for a conversation the user left does not hijack the next submission", async ({
+  page,
+}) => {
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const calls: string[] = [];
+
+  await page.route("**/conversations", async (route: Route) => {
+    calls.push(`${route.request().method()} /conversations`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body:
+        route.request().method() === "GET"
+          ? JSON.stringify([
+              { conversation_id: "conv-other", title: "Other chat", last_message_at: "2026-06-01T00:00:00Z" },
+              { conversation_id: "conv-smoke", title: "Current chat", last_message_at: "2026-06-28T00:00:00Z" },
+            ])
+          : JSON.stringify({ conversation_id: "conv-reborn", session_id: "conv-reborn" }),
+    });
+  });
+  // conv-smoke's in-flight turn is held open until the user has switched to
+  // conv-other, then fails as vanished — recovery must not steal the storage
+  // slot conv-other is now occupying.
+  await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
+    await pending;
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "conversation not found" }),
+    });
+  });
+  // conv-smoke has to survive history loading, or it is cleared from storage
+  // before the turn even starts and the scenario never happens.
+  await page.route("**/conversations/conv-smoke/messages", async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/conversations/conv-other/messages", async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/conversations/conv-other/messages/stream", async (route: Route) => {
+    calls.push("POST /conversations/conv-other/messages/stream");
+    const body = JSON.parse(route.request().postData() || "{}") as { message?: string };
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: `Echo: ${body.message}`, route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await pinUser(page);
+  await page.goto("/widget-demo.html");
+  // Start the turn in conv-smoke, so the recovery below belongs to a thread the
+  // user will have left by the time it fails.
+  await page.evaluate((key) => localStorage.setItem(key, "conv-smoke"), CONVERSATION_KEY);
+
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "hello");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(true);
+
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+  await shadowClickText(page, ".thread-item", "Other chat");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
+
+  // Let conv-smoke's turn fail and recover into conv-reborn while the user is
+  // looking at conv-other.
+  release();
+  await expect.poll(() => calls).toContain("POST /conversations");
+
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
+    .toBe("conv-other");
+
+  await shadowFill(page, ".input", "still here");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Echo: still here");
+  expect(calls).toContain("POST /conversations/conv-other/messages/stream");
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
+    .toBe("conv-other");
+});
+
+test("background recovery does not capture a new chat the user started meanwhile", async ({
+  page,
+}) => {
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const calls: string[] = [];
+  const created: string[] = ["conv-reborn", "conv-brand-new"];
+
+  await page.route("**/conversations", async (route: Route) => {
+    const method = route.request().method();
+    calls.push(`${method} /conversations`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body:
+        method === "GET"
+          ? "[]"
+          : JSON.stringify({
+              conversation_id: created.shift(),
+              session_id: "s",
+            }),
+    });
+  });
+  // The first turn is held open until the user has hit "New chat", then fails
+  // as vanished. Its replacement must not become the selected conversation.
+  await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
+    await pending;
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "conversation not found" }),
+    });
+  });
+  // conv-smoke has to survive history loading, or it is cleared from storage
+  // before the turn even starts and the scenario never happens.
+  await page.route("**/conversations/conv-smoke/messages", async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  for (const id of ["conv-reborn", "conv-brand-new"]) {
+    await page.route(`**/conversations/${id}/messages/stream`, async (route: Route) => {
+      const body = JSON.parse(route.request().postData() || "{}") as { message?: string };
+      calls.push(`POST ${id} :: ${body.message}`);
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: [
+          `event: final\ndata: ${JSON.stringify({ type: "final", content: `${id}: ${body.message}`, route: [], used_tools: [] })}`,
+          "event: done\ndata: [DONE]",
+          "",
+        ].join("\n\n"),
+      });
+    });
+  }
+
+  await pinUser(page);
+  await page.goto("/widget-demo.html");
+  await page.evaluate((key) => localStorage.setItem(key, "conv-smoke"), CONVERSATION_KEY);
+
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "hello");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(true);
+
+  await shadowClick(page, '.header-btn[aria-label="New chat"]');
+  await expect.poll(() => shadowText(page, ".messages")).toContain("How can I help you today?");
+
+  // conv-smoke's turn now fails and recovers into conv-reborn in the
+  // background, while the user is sitting in an unsaved new chat.
+  release();
+  await expect.poll(() => calls).toContain("POST /conversations");
+
+  await shadowFill(page, ".input", "fresh start");
+  await shadowClick(page, ".send");
+
+  // The new chat must get its own conversation, not the recovered one. The
+  // recovered turn legitimately retries "hello" on conv-reborn; what it must
+  // never do is take the next message with it.
+  await expect.poll(() => shadowText(page, ".messages")).toContain("conv-brand-new: fresh start");
+  expect(calls).toContain("POST conv-brand-new :: fresh start");
+  expect(calls).not.toContain("POST conv-reborn :: fresh start");
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
+    .toBe("conv-brand-new");
+});
+
 test("stale stored conversation is replaced before sending to the agent", async ({ page }) => {
   const calls = await mockConversationApiWithStaleConversation(page);
   await pinUser(page);
@@ -767,6 +947,11 @@ test("a turn whose conversation vanishes mid-request follows the replacement", a
   expect(calls).toContain("POST /conversations/conv-gone/messages/stream");
   expect(calls).toContain("POST /conversations/conv-reborn/messages/stream");
   await expect.poll(() => usageCalls[usageCalls.length - 1]).toBe("/conversations/conv-reborn/usage");
+  // Recovery of the thread on screen *does* move the selection — the inverse of
+  // the background case, and the reason that decision is conditional.
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
+    .toBe("conv-reborn");
 });
 
 test("script-only auto-mount creates one configured widget", async ({ page }) => {

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -266,6 +266,17 @@ async function shadowClick(page: Page, selector: string, index = 0) {
   }, selector);
 }
 
+async function shadowClickText(page: Page, selector: string, text: string, index = 0) {
+  const handle = await widget(page, index);
+  await handle.evaluate(
+    (element, { selector, text }) => {
+      const targets = Array.from(element.shadowRoot?.querySelectorAll<HTMLElement>(selector) ?? []);
+      targets.find((node) => node.textContent?.includes(text))?.click();
+    },
+    { selector, text },
+  );
+}
+
 async function shadowFocus(page: Page, selector: string, index = 0) {
   const handle = await widget(page, index);
   await handle.evaluate((element, selector) => {
@@ -555,6 +566,57 @@ test("a stored conversation owned by another caller is replaced, not retried for
     .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
     .toBe("conv-fresh");
   expect(calls).toContain("POST /conversations/conv-fresh/messages/stream");
+});
+
+test("thinking dots persist when switching away from an in-flight thread and back", async ({
+  page,
+}) => {
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await mockConversationApi(page, {
+    threads: [
+      { conversation_id: "conv-other", title: "Other chat", last_message_at: "2026-06-01T00:00:00Z" },
+      { conversation_id: "conv-smoke", title: "Current chat", last_message_at: "2026-06-28T00:00:00Z" },
+    ],
+  });
+  await page.route("**/conversations/conv-other/messages", async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
+    await pending;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: "done", route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "hello");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(true);
+
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+  await shadowClickText(page, ".thread-item", "Other chat");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
+
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+  await shadowClickText(page, ".thread-item", "Current chat");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(true);
+
+  release();
+  await expect.poll(() => shadowText(page, ".messages")).toContain("done");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
 });
 
 test("stale stored conversation is replaced before sending to the agent", async ({ page }) => {


### PR DESCRIPTION
**Stack 3/3** · base: `feat/widget-thread-list` (#59)

Shows a bouncing-dots indicator while the assistant has no answer text yet, and keeps it visible when the user leaves a streaming thread and returns. Messages and usage live in per-conversation maps keyed by the id captured at submit time, so switching threads only swaps the view — the in-flight stream keeps writing to its own bucket. `typing` means "stream in flight" (set at submit, cleared at completion); `reduceStreamEvent` is reduced to content accumulation only, fixing dots that could otherwise linger on an empty final answer.

Every request now names its conversation (`send(id, text)`, `stream(id, text)`, `loadHistory(id)`, `loadUsage(id)`); localStorage only remembers which thread was selected last and never decides where an in-flight request lands (review feedback, `f529a92`).

Verified: widget typecheck, `test:widget`, and Playwright e2e (incl. switch-away-and-back and a mid-request thread-switch regression test) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)