### PR TITLE
fix(runs): expire terminal in-memory run records

### DIFF
--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -274,16 +274,33 @@ A future Redis implementation must provide the same contract across pods using
 an appropriate atomic Redis operation, and can be selected through composition
 without changing `RunLifecycle` or `LangGraphEngine`.
 
+The adapter is intentionally lock-free under its process-local execution model:
+one repository instance is accessed from one asyncio event loop and OS thread,
+and its check-and-mutate sequences contain no suspension points. Coroutines
+therefore cannot interleave inside a repository operation. The adapter must not
+be shared across threads or event loops; a deployment requiring that model must
+inject an implementation with the appropriate synchronization.
+
 The in-memory adapter bounds terminal-state retention to prevent completed run
 records from accumulating for the lifetime of a long-running process. It keeps
 `COMPLETED`, `FAILED`, and `CANCELLED` records for 24 hours by default, using a
-configurable adapter-local TTL and opportunistic eviction on repository access.
+configurable adapter-local TTL. Status reads check only their requested run;
+transitions additionally process a fixed-size batch from a FIFO expiration
+queue so untouched terminal records are eventually reclaimed. Cleanup cost is
+therefore bounded and never scans or drains all expired runs on a request path.
 `RUNNING`, `PENDING_APPROVAL`, and `RESUMING` records never expire, so cleanup
 cannot invalidate an active execution or resumable approval. After a terminal
 record expires, its `run_id` is unknown and may be registered again; the TTL is
 therefore also the in-memory adapter's idempotency and status-query retention
 window. This policy does not change the `RunRepository` protocol: applications
 that need different retention inject another configured or persistent adapter.
+
+`create_if_absent` deliberately performs no eviction. Its existence check and
+insert have no `await` between them, preserving one-winner asyncio concurrency
+semantics without a lock. Consequently, attempting to create an existing run
+cannot delete it or change its original expiration; an expired record becomes
+reusable only after targeted status access or bounded transition cleanup has
+applied the normal TTL eviction policy.
 
 Run status changes cross the same boundary through `transition_if_allowed`.
 Checking whether a transition is legal and applying it are one repository

--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -274,6 +274,17 @@ A future Redis implementation must provide the same contract across pods using
 an appropriate atomic Redis operation, and can be selected through composition
 without changing `RunLifecycle` or `LangGraphEngine`.
 
+The in-memory adapter bounds terminal-state retention to prevent completed run
+records from accumulating for the lifetime of a long-running process. It keeps
+`COMPLETED`, `FAILED`, and `CANCELLED` records for 24 hours by default, using a
+configurable adapter-local TTL and opportunistic eviction on repository access.
+`RUNNING`, `PENDING_APPROVAL`, and `RESUMING` records never expire, so cleanup
+cannot invalidate an active execution or resumable approval. After a terminal
+record expires, its `run_id` is unknown and may be registered again; the TTL is
+therefore also the in-memory adapter's idempotency and status-query retention
+window. This policy does not change the `RunRepository` protocol: applications
+that need different retention inject another configured or persistent adapter.
+
 Run status changes cross the same boundary through `transition_if_allowed`.
 Checking whether a transition is legal and applying it are one repository
 operation, so completion and cancellation cannot both win against the same

--- a/src/agent_engine/runs/in_memory.py
+++ b/src/agent_engine/runs/in_memory.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
-import heapq
 import math
 import time
