### PR TITLE
fix(generate): report unreferenced tools

### DIFF
--- a/src/agent_engine/core/spec.py
+++ b/src/agent_engine/core/spec.py
@@ -168,3 +168,4 @@ class SystemSpec:
     hooks: HooksConfig = field(default_factory=HooksConfig)
     plugins: PluginsConfig = field(default_factory=PluginsConfig)
     execution: ExecutionPolicy = field(default_factory=ExecutionPolicy)
+    tools: tuple[ToolSpec, ...] = field(default_factory=tuple)

--- a/src/agent_engine/generate/generator.py
+++ b/src/agent_engine/generate/generator.py
@@ -15,6 +15,7 @@ from agent_engine.generate.manifest import (
 class GenerateResult:
     created: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
+    ignored: list[str] = field(default_factory=list)
 
 
 class Generator:
@@ -37,6 +38,7 @@ class Generator:
             has_protected,
             mcp_plugin_ids,
         ) = _collect(spec.graph)
+        result.ignored.extend(tool.id for tool in spec.tools if tool.id not in tool_ids)
 
         tools_dir = base_dir / "plugins" / "tools"
         tools_dir.mkdir(parents=True, exist_ok=True)

--- a/src/agent_engine/parsers/yaml/parser.py
+++ b/src/agent_engine/parsers/yaml/parser.py
@@ -521,6 +521,10 @@ class YAMLParser(Parser):
             meta=SystemMeta(name=data["system"]["name"]),
             defaults=defaults,
             graph=graph,
+            tools=tuple(
+                ToolSpec(id=tool_id, description=raw.get("description", ""))
+                for tool_id, raw in tools.items()
+            ),
             hooks=_build_hooks(data.get("hooks")),
             plugins=_build_plugins(data.get("plugins")),
             execution=_build_execution(data.get("execution")),

--- a/src/agentctl/main.py
+++ b/src/agentctl/main.py
@@ -72,9 +72,13 @@ def generate(config: str) -> None:
         click.echo(f"  create  {name}")
     for name in result.skipped:
         click.echo(f"  skip    {name}")
+    for name in result.ignored:
+        click.echo(f"  ignore  {name}  (declared but not referenced by any agent)")
 
     if result.created:
         click.echo(f"\n✓ Created {len(result.created)} stub(s). Fill in the method bodies.")
+    elif result.ignored:
+        click.echo("✓ Nothing to generate — no referenced stubs are missing.")
     else:
         click.echo("✓ Nothing to generate — all stubs already exist.")
 

--- a/tests/cli/test_generate_command.py
+++ b/tests/cli/test_generate_command.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agentctl.main import cli
+
+
+def test_generate_reports_unused_declared_tools(tmp_path: Path) -> None:
+    config = tmp_path / "agents.yaml"
+    config.write_text(
+        """
+system:
+  name: test
+defaults:
+  model: {provider: anthropic, name: claude-test}
+tools:
+  used_tool:
+    description: Used tool
+  unused_tool:
+    description: Unused tool
+agents:
+  worker:
+    description: Worker
+    tools: [used_tool]
+graph:
+  worker:
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["generate", "--config", str(config)])
+
+    assert result.exit_code == 0
+    assert "  ignore  unused_tool  (declared but not referenced by any agent)" in result.output
+    assert (tmp_path / "plugins" / "tools" / "used_tool.py").is_file()
+    assert not (tmp_path / "plugins" / "tools" / "unused_tool.py").exists()
+
+    second = CliRunner().invoke(cli, ["generate", "--config", str(config)])
+
+    assert second.exit_code == 0
+    assert "  ignore  unused_tool  (declared but not referenced by any agent)" in second.output
+    assert "Nothing to generate — no referenced stubs are missing." in second.output

--- a/tests/generate/test_plugins_manifest.py
+++ b/tests/generate/test_plugins_manifest.py
@@ -242,6 +242,30 @@ def test_generate_is_idempotent_and_preserves_manifest(tmp_path: Path) -> None:
     assert f"plugins/{MANIFEST_NAME}" in result.skipped  # existed, not recreated
 
 
+def test_generate_reports_declared_tools_not_referenced_by_an_agent(tmp_path: Path) -> None:
+    used = ToolSpec("book_flight", "book a flight")
+    unused = ToolSpec("cancel_flight", "cancel a flight")
+    agent = AgentSpec(
+        id="flights",
+        name="flights",
+        description="books flights",
+        model=_MODEL,
+        tools=(used,),
+    )
+    spec = SystemSpec(
+        meta=SystemMeta(name="gen-test"),
+        defaults=None,
+        graph=GraphNode(node=agent),
+        tools=(used, unused),
+    )
+
+    result = Generator().generate(spec, tmp_path)
+
+    assert result.ignored == ["cancel_flight"]
+    assert (tmp_path / "plugins" / "tools" / "book_flight.py").is_file()
+    assert not (tmp_path / "plugins" / "tools" / "cancel_flight.py").exists()
+
+
 def test_generator_creates_missing_prompt_stubs(tmp_path: Path) -> None:
     # Setup spec with an orchestrator routing to an agent, both having missing prompts
     agent = AgentSpec(


### PR DESCRIPTION
## Summary

- preserve the complete top-level tool registry in the compiled system spec
- report tools that are declared but not referenced by any agent as `ignore`
- keep ignored tools out of generated stubs and `plugins.toml`
- cover direct generator behavior and first/idempotent CLI runs

Fixes #67

## Validation

- targeted regression tests: 2 passed
- full pytest excluding five existing Windows path-separator assertions in `tests/generate/test_plugins_manifest.py`: 555 passed
- `mypy src tests`: 169 source files passed
- Ruff check and format check for all changed files
- `git diff --check`

## AI assistance

Implemented and reviewed with OpenAI Codex; all listed validation commands were run locally.