### PR TITLE
fix(widget): keep chat history rows scrollable

### DIFF
--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53685,11 +53685,11 @@ function styles(config) {
     .thread-drawer.open { transform: none; opacity: 1; pointer-events: auto; }
     .thread-drawer-head { display: flex; align-items: center; justify-content: space-between;
       padding: 10px 12px 10px 18px; font-weight: 600; font-size: 14px; color: #18181b;
-      border-bottom: 1px solid #f0f0f1; }
+      border-bottom: 1px solid #f0f0f1; flex: 0 0 auto; }
     .thread-new { display: flex; align-items: center; gap: 8px; margin: 12px 14px 4px;
       padding: 10px 14px; border: 1px solid #e4e4e7; border-radius: 12px; background: #fff;
       color: #18181b; font-size: 14px; font-weight: 500; cursor: pointer; font-family: inherit;
-      transition: background .12s; }
+      transition: background .12s; flex: 0 0 auto; }
     .thread-new:hover { background: #f4f4f5; }
     .thread-new svg { width: 16px; height: 16px; flex: 0 0 auto; }
     .thread-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px 10px 14px;
@@ -53698,7 +53698,7 @@ function styles(config) {
     .thread-item { text-align: left; border: 0; background: transparent; cursor: pointer;
       padding: 10px 12px; border-radius: 10px; font-size: 13.5px; color: #3f3f46;
       font-family: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-      transition: background .12s; }
+      transition: background .12s; flex: 0 0 auto; }
     .thread-item:hover { background: #f4f4f5; }
     .thread-item.active { background: #f4f4f5; color: #18181b; font-weight: 600; }
     .thread-empty { color: #a1a1aa; font-size: 13px; text-align: center; padding: 24px 12px; margin: 0; }

--- a/src/agent_manager/api/static/widget/styles/styles.ts
+++ b/src/agent_manager/api/static/widget/styles/styles.ts
@@ -66,11 +66,11 @@ export function styles(config: AgentChatConfig): string {
     .thread-drawer.open { transform: none; opacity: 1; pointer-events: auto; }
     .thread-drawer-head { display: flex; align-items: center; justify-content: space-between;
       padding: 10px 12px 10px 18px; font-weight: 600; font-size: 14px; color: #18181b;
-      border-bottom: 1px solid #f0f0f1; }
+      border-bottom: 1px solid #f0f0f1; flex: 0 0 auto; }
     .thread-new { display: flex; align-items: center; gap: 8px; margin: 12px 14px 4px;
       padding: 10px 14px; border: 1px solid #e4e4e7; border-radius: 12px; background: #fff;
       color: #18181b; font-size: 14px; font-weight: 500; cursor: pointer; font-family: inherit;
-      transition: background .12s; }
+      transition: background .12s; flex: 0 0 auto; }
     .thread-new:hover { background: #f4f4f5; }
     .thread-new svg { width: 16px; height: 16px; flex: 0 0 auto; }
     .thread-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px 10px 14px;
@@ -79,7 +79,7 @@ export function styles(config: AgentChatConfig): string {
     .thread-item { text-align: left; border: 0; background: transparent; cursor: pointer;
       padding: 10px 12px; border-radius: 10px; font-size: 13.5px; color: #3f3f46;
       font-family: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-      transition: background .12s; }
+      transition: background .12s; flex: 0 0 auto; }
     .thread-item:hover { background: #f4f4f5; }
     .thread-item.active { background: #f4f4f5; color: #18181b; font-weight: 600; }
     .thread-empty { color: #a1a1aa; font-size: 13px; text-align: center; padding: 24px 12px; margin: 0; }

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -570,6 +570,40 @@ test("thread drawer lists conversations, switches to one, and starts a new chat"
   await expect.poll(() => shadowText(page, ".messages")).toContain("How can I help you today?");
 });
 
+test("thread drawer keeps conversation rows readable and scrollable", async ({ page }) => {
+  const threads = Array.from({ length: 30 }, (_, index) => ({
+    conversation_id: `conv-${index}`,
+    title: `Conversation ${index}`,
+    last_message_at: "2026-06-01T00:00:00Z",
+  }));
+  await mockConversationApi(page, { threads });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+
+  const handle = await widget(page);
+  const metrics = await handle.evaluate((element) => {
+    const root = element.shadowRoot;
+    const list = root?.querySelector<HTMLElement>(".thread-list");
+    const items = Array.from(root?.querySelectorAll<HTMLElement>(".thread-item") ?? []);
+    if (!list || items.length === 0) throw new Error("Thread drawer did not render");
+
+    return {
+      itemCount: items.length,
+      itemHeights: items.map((item) => item.getBoundingClientRect().height),
+      itemFlexShrink: getComputedStyle(items[0]).flexShrink,
+      listClientHeight: list.clientHeight,
+      listScrollHeight: list.scrollHeight,
+    };
+  });
+
+  expect(metrics.itemCount).toBe(30);
+  expect(metrics.itemFlexShrink).toBe("0");
+  expect(Math.min(...metrics.itemHeights)).toBeGreaterThan(30);
+  expect(metrics.listScrollHeight).toBeGreaterThan(metrics.listClientHeight);
+});
+
 test("thinking dots persist when switching away from an in-flight thread and back", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- prevent chat drawer headers, the new-chat action, and conversation rows from shrinking
- rebuild the committed widget bundle from the TypeScript source
- add a browser regression test that verifies stable row heights and vertical overflow with 30 conversations

Fixes #61.

## Validation

- `npm run typecheck:widget`
- `npm run typecheck:e2e`
- `npm run test:widget`
- `npm run build:widget`
- `npx playwright test tests/e2e/widget.spec.ts --headed` (21 passed)
- `git diff --check origin/main...HEAD`

## AI assistance

AI assistance was used to inspect the drawer layout, implement the focused CSS fix and regression test, and run validation. The final diff and test behavior were reviewed before submission.