### PR TITLE
fix(api): sanitize raw tool exception text to generic error in ToolRecord

### DIFF
--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -118,6 +118,14 @@ class ToolRecord(BaseModel):
     error: str | None = None
 
 
+def _client_tool_record(t: Any) -> ToolRecord:
+    fields = dataclasses.asdict(t)
+    if fields.get("error"):
+        fields["error"] = "Tool execution failed"
+    return ToolRecord(**fields)
+
+
+
 class PendingApprovalModel(BaseModel):
     """Sanitized pending-approval payload returned to the client/UI."""
 
@@ -255,7 +263,8 @@ def create_app(
             system_name=result.system_name,
             answer=result.answer,
             visited=result.visited,
-            used_tools=[ToolRecord(**dataclasses.asdict(t)) for t in result.used_tools],
+            used_tools=[_client_tool_record(t) for t in result.used_tools],
+
             run_id=run_id,
             status=result.status,
             pending_approval=_pending_model(result.pending_approval),
@@ -334,7 +343,8 @@ def create_app(
             system_name=result.system_name,
             answer=result.answer,
             visited=result.visited,
-            used_tools=[ToolRecord(**dataclasses.asdict(t)) for t in result.used_tools],
+            used_tools=[_client_tool_record(t) for t in result.used_tools],
+
             run_id=run_id,
             status=result.status,
             pending_approval=_pending_model(result.pending_approval),

--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -125,11 +125,11 @@ def _client_tool_record(t: Any) -> ToolRecord:
     return ToolRecord(**fields)
 
 
-
 class PendingApprovalModel(BaseModel):
     """Sanitized pending-approval payload returned to the client/UI."""
 
     run_id: str
+
     approval_id: str
     agent_id: str
     tool_name: str

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -351,7 +351,8 @@ class AgentNode:
         """
         error = str(exc)[:200]
         used_tools.append(self._usage(call, "failed", error=error))
-        self._log_call(logging.WARNING, "tool call failed", call, ms=latency_ms)
+        self._log_call(logging.WARNING, "tool call failed", call, ms=latency_ms, error=error)
+
         await self._hook_manager.run_on_tool_error(
             current_run_context.get(),
             self._call_context(call, "failed", latency_ms, error=error),

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -136,7 +136,6 @@ async def send_message(
     )
 
 
-
 def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
     return StreamEventOut(
         type=event.type,
@@ -154,7 +153,6 @@ def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
             else None
         ),
     )
-
 
 
 @router.post("/conversations/{conversation_id}/messages/stream")

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -110,6 +110,13 @@ async def get_usage(
     )
 
 
+def _client_tool_record(t: Any) -> ToolRecord:
+    fields = dataclasses.asdict(t)
+    if fields.get("error"):
+        fields["error"] = "Tool execution failed"
+    return ToolRecord(**fields)
+
+
 @router.post("/conversations/{conversation_id}/messages", response_model=SendMessageResponse)
 async def send_message(
     conversation_id: str, body: SendMessageRequest, service: Service, caller_id: CallerId
@@ -125,8 +132,9 @@ async def send_message(
     return SendMessageResponse(
         answer=result.answer,
         visited=list(result.visited),
-        used_tools=[ToolRecord(**dataclasses.asdict(t)) for t in result.used_tools],
+        used_tools=[_client_tool_record(t) for t in result.used_tools],
     )
+
 
 
 def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
@@ -141,11 +149,12 @@ def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
         error=event.error,
         system_name=event.system_name,
         used_tools=(
-            [ToolRecord(**dataclasses.asdict(tool)) for tool in event.used_tools]
+            [_client_tool_record(tool) for tool in event.used_tools]
             if event.used_tools
             else None
         ),
     )
+
 
 
 @router.post("/conversations/{conversation_id}/messages/stream")

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -391,9 +391,9 @@ class _ToolErrorEngine(RecordingEngine):
         yield RunStreamEvent(type="final", content="done", used_tools=(tool_err,))
 
 
-
 def test_tool_error_text_is_sanitized_in_send_message() -> None:
     """Raw tool exception details must be sanitized to generic text in API responses."""
+
     app = FastAPI()
     service = ConversationService(_ToolErrorEngine(), MemoryRepository())
     app.state.service = service

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -13,6 +13,7 @@ from agent_engine.engine.engine import Engine
 from agent_engine.engine.types import ChatMessage, RunResult
 from agent_engine.runtime.hooks.models import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
+from agent_engine.runtime.tool_models import ToolUsageRecord
 from agent_manager.api.routes import router
 from agent_manager.application import ConversationService
 from agent_manager.domain import TokenBudgetUsage, thread_title
@@ -347,4 +348,83 @@ def test_stream_returns_429_when_token_budget_exceeded() -> None:
         detail["message"]
         == "This conversation has reached its context limit. Start a new chat to continue."
     )
+
+
+class _ToolErrorEngine(RecordingEngine):
+    async def run(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> RunResult:
+        res = await super().run(message, history=history, context=context)
+        err_msg = (
+            "HTTPConnectionPool(host='localhost', port=3000): "
+            "Max retries exceeded with url: /api/v1/auths/add"
+        )
+        tool_err = ToolUsageRecord(
+            name="add_new_user",
+            provider="local",
+            status="failed",
+            error=err_msg,
+        )
+        return dataclasses.replace(res, used_tools=(tool_err,))
+
+    async def stream(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        err_msg = (
+            "HTTPConnectionPool(host='localhost', port=3000): "
+            "Max retries exceeded with url: /api/v1/auths/add"
+        )
+        tool_err = ToolUsageRecord(
+            name="add_new_user",
+            provider="local",
+            status="failed",
+            error=err_msg,
+        )
+        yield RunStreamEvent(type="final", content="done", used_tools=(tool_err,))
+
+
+
+def test_tool_error_text_is_sanitized_in_send_message() -> None:
+    """Raw tool exception details must be sanitized to generic text in API responses."""
+    app = FastAPI()
+    service = ConversationService(_ToolErrorEngine(), MemoryRepository())
+    app.state.service = service
+    app.include_router(router)
+    client = TestClient(app)
+
+    cid = client.post("/conversations").json()["conversation_id"]
+    response = client.post(f"/conversations/{cid}/messages", json={"message": "trigger tool"})
+
+    assert response.status_code == 200
+    used_tools = response.json()["used_tools"]
+    assert len(used_tools) == 1
+    assert used_tools[0]["error"] == "Tool execution failed"
+    assert "localhost" not in used_tools[0]["error"]
+
+
+def test_tool_error_text_is_sanitized_in_stream_message() -> None:
+    """Raw tool exception details must be sanitized to generic text in stream SSE events."""
+    app = FastAPI()
+    service = ConversationService(_ToolErrorEngine(), MemoryRepository())
+    app.state.service = service
+    app.include_router(router)
+    client = TestClient(app)
+
+    cid = client.post("/conversations").json()["conversation_id"]
+    url = f"/conversations/{cid}/messages/stream"
+    response = client.post(url, json={"message": "trigger tool"})
+
+    assert response.status_code == 200
+    assert "Tool execution failed" in response.text
+    assert "localhost" not in response.text
+
+
 


### PR DESCRIPTION
Closes #69

### Summary of Changes
- Sanitizes `used_tools[].error` at the API boundary (`routes.py` and `app.py`) to `"Tool execution failed"` so internal Python/network exception details are not exposed to clients.
- Preserves full exception logging in server-side logs and LLM model prompts.
- Adds unit tests in `tests/agent_manager/test_api.py`.