### PR TITLE
fix(widget): hide internal tool provider labels

### DIFF
--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53487,7 +53487,7 @@ function AgentActivity({ route, tools = [] }) {
         ToolHeader,
         {
           state: toToolState(tool.status),
-          title: tool.provider ? `${tool.name} \xB7 ${tool.provider}` : tool.name
+          title: tool.name
         }
       ),
       tool.error ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(ToolContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(ToolOutput, { errorText: tool.error }) }) : null

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -456,7 +456,7 @@ function AgentActivity({ route, tools = [] }: { route?: string[]; tools?: ToolRe
         <Tool key={`${tool.name}-${index}`} defaultOpen={tool.status === "failed"}>
           <ToolHeader
             state={toToolState(tool.status)}
-            title={tool.provider ? `${tool.name} · ${tool.provider}` : tool.name}
+            title={tool.name}
           />
           {tool.error ? (
             <ToolContent>

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -21,6 +21,7 @@ async function mockConversationApi(
   options: {
     failSend?: boolean;
     threads?: Array<{ conversation_id: string; title: string | null; last_message_at: string | null }>;
+    usedTools?: Array<{ name: string; provider: string; status: string }>;
   } = {},
 ) {
   const calls: string[] = [];
@@ -77,7 +78,7 @@ async function mockConversationApi(
       body: [
         `event: answer_delta\ndata: ${JSON.stringify({ type: "answer_delta", content: "Echo: " })}`,
         `event: answer_delta\ndata: ${JSON.stringify({ type: "answer_delta", content: body.message || "" })}`,
-        `event: final\ndata: ${JSON.stringify({ type: "final", content: `Echo: ${body.message || ""}`, route: [], used_tools: [] })}`,
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: `Echo: ${body.message || ""}`, route: [], used_tools: options.usedTools ?? [] })}`,
         "event: done\ndata: [DONE]",
         "",
       ].join("\n\n"),
@@ -446,6 +447,20 @@ test("sending a message calls backend, renders assistant answer, stores conversa
   await expect.poll(() => shadowText(page, ".messages")).toContain("hello browser");
   await expect.poll(() => shadowText(page, ".messages")).toContain("Echo: hello browser");
   expect(calls).toContain("GET /conversations/conv-smoke/messages");
+});
+
+test("tool activity shows the tool name without its internal provider", async ({ page }) => {
+  await mockConversationApi(page, {
+    usedTools: [{ name: "search_docs", provider: "mcp", status: "succeeded" }],
+  });
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "find the docs");
+  await page.keyboard.press("Enter");
+
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Echo: find the docs");
+  await expect.poll(() => shadowText(page, ".tool-title")).toBe("search_docs");
+  await expect.poll(() => shadowText(page, ".tool-title")).not.toContain("mcp");
 });
 
 test("Shift+Enter inserts a newline and Enter sends", async ({ page }) => {


### PR DESCRIPTION
Closes #70.

The widget now shows only the public tool name in activity cards. The internal `local` or `mcp` provider remains in the data model for execution and status handling, but is no longer exposed in the user-facing title.

Validation:
- `npm run typecheck:widget`
- `npm run typecheck:e2e`
- `npm run build:widget`
- `npm run test:widget`
- `npm run test:widget:e2e -- tests/e2e/widget.spec.ts -g "tool activity"`
- `ruff check src tests`
- `mypy src tests`

The repository-wide pytest command is currently blocked by the environment's pre-existing `pytest-recording` and `pytest-vcr` plugin conflict.
