### PR TITLE
Prefix local build image with ghcr.io/extra-org/extra to match prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ FLAGSHIP := $(EXAMPLE)/$(CONFIG)
 # Every example must stay offline-valid — `make validate` checks them all.
 EXAMPLES := examples/starter examples/enterprise-knowledge-assistant
 
-IMAGE := extra:local
+IMAGE := ghcr.io/extra-org/extra:local
 COMPOSE := CONFIG=$(CONFIG) docker compose -f $(EXAMPLE)/docker-compose.yml
 
 .DEFAULT_GOAL := help
@@ -72,7 +72,7 @@ validate: ## Validate every example offline (no LLM calls, no network, no API ke
 inspect: ## Inspect the flagship example offline (agents, MCPs, hooks, plugins, tags).
 	agentctl inspect $(FLAGSHIP)
 
-build: ## Build the container image, tagged extra:local.
+build: ## Build the container image, tagged ghcr.io/extra-org/extra:local.
 	docker build -t $(IMAGE) .
 
 # Validate inside the image so only Docker is required, not a local install.

--- a/examples/enterprise-knowledge-assistant/docker-compose.yml
+++ b/examples/enterprise-knowledge-assistant/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mcp:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     entrypoint: ["python", "-m", "mcps.local_knowledge_mcp.server"]
     volumes:
       - .:/workspace
@@ -9,7 +9,7 @@ services:
       - "8100:8100"
 
   engine:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     profiles: ["engine"]
     command: ["serve", "--config", "/workspace/${CONFIG:-agents.yaml}", "--host", "0.0.0.0", "--port", "8090"]
     volumes:
@@ -21,7 +21,7 @@ services:
       - mcp
 
   manager:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     profiles: ["ui"]
     command: ["agent-manager", "--config", "/workspace/${CONFIG:-agents.yaml}", "--host", "0.0.0.0", "--port", "8100"]
     volumes:

--- a/examples/starter/docker-compose.yml
+++ b/examples/starter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mcp:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     entrypoint: ["python", "-m", "mcps.bank.server"]
     volumes:
       - .:/workspace
@@ -9,7 +9,7 @@ services:
       - "8100:8100"
 
   engine:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     profiles: ["engine"]
     command: ["serve", "--config", "/workspace/${CONFIG:-agents.yaml}", "--host", "0.0.0.0", "--port", "8090"]
     volumes:
@@ -21,7 +21,7 @@ services:
       - mcp
 
   manager:
-    image: extra:local
+    image: ghcr.io/extra-org/extra:local
     profiles: ["ui"]
     command: ["agent-manager", "--config", "/workspace/${CONFIG:-agents.yaml}", "--host", "0.0.0.0", "--port", "8100"]
     volumes:


### PR DESCRIPTION
## Summary
- `make build` tagged the local image as `extra:local` (`Makefile:20`), while prod releases push to `ghcr.io/${{ github.repository }}:${TAG}` (i.e. `ghcr.io/extra-org/extra:*`). The differing prefix made it harder to tell the local build is the same image as prod, just a different tag.
- Changed the local tag to `ghcr.io/extra-org/extra:local` in the three places that reference it: `Makefile`, `examples/starter/docker-compose.yml`, `examples/enterprise-knowledge-assistant/docker-compose.yml`.

Fixes #82

## Test plan
- [x] `grep -rn "extra:local"` — only the new `ghcr.io/extra-org/extra:local` references remain, no stragglers
- [x] `docker compose -f examples/starter/docker-compose.yml config -q` — parses cleanly
- [x] `docker compose -f examples/enterprise-knowledge-assistant/docker-compose.yml config -q` — parses cleanly
- Did not run a full `make build` (would require pulling/building the whole image), but the change is a pure string substitution with no other logic touched.