### PR TITLE
ci(widget): run widget checks in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 # CI — the quality gate (issue #23).
 #
-# Runs `make check` (ruff + mypy + pytest) and `make validate` (offline
-# validation of the flagship example) on every pull request and on pushes
-# to main. Single Python version per pyproject.toml (requires-python >=3.11);
-# no matrix, no caching tuning — see the issue's non-goals.
+# Runs the Python quality gate and the widget TypeScript/browser checks on
+# every pull request and on pushes to main.
 #
 # To make this a required status check, protect `main` in the repo settings
 # and require the "check" job (maintainer action, not part of this file).
@@ -40,3 +38,40 @@ jobs:
 
       - name: Validate flagship example (offline)
         run: make validate
+
+  widget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install widget server dependencies
+        run: python -m pip install -e .
+
+      - name: Install widget dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Typecheck widget
+        run: npm run typecheck:widget
+
+      - name: Typecheck widget E2E tests
+        run: npm run typecheck:e2e
+
+      - name: Test widget
+        run: npm run test:widget
+
+      - name: Test widget in Chromium
+        run: npm run test:widget:e2e


### PR DESCRIPTION
## Summary

- add a dedicated widget CI job alongside the existing Python quality gate
- install locked Node dependencies plus Chromium and its system dependencies
- enforce widget and E2E TypeScript checks, unit tests, and Playwright browser tests on pull requests and main pushes

Closes #64.

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- `node node_modules/typescript/bin/tsc -p tsconfig.widget.json --noEmit`
- `node node_modules/typescript/bin/tsc -p tsconfig.e2e.json --noEmit`
- `node src/agent_manager/api/static/widget.test.mjs` (widget self-check: OK)
- `node node_modules/@playwright/test/cli.js test --headed` (20 passed)
- `git diff --check`

## AI assistance

AI assistance was used to inspect the existing quality gate, implement the scoped workflow update, and run validation. The final workflow diff and test results were reviewed before submission.