+from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from agent_engine.approvals.errors import InvalidStateTransition
 from agent_engine.approvals.models import (
@@ -15,6 +15,8 @@ from agent_engine.approvals.models import (
 )
 
 DEFAULT_TERMINAL_RUN_TTL_SECONDS = 86_400.0  # 24 hours
+
+_EXPIRATION_CLEANUP_BATCH_SIZE = 8
 
 _TERMINAL_RUN_STATUSES = frozenset(
     {
@@ -25,13 +27,22 @@ _TERMINAL_RUN_STATUSES = frozenset(
 )
 
 
+@dataclass(slots=True)
+class _StoredRun:
+    record: RunRecord
+    expires_at: float | None = None
+
+
 class InMemoryRunRepository:
     """Process-local implementation of :class:`RunRepository`.
 
-    Operations are serialized only inside this Python process. The adapter is
-    adequate for local use and tests, but it does not provide cross-pod
-    registration or transition guarantees. Terminal records are retained for
-    ``terminal_ttl_seconds``; active and approval-pending records do not expire.
+    This adapter assumes every call for an instance runs on one asyncio event
+    loop and OS thread. Repository mutations contain no ``await`` points, so a
+    coroutine cannot interleave with a check-and-mutate sequence. The adapter is
+    not safe to share across threads or event loops and provides no cross-process
+    guarantees. Terminal records are retained for ``terminal_ttl_seconds``;
+    active and approval-pending records do not expire. An injected ``clock``
+    must be monotonic so the bounded FIFO cleanup queue stays expiration-ordered.
     """
 
     def __init__(
@@ -42,59 +53,75 @@ class InMemoryRunRepository:
     ) -> None:
         if not math.isfinite(terminal_ttl_seconds) or terminal_ttl_seconds <= 0:
             raise ValueError("terminal_ttl_seconds must be a positive finite number")
-        self._runs: dict[str, RunRecord] = {}
-        self._terminal_expirations: list[tuple[float, str]] = []
-        self._lock = asyncio.Lock()
+        self._runs: dict[str, _StoredRun] = {}
+        self._expiration_queue: deque[tuple[float, str]] = deque()
         self._terminal_ttl_seconds = terminal_ttl_seconds
         self._clock = clock or time.monotonic
 
     async def create_if_absent(self, record: RunRecord) -> bool:
         """Register ``record`` unless its ``run_id`` is already known.
 
-        The existence check and write share one process-local critical section,
-        so exactly one local caller gets ``created=True``. A future shared
-        implementation provides the same contract with its own atomic primitive.
+        The check and insert contain no suspension point, so exactly one caller
+        on the owning event loop gets ``created=True``. A future shared adapter
+        provides the same contract with its own atomic primitive.
         """
-        async with self._lock:
-            now = self._clock()
-            self._evict_expired(now)
-            existing = self._runs.get(record.run_id)
-            if existing is not None:
-                return False
-            self._runs[record.run_id] = record
-            if record.status in _TERMINAL_RUN_STATUSES:
-                self._schedule_expiration(record.run_id, now)
-            return True
+        run_id = record.run_id
+        if run_id in self._runs:
+            return False
+
+        expires_at = (
+            self._clock() + self._terminal_ttl_seconds
+            if record.status in _TERMINAL_RUN_STATUSES
+            else None
+        )
+        entry = _StoredRun(record=record, expires_at=expires_at)
+        self._runs[run_id] = entry
+        if expires_at is not None:
+            self._expiration_queue.append((expires_at, run_id))
+        return True
 
     async def get(self, run_id: str) -> RunRecord | None:
-        async with self._lock:
-            self._evict_expired(self._clock())
-            return self._runs.get(run_id)
+        entry = self._get_unexpired_entry(run_id)
+        return None if entry is None else entry.record
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
-        async with self._lock:
-            now = self._clock()
-            self._evict_expired(now)
-            record = self._runs.get(run_id)
-            if record is None:
-                return False
+        now = self._clock()
+        entry = self._get_unexpired_entry(run_id, now)
+        changed = False
+        if entry is not None:
             try:
-                record.transition(target)
+                entry.record.transition(target)
             except InvalidStateTransition:
-                return False
-            if target in _TERMINAL_RUN_STATUSES:
-                self._schedule_expiration(run_id, now)
-            return True
+                pass
+            else:
+                changed = True
+                if target in _TERMINAL_RUN_STATUSES:
+                    entry.expires_at = now + self._terminal_ttl_seconds
+                    self._expiration_queue.append((entry.expires_at, run_id))
+        self._evict_expired_batch(now)
+        return changed
 
-    def _schedule_expiration(self, run_id: str, now: float) -> None:
-        heapq.heappush(
-            self._terminal_expirations,
-            (now + self._terminal_ttl_seconds, run_id),
-        )
+    def _get_unexpired_entry(self, run_id: str, now: float | None = None) -> _StoredRun | None:
+        entry = self._runs.get(run_id)
+        if (
+            entry is not None
+            and entry.expires_at is not None
+            and entry.expires_at <= (self._clock() if now is None else now)
+            and entry.record.status in _TERMINAL_RUN_STATUSES
+        ):
+            self._runs.pop(run_id)
+            return None
+        return entry
 
-    def _evict_expired(self, now: float) -> None:
-        while self._terminal_expirations and self._terminal_expirations[0][0] <= now:
-            _, run_id = heapq.heappop(self._terminal_expirations)
-            record = self._runs.get(run_id)
-            if record is not None and record.status in _TERMINAL_RUN_STATUSES:
+    def _evict_expired_batch(self, now: float) -> None:
+        for _ in range(_EXPIRATION_CLEANUP_BATCH_SIZE):
+            if not self._expiration_queue or self._expiration_queue[0][0] > now:
+                return
+            expires_at, run_id = self._expiration_queue.popleft()
+            current_entry = self._runs.get(run_id)
+            if (
+                current_entry is not None
+                and current_entry.expires_at == expires_at
+                and current_entry.record.status in _TERMINAL_RUN_STATUSES
+            ):
                 self._runs.pop(run_id)

--- a/src/agent_engine/runs/in_memory.py
+++ b/src/agent_engine/runs/in_memory.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
+import math
+import time
+from collections.abc import Callable
 
 from agent_engine.approvals.errors import InvalidStateTransition
 from agent_engine.approvals.models import (
     RunRecord,
     RunStatus,
+)
+
+DEFAULT_TERMINAL_RUN_TTL_SECONDS = 86_400.0  # 24 hours
+
+_TERMINAL_RUN_STATUSES = frozenset(
+    {
+        RunStatus.COMPLETED,
+        RunStatus.FAILED,
+        RunStatus.CANCELLED,
+    }
 )
 
 
@@ -16,12 +30,23 @@ class InMemoryRunRepository:
 
     Operations are serialized only inside this Python process. The adapter is
     adequate for local use and tests, but it does not provide cross-pod
-    registration or transition guarantees.
+    registration or transition guarantees. Terminal records are retained for
+    ``terminal_ttl_seconds``; active and approval-pending records do not expire.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        terminal_ttl_seconds: float = DEFAULT_TERMINAL_RUN_TTL_SECONDS,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if not math.isfinite(terminal_ttl_seconds) or terminal_ttl_seconds <= 0:
+            raise ValueError("terminal_ttl_seconds must be a positive finite number")
         self._runs: dict[str, RunRecord] = {}
+        self._terminal_expirations: list[tuple[float, str]] = []
         self._lock = asyncio.Lock()
+        self._terminal_ttl_seconds = terminal_ttl_seconds
+        self._clock = clock or time.monotonic
 
     async def create_if_absent(self, record: RunRecord) -> bool:
         """Register ``record`` unless its ``run_id`` is already known.
@@ -31,18 +56,25 @@ class InMemoryRunRepository:
         implementation provides the same contract with its own atomic primitive.
         """
         async with self._lock:
+            now = self._clock()
+            self._evict_expired(now)
             existing = self._runs.get(record.run_id)
             if existing is not None:
                 return False
             self._runs[record.run_id] = record
+            if record.status in _TERMINAL_RUN_STATUSES:
+                self._schedule_expiration(record.run_id, now)
             return True
 
     async def get(self, run_id: str) -> RunRecord | None:
         async with self._lock:
+            self._evict_expired(self._clock())
             return self._runs.get(run_id)
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
         async with self._lock:
+            now = self._clock()
+            self._evict_expired(now)
             record = self._runs.get(run_id)
             if record is None:
                 return False
@@ -50,4 +82,19 @@ class InMemoryRunRepository:
                 record.transition(target)
             except InvalidStateTransition:
                 return False
+            if target in _TERMINAL_RUN_STATUSES:
+                self._schedule_expiration(run_id, now)
             return True
+
+    def _schedule_expiration(self, run_id: str, now: float) -> None:
+        heapq.heappush(
+            self._terminal_expirations,
+            (now + self._terminal_ttl_seconds, run_id),
+        )
+
+    def _evict_expired(self, now: float) -> None:
+        while self._terminal_expirations and self._terminal_expirations[0][0] <= now:
+            _, run_id = heapq.heappop(self._terminal_expirations)
+            record = self._runs.get(run_id)
+            if record is not None and record.status in _TERMINAL_RUN_STATUSES:
+                self._runs.pop(run_id)

--- a/tests/runs/test_repository.py
+++ b/tests/runs/test_repository.py
@@ -8,7 +8,10 @@ import math
 import pytest
 
 from agent_engine.approvals.models import RunRecord, RunStatus
-from agent_engine.runs.in_memory import InMemoryRunRepository
+from agent_engine.runs.in_memory import (
+    _EXPIRATION_CLEANUP_BATCH_SIZE,
+    InMemoryRunRepository,
+)
 from agent_engine.runs.repository import RunRepository
 
 pytestmark = pytest.mark.asyncio
@@ -31,8 +34,13 @@ def run_repository() -> RunRepository:
     return InMemoryRunRepository()
 
 
-def _run(run_id: str, *, system_name: str = "system") -> RunRecord:
-    return RunRecord(run_id=run_id, thread_id=run_id, system_name=system_name)
+def _run(
+    run_id: str,
+    *,
+    system_name: str = "system",
+    status: RunStatus = RunStatus.RUNNING,
+) -> RunRecord:
+    return RunRecord(run_id=run_id, thread_id=run_id, system_name=system_name, status=status)
 
 
 async def test_in_memory_run_repository_implements_contract() -> None:
@@ -78,16 +86,45 @@ async def test_run_repository_registers_different_ids(
     assert await run_repository.get("r2") is not None
 
 
-async def test_in_memory_run_registration_has_one_process_local_winner() -> None:
+async def test_many_concurrent_run_registrations_have_one_winner() -> None:
     repository = InMemoryRunRepository()
-
-    async def register(index: int) -> bool:
-        return await repository.create_if_absent(_run("shared", system_name=f"system-{index}"))
-
-    results = await asyncio.gather(*(register(index) for index in range(20)))
+    results = await asyncio.gather(
+        *(
+            repository.create_if_absent(_run("shared", system_name=f"system-{index}"))
+            for index in range(100)
+        )
+    )
 
     assert sum(results) == 1
     assert await repository.get("shared") is not None
+
+
+async def test_concurrent_creates_for_unrelated_runs_all_succeed() -> None:
+    repository = InMemoryRunRepository()
+    run_ids = [f"run-{index}" for index in range(100)]
+
+    results = await asyncio.gather(
+        *(repository.create_if_absent(_run(run_id)) for run_id in run_ids)
+    )
+    stored = await asyncio.gather(*(repository.get(run_id) for run_id in run_ids))
+
+    assert all(results)
+    assert all(record is not None for record in stored)
+
+
+async def test_transition_and_duplicate_create_for_same_run_are_safe() -> None:
+    repository = InMemoryRunRepository()
+    original = _run("shared", system_name="original")
+    await repository.create_if_absent(original)
+    duplicate_result, transition_result = await asyncio.gather(
+        repository.create_if_absent(_run("shared", system_name="replacement")),
+        repository.transition_if_allowed("shared", RunStatus.COMPLETED),
+    )
+
+    assert duplicate_result is False
+    assert transition_result is True
+    assert await repository.get("shared") == original
+    assert original.status == RunStatus.COMPLETED
 
 
 async def test_transition_if_allowed_is_a_single_process_local_operation() -> None:
@@ -163,11 +200,81 @@ async def test_expired_run_id_can_be_registered_again() -> None:
     await repository.create_if_absent(original)
     await repository.transition_if_allowed("reused", RunStatus.COMPLETED)
     clock.advance(1)
+    assert await repository.get("reused") is None
 
     replacement = _run("reused", system_name="replacement")
 
     assert await repository.create_if_absent(replacement) is True
     assert await repository.get("reused") == replacement
+
+
+async def test_existing_run_registration_preserves_original_expiration() -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=10, clock=clock)
+    original = _run("finished", system_name="original")
+    await repository.create_if_absent(original)
+    await repository.transition_if_allowed("finished", RunStatus.COMPLETED)
+    clock.advance(5)
+    original_entry = repository._runs["finished"]
+    original_expiration = original_entry.expires_at
+    original_queue = tuple(repository._expiration_queue)
+
+    created = await repository.create_if_absent(_run("finished", system_name="replacement"))
+
+    assert created is False
+    assert repository._runs["finished"] is original_entry
+    assert original_entry.expires_at == original_expiration
+    assert tuple(repository._expiration_queue) == original_queue
+    clock.advance(4)
+    assert await repository.get("finished") == original
+    clock.advance(1)
+    assert await repository.get("finished") is None
+
+
+async def test_create_if_absent_does_not_evict_expired_records() -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=1, clock=clock)
+    expired = _run("expired")
+    await repository.create_if_absent(expired)
+    await repository.transition_if_allowed("expired", RunStatus.COMPLETED)
+    clock.advance(1)
+
+    assert await repository.create_if_absent(_run("expired")) is False
+    assert await repository.create_if_absent(_run("new")) is True
+    assert repository._runs["expired"].record is expired
+
+    assert await repository.get("expired") is None
+
+
+async def test_stale_expiration_cannot_delete_newer_record() -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=1, clock=clock)
+    original = _run("reused", status=RunStatus.COMPLETED)
+    await repository.create_if_absent(original)
+    clock.advance(1)
+    assert await repository.get("reused") is None
+
+    replacement = _run("reused")
+    assert await repository.create_if_absent(replacement) is True
+    assert await repository.transition_if_allowed("reused", RunStatus.COMPLETED) is True
+
+    assert await repository.get("reused") is replacement
+
+
+async def test_expiration_cleanup_work_is_bounded_per_transition() -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=1, clock=clock)
+    expired_count = 100
+    for index in range(expired_count):
+        await repository.create_if_absent(_run(f"expired-{index}", status=RunStatus.COMPLETED))
+    clock.advance(1)
+
+    assert await repository.transition_if_allowed("missing", RunStatus.COMPLETED) is False
+
+    remaining_expired = sum(run_id.startswith("expired-") for run_id in repository._runs)
+    removed = expired_count - remaining_expired
+    assert 0 < removed <= _EXPIRATION_CLEANUP_BATCH_SIZE
+    assert len(repository._expiration_queue) > 0
 
 
 @pytest.mark.parametrize("ttl", [0, -1, math.inf, math.nan])

--- a/tests/runs/test_repository.py
+++ b/tests/runs/test_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 
 import pytest
 
@@ -11,6 +12,17 @@ from agent_engine.runs.in_memory import InMemoryRunRepository
 from agent_engine.runs.repository import RunRepository
 
 pytestmark = pytest.mark.asyncio
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
 
 
 @pytest.fixture
@@ -104,3 +116,61 @@ async def test_transition_if_allowed_leaves_missing_or_terminal_runs_unchanged()
     stored = await repository.get("finished")
     assert stored is not None
     assert stored.status == RunStatus.COMPLETED
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED],
+)
+async def test_terminal_runs_expire_after_configured_ttl(terminal_status: RunStatus) -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=60, clock=clock)
+    record = _run("finished")
+    await repository.create_if_absent(record)
+    assert await repository.transition_if_allowed("finished", terminal_status) is True
+
+    clock.advance(59)
+    assert await repository.get("finished") == record
+
+    clock.advance(1)
+    assert await repository.get("finished") is None
+
+
+@pytest.mark.parametrize(
+    "active_status",
+    [RunStatus.RUNNING, RunStatus.PENDING_APPROVAL, RunStatus.RESUMING],
+)
+async def test_active_runs_do_not_expire(active_status: RunStatus) -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=1, clock=clock)
+    record = RunRecord(
+        run_id="active",
+        thread_id="active",
+        system_name="system",
+        status=active_status,
+    )
+    await repository.create_if_absent(record)
+
+    clock.advance(10)
+
+    assert await repository.get("active") == record
+
+
+async def test_expired_run_id_can_be_registered_again() -> None:
+    clock = ManualClock()
+    repository = InMemoryRunRepository(terminal_ttl_seconds=1, clock=clock)
+    original = _run("reused", system_name="original")
+    await repository.create_if_absent(original)
+    await repository.transition_if_allowed("reused", RunStatus.COMPLETED)
+    clock.advance(1)
+
+    replacement = _run("reused", system_name="replacement")
+
+    assert await repository.create_if_absent(replacement) is True
+    assert await repository.get("reused") == replacement
+
+
+@pytest.mark.parametrize("ttl", [0, -1, math.inf, math.nan])
+async def test_terminal_run_ttl_must_be_positive_and_finite(ttl: float) -> None:
+    with pytest.raises(ValueError, match="positive finite"):
+        InMemoryRunRepository(terminal_ttl_seconds=ttl)


### PR DESCRIPTION
Why cleanup is not a background process
I intentionally kept TTL cleanup opportunistic instead of starting a background task.
The repository uses a min-heap ordered by expiration time. During normal access, cleanup only checks the first heap entry, so the common case is effectively O(1) and does not scan the run dictionary.
A background task would require explicit startup and shutdown ownership. RunRepository currently has no lifecycle methods, and silently creating an asyncio task inside the in-memory adapter could:
bind the repository to the wrong event loop;
leave pending tasks during shutdown or tests;
require additional cancellation and error-handling logic;
expand the repository abstraction solely for an in-memory implementation.
Opportunistic cleanup keeps the existing RunRepository contract unchanged, avoids unmanaged asynchronous tasks, and performs expiration under the same lock as repository operations, preserving atomic behavior.
If profiling later shows latency spikes from many records expiring simultaneously, cleanup can be bounded per operation or moved to an explicitly managed maintenance service with a well-defined startup/shutdown lifecycle.