### PR TITLE
fix(widget): avoid crypto.randomUUID crash outside secure contexts

### DIFF
--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -52423,6 +52423,16 @@ var X = createLucideIcon("x", __iconNode12);
 // src/agent_manager/api/static/widget/react/AgentChatApp.tsx
 var import_react10 = __toESM(require_react(), 1);
 
+// src/agent_manager/api/static/widget/id.ts
+function randomId() {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = bytes[6] & 15 | 64;
+  bytes[8] = bytes[8] & 63 | 128;
+  const hex = Array.from(bytes, (b3) => b3.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 // src/agent_manager/api/static/widget/storage/conversationStorage.ts
 function conversationStorageKey(endpoint, userId) {
   return `agent-chat:${endpoint}:${userId}`;
@@ -52440,7 +52450,7 @@ function getOrCreateUserId(endpoint, storage = localStorage) {
   const key = `agent-chat:user:${endpoint}`;
   let id = storage.getItem(key);
   if (!id) {
-    id = crypto.randomUUID();
+    id = randomId();
     storage.setItem(key, id);
   }
   return id;
@@ -53161,7 +53171,7 @@ var import_jsx_runtime4 = __toESM(require_jsx_runtime(), 1);
 var DEFAULT_GREETING = "How can I help you today?";
 var GENERIC_ERROR = "Something went wrong. Please try again.";
 var COPIED_RESET_MS = 2e3;
-var newId = () => crypto.randomUUID();
+var newId = randomId;
 var toEntry = (message) => ({
   id: newId(),
   role: message.role === "user" ? "user" : "ai",

--- a/src/agent_manager/api/static/widget/id.ts
+++ b/src/agent_manager/api/static/widget/id.ts
@@ -1,0 +1,15 @@
+/** UUID v4 generator that also works outside secure contexts.
+ *
+ * `crypto.randomUUID()` throws on plain http origins other than localhost
+ * (browsers restrict it to secure contexts). `crypto.getRandomValues()` has
+ * no such restriction, so build a v4 UUID from it when `randomUUID` is
+ * unavailable.
+ */
+export function randomId(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -10,6 +10,7 @@ import {
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentChatHttpError, type AgentChatClient } from "../api/AgentChatClient";
+import { randomId } from "../id";
 import { getStoredConversationId } from "../storage/conversationStorage";
 
 import type {
@@ -44,7 +45,7 @@ const DEFAULT_GREETING = "How can I help you today?";
 const GENERIC_ERROR = "Something went wrong. Please try again.";
 const COPIED_RESET_MS = 2000;
 
-const newId = () => crypto.randomUUID();
+const newId = randomId;
 
 const toEntry = (message: ChatMessage): MessageEntry => ({
   id: newId(),

--- a/src/agent_manager/api/static/widget/storage/conversationStorage.ts
+++ b/src/agent_manager/api/static/widget/storage/conversationStorage.ts
@@ -5,6 +5,8 @@
  * Keyed by endpoint alone, the next user would resume the previous user's
  * conversation.
  */
+import { randomId } from "../id";
+
 export function conversationStorageKey(endpoint: string, userId: string): string {
   return `agent-chat:${endpoint}:${userId}`;
 }
@@ -38,7 +40,7 @@ export function getOrCreateUserId(endpoint: string, storage: Storage = localStor
   const key = `agent-chat:user:${endpoint}`;
   let id = storage.getItem(key);
   if (!id) {
-    id = crypto.randomUUID();
+    id = randomId();
     storage.setItem(key, id);
   }
   return id;


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` is restricted to secure contexts (https, or `http://localhost` exactly). Loading `/demo` from any other http origin threw a `TypeError` inside `AgentChatElement.connectedCallback`, which aborted before React ever rendered — the launcher silently never appeared.
- Added `randomId()` in `id.ts`, falling back to `crypto.getRandomValues` (no secure-context restriction) to build an RFC 4122 v4 UUID by hand — same bit-setting algorithm as the `uuid` npm package. When `randomUUID` is available it's used unchanged.
- Rebuilt `widget.js` so the fix is in the served bundle.

## Test plan
- [x] `npm run typecheck:widget`
- [x] `npm run test:widget`
- [x] `npm run build:widget`
- [ ] Rebuild the docker image (`make build`) and confirm the launcher renders when `/demo` is loaded from a non-localhost http origin