### PR TITLE
generate: report tools declared but not referenced by any agent

### DIFF
--- a/src/agent_engine/core/spec.py
+++ b/src/agent_engine/core/spec.py
@@ -168,3 +168,6 @@ class SystemSpec:
     hooks: HooksConfig = field(default_factory=HooksConfig)
     plugins: PluginsConfig = field(default_factory=PluginsConfig)
     execution: ExecutionPolicy = field(default_factory=ExecutionPolicy)
+    # The full top-level `tools:` registry, independent of which agents
+    # reference them. Lets `generate` report tools declared but unused.
+    declared_tools: tuple[ToolSpec, ...] = field(default_factory=tuple)

--- a/src/agent_engine/generate/generator.py
+++ b/src/agent_engine/generate/generator.py
@@ -15,6 +15,7 @@ from agent_engine.generate.manifest import (
 class GenerateResult:
     created: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
+    ignored: list[str] = field(default_factory=list)
 
 
 class Generator:
@@ -44,6 +45,10 @@ class Generator:
             self._write(
                 tools_dir / f"{tool_id}.py", _tool_stub(tool_id, description), result, base_dir
             )
+
+        result.ignored.extend(
+            t.id for t in spec.declared_tools if t.id not in tool_ids
+        )
 
         resolvers_dir = base_dir / "plugins" / "resolvers"
         resolvers_dir.mkdir(parents=True, exist_ok=True)

--- a/src/agent_engine/parsers/yaml/parser.py
+++ b/src/agent_engine/parsers/yaml/parser.py
@@ -658,6 +658,10 @@ class YAMLParser(Parser):
             hooks=_build_hooks(data.get("hooks")),
             plugins=_build_plugins(data.get("plugins")),
             execution=_build_execution(data.get("execution")),
+            declared_tools=tuple(
+                ToolSpec(id=tool_id, description=raw.get("description", ""))
+                for tool_id, raw in tools.items()
+            ),
         )
 
     def _build_defaults(self, raw: Any) -> DefaultsConfig | None:

--- a/src/agentctl/main.py
+++ b/src/agentctl/main.py
@@ -72,6 +72,8 @@ def generate(config: str) -> None:
         click.echo(f"  create  {name}")
     for name in result.skipped:
         click.echo(f"  skip    {name}")
+    for name in result.ignored:
+        click.echo(f"  ignore  {name}  (declared but not referenced by any agent)")
 
     if result.created:
         click.echo(f"\n✓ Created {len(result.created)} stub(s). Fill in the method bodies.")

--- a/tests/generate/test_plugins_manifest.py
+++ b/tests/generate/test_plugins_manifest.py
@@ -242,6 +242,37 @@ def test_generate_is_idempotent_and_preserves_manifest(tmp_path: Path) -> None:
     assert f"plugins/{MANIFEST_NAME}" in result.skipped  # existed, not recreated
 
 
+# -- declared-but-unreferenced tools -------------------------------------------
+
+
+def test_generate_reports_declared_but_unreferenced_tools(tmp_path: Path) -> None:
+    spec = _spec_with_plugins()
+    spec = SystemSpec(
+        meta=spec.meta,
+        defaults=spec.defaults,
+        graph=spec.graph,
+        hooks=spec.hooks,
+        plugins=spec.plugins,
+        declared_tools=(
+            ToolSpec("book_flight", "book a flight"),
+            ToolSpec("cancel_flight", "cancel a flight"),
+        ),
+    )
+
+    result = Generator().generate(spec, tmp_path)
+
+    # book_flight is referenced by the flights agent, so it's not reported.
+    assert "cancel_flight" in result.ignored
+    assert "book_flight" not in result.ignored
+    # Still no stub — nothing calls it.
+    assert not (tmp_path / "plugins" / "tools" / "cancel_flight.py").exists()
+
+
+def test_generate_reports_no_ignored_tools_when_all_referenced(tmp_path: Path) -> None:
+    result = Generator().generate(_spec_with_plugins(), tmp_path)
+    assert result.ignored == []
+
+
 def test_generator_creates_missing_prompt_stubs(tmp_path: Path) -> None:
     # Setup spec with an orchestrator routing to an agent, both having missing prompts
     agent = AgentSpec(

--- a/tests/parsers/test_declared_tools.py
+++ b/tests/parsers/test_declared_tools.py
@@ -1,0 +1,55 @@
+"""Tests that the parser preserves the full top-level tools: registry.
+
+Regression coverage for the `generate` command silently omitting tools that
+are declared but never referenced by any agent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_engine.parsers.yaml.parser import YAMLParser
+
+_SPEC = """
+system:
+  name: test
+
+defaults:
+  model:
+    provider: openai
+    name: gpt-4o-mini
+
+tools:
+  add_new_user:
+    description: Adding new user to the system
+  block_card:
+    description: Block a bank card
+
+agents:
+  admin_agent:
+    description: "Admin agent"
+    prompts:
+      system: prompts/admin.md
+    tools: [block_card]
+
+graph:
+  admin_agent:
+"""
+
+
+def _parse(tmp_path: Path):
+    cfg = tmp_path / "spec.yml"
+    cfg.write_text(_SPEC, encoding="utf-8")
+    return YAMLParser().parse(str(cfg))
+
+
+def test_declared_tools_includes_unreferenced_entries(tmp_path: Path) -> None:
+    spec = _parse(tmp_path)
+    declared_ids = {t.id for t in spec.declared_tools}
+    assert declared_ids == {"add_new_user", "block_card"}
+
+
+def test_declared_tools_carries_descriptions(tmp_path: Path) -> None:
+    spec = _parse(tmp_path)
+    by_id = {t.id: t.description for t in spec.declared_tools}
+    assert by_id["add_new_user"] == "Adding new user to the system"


### PR DESCRIPTION
## Summary
- `Generator.generate()` only looked at `tool_ids` collected by walking the agent graph (`_collect()`), so a tool declared in the top-level `tools:` registry but never added to any agent's `tools:` list was invisible in `agentctl generate` output — no stub (correct, nothing uses it) but no mention either. A forgotten reference looked identical to an intentional one.
- Added `SystemSpec.declared_tools`, populated from the full top-level `tools:` registry during YAML parsing (previously this registry was only used transiently inside the parser to resolve per-agent tool references, then discarded).
- `Generator.generate()` now diffs `declared_tools` against the referenced `tool_ids` and reports the difference on a new `GenerateResult.ignored` field.
- `agentctl generate` surfaces it:
  ```
    ignore  add_new_user  (declared but not referenced by any agent)
  ```

Fixes #67

## Test plan
- [x] New test `tests/parsers/test_declared_tools.py` — confirms the parser populates `SystemSpec.declared_tools` (ids + descriptions) from real YAML, using the exact repro from the issue
- [x] New tests in `tests/generate/test_plugins_manifest.py` — `Generator.generate()` reports an unreferenced declared tool in `result.ignored` (and not in `created`/no stub file), and reports nothing when all declared tools are referenced
- [x] Ran `tests/parsers`, `tests/generate`, `tests/core` — all pass except 5 pre-existing failures unrelated to this change (a Windows-only path-separator assertion bug: `result.created.count("plugins/plugins.toml")` compares a forward-slash literal against `str(Path.relative_to(...))`, which yields backslashes on Windows — reproduces identically on `main` before this change)