### PR TITLE
ci: run UI tests on every PR and deploy, not just Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 # CI — the quality gate (issue #23).
 #
-# Runs `make check` (ruff + mypy + pytest) and `make validate` (offline
-# validation of the flagship example) on every pull request and on pushes
-# to main. Single Python version per pyproject.toml (requires-python >=3.11);
-# no matrix, no caching tuning — see the issue's non-goals.
+# Two jobs, both on every pull request and on pushes to main (the push that
+# release-please deploys from, so a deploy never ships untested UI):
+#   - check: `make check` (ruff + mypy + pytest) and `make validate` (offline
+#     validation of the flagship example). Single Python version per
+#     pyproject.toml (requires-python >=3.11); no matrix, no caching tuning —
+#     see the issue's non-goals.
+#   - ui: widget typecheck + unit tests + Playwright e2e against the served
+#     widget and /playground page, and a staleness check that the committed
+#     widget.js bundle matches the TypeScript source.
 #
-# To make this a required status check, protect `main` in the repo settings
-# and require the "check" job (maintainer action, not part of this file).
+# To make these required status checks, protect `main` in the repo settings
+# and require the "check" and "ui" jobs (maintainer action, not part of
+# this file).
 
 name: CI
 
@@ -40,3 +46,46 @@ jobs:
 
       - name: Validate flagship example (offline)
         run: make validate
+
+  ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      # The Playwright web server imports agent_manager to serve the widget
+      # the way production does; runtime deps only, no dev extras.
+      - name: Install Python package
+        run: python -m pip install -e .
+
+      - name: Typecheck widget and e2e sources
+        run: |
+          npm run typecheck:widget
+          npm run typecheck:e2e
+
+      - name: Rebuild widget and fail if the committed bundle is stale
+        run: |
+          npm run build:widget
+          git diff --exit-code src/agent_manager/api/static/widget.js
+
+      - name: Widget unit tests
+        run: npm run test:widget
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: UI e2e tests (Playwright)
+        run: npm run test:widget:e2e

--- a/tests/e2e/playground.spec.ts
+++ b/tests/e2e/playground.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+// The /playground route (agent-manager's built-in demo page) serves demo.html
+// with the widget embedded. These tests cover the route wiring plus a full
+// user round-trip on that page; deep widget behavior lives in widget.spec.ts.
+
+async function mockConversationApi(page: Page) {
+  const calls: string[] = [];
+
+  await page.route("**/conversations", async (route) => {
+    const method = route.request().method();
+    calls.push(`${method} ${new URL(route.request().url()).pathname}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body:
+        method === "GET"
+          ? JSON.stringify([])
+          : JSON.stringify({ conversation_id: "conv-playground", session_id: "conv-playground" }),
+    });
+  });
+
+  await page.route(/\/conversations\?/, async (route) => {
+    calls.push(`GET ${new URL(route.request().url()).pathname}`);
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.route("**/conversations/*/messages", async (route: Route) => {
+    calls.push(`${route.request().method()} ${new URL(route.request().url()).pathname}`);
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.route("**/conversations/*/messages/stream", async (route: Route) => {
+    const request = route.request();
+    calls.push(`${request.method()} ${new URL(request.url()).pathname}`);
+    const body = JSON.parse(request.postData() || "{}") as { message?: string };
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: answer_delta\ndata: ${JSON.stringify({ type: "answer_delta", content: `Echo: ${body.message || ""}` })}`,
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: `Echo: ${body.message || ""}`, route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  return calls;
+}
+
+async function widget(page: Page) {
+  const handle = await page.locator("agent-chat").elementHandle();
+  if (!handle) throw new Error("agent-chat element not found");
+  return handle;
+}
+
+async function shadowText(page: Page, selector: string) {
+  const handle = await widget(page);
+  return await handle.evaluate((element, selector) => {
+    return element.shadowRoot?.querySelector(selector)?.textContent || "";
+  }, selector);
+}
+
+async function shadowClassContains(page: Page, selector: string, className: string) {
+  const handle = await widget(page);
+  return await handle.evaluate(
+    (element, { selector, className }) => {
+      return element.shadowRoot?.querySelector(selector)?.classList.contains(className) || false;
+    },
+    { selector, className },
+  );
+}
+
+async function shadowClick(page: Page, selector: string) {
+  const handle = await widget(page);
+  await handle.evaluate((element, selector) => {
+    element.shadowRoot?.querySelector<HTMLElement>(selector)?.click();
+  }, selector);
+}
+
+async function shadowFill(page: Page, selector: string, value: string) {
+  const handle = await widget(page);
+  await handle.evaluate(
+    (element, { selector, value }) => {
+      const target = element.shadowRoot?.querySelector<HTMLTextAreaElement>(selector);
+      if (!target) throw new Error(`Missing ${selector}`);
+      target.value = value;
+      target.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    },
+    { selector, value },
+  );
+}
+
+test("GET /playground serves the demo page with one embedded widget", async ({ page }) => {
+  const response = await page.goto("/playground");
+
+  expect(response?.status()).toBe(200);
+  expect(response?.headers()["content-type"]).toContain("text/html");
+  await expect(page).toHaveTitle(/embed example/);
+  await expect(page.getByRole("heading", { name: "Drop-in chat widget" })).toBeVisible();
+  await expect(page.locator("agent-chat")).toHaveCount(1);
+});
+
+test("GET /widget.js is served as JavaScript for third-party embeds", async ({ page }) => {
+  const response = await page.request.get("/widget.js");
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("javascript");
+  expect((await response.body()).length).toBeGreaterThan(0);
+});
+
+test("playground widget mounts cleanly and opens with its configured greeting", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (message) => {
+    if (["error", "warning"].includes(message.type())) consoleMessages.push(message.text());
+  });
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await mockConversationApi(page);
+  await page.goto("/playground");
+
+  await expect.poll(() => page.evaluate(() => Boolean(customElements.get("agent-chat")))).toBe(true);
+  await shadowClick(page, ".launcher");
+  await expect.poll(() => shadowClassContains(page, ".panel", "open")).toBe(true);
+  await expect.poll(() => shadowText(page, ".header")).toContain("Support");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("How can I help you today?");
+
+  expect(consoleMessages).toEqual([]);
+  expect(pageErrors).toEqual([]);
+});
+
+test("playground chat round-trip: send a message, get the streamed answer", async ({ page }) => {
+  const calls = await mockConversationApi(page);
+  await page.goto("/playground");
+
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "hello from the playground");
+  await page.keyboard.press("Enter");
+
+  await expect.poll(() => shadowText(page, ".messages")).toContain("hello from the playground");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Echo: hello from the playground");
+  expect(calls).toContain("POST /conversations");
+  expect(calls).toContain("POST /conversations/conv-playground/messages/stream");
+});


### PR DESCRIPTION
## What

Per @Asaf-prog's request: run UI tests automatically, not only the Python suite.

- **New `ui` job in `ci.yml`** — runs on every PR and every push to `main` (the push release-please deploys from, so a deploy can no longer ship an untested UI):
  1. Typecheck of the widget and e2e sources
  2. Stale-bundle check — rebuilds `widget.js` from the TypeScript source and fails if the committed bundle doesn't match
  3. Widget unit tests (`widget.test.mjs`)
  4. The full Playwright e2e suite (Chromium) against the widget served by `agent_manager`, the same way production serves it
- **New `tests/e2e/playground.spec.ts`** — the `/playground` route added in #84 had zero UI coverage. Covers the route wiring (`/playground` + `/widget.js` content types), a clean widget mount with the configured greeting and no console errors, and a full send → streamed-answer round-trip against a mocked conversation API.

The existing `widget.spec.ts` suite (20 tests) was already in the repo but nothing ever ran it in CI — now it gates every merge.

## Verified locally

- `npx playwright test` → **24 passed** (20 existing + 4 new)
- `npm run typecheck:widget` / `typecheck:e2e` / `test:widget` → clean
- `npm run build:widget` → byte-identical to the committed `widget.js` (stale check passes)
- `make check` → passes (575 tests)

## Note for maintainers

To make this block merges, add `ui` as a required status check next to `check` in the branch protection settings (same note as in the workflow header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)