### PR TITLE
fix(config): rename AGENT_env vars to EXTRA_ with backward-compat deprecation warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,11 +17,11 @@ ANTHROPIC_API_KEY=your-anthropic-key-here
 #              Needs the manager served from the host's origin.
 #   mint       the host mints a short-lived token for us from a shared secret.
 #
-# AGENT_AUTH_MODE=host_token
-# AGENT_AUTH_SECRET=copy-the-hosts-jwt-secret-here-32-chars-min
-# AGENT_AUTH_CLAIM_USER_ID=id
-# AGENT_AUTH_COOKIE=token
+# EXTRA_AUTH_MODE=host_token
+# EXTRA_AUTH_SECRET=copy-the-hosts-jwt-secret-here-32-chars-min
+# EXTRA_AUTH_CLAIM_USER_ID=id
+# EXTRA_AUTH_COOKIE=token
 #
-# Signs the visitor passes we issue. Derived from AGENT_AUTH_SECRET when unset;
+# Signs the visitor passes we issue. Derived from EXTRA_AUTH_SECRET when unset;
 # set it explicitly in production so passes survive a secret rotation.
-# AGENT_AUTH_ANONYMOUS_SECRET=a-separate-secret-32-characters-minimum
+# EXTRA_AUTH_ANONYMOUS_SECRET=a-separate-secret-32-characters-minimum

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -97,7 +97,7 @@ Identity arrives as a signed JWT, in either of two places:
 
 - `Authorization: Bearer <token>` — a token the host app minted, or a visitor
   pass the manager issued.
-- The host's own session cookie, named by `AGENT_AUTH_COOKIE`, when the manager
+- The host's own session cookie, named by `EXTRA_AUTH_COOKIE`, when the manager
   is served from the host's origin.
 
 See [Identity](/docs/identity) for how a host product is wired up, including the

--- a/docs/identity.mdx
+++ b/docs/identity.mdx
@@ -40,9 +40,9 @@ Serve Extra from a path on the site your users already sign into — say
 `acme.com/agents` — and it reads the session they already have.
 
 ```bash
-AGENT_AUTH_MODE=host_token
-AGENT_AUTH_SECRET=${YOUR_JWT_SECRET}   # the key your app already signs with
-AGENT_AUTH_COOKIE=session              # your session cookie's name
+EXTRA_AUTH_MODE=host_token
+EXTRA_AUTH_SECRET=${YOUR_JWT_SECRET}   # the key your app already signs with
+EXTRA_AUTH_COOKIE=session              # your session cookie's name
 ```
 
 ```html
@@ -56,7 +56,7 @@ verifies it with your own secret.
 <Note>
 Works with any app that issues a session JWT — Open WebUI, Django, Rails, most
 Node stacks. If your user id isn't in the `sub` claim, set
-`AGENT_AUTH_CLAIM_USER_ID`.
+`EXTRA_AUTH_CLAIM_USER_ID`.
 </Note>
 
 ---
@@ -69,7 +69,7 @@ vouches for the user instead.
 ```js
 app.get("/agent-chat/token", requireLogin, (req, res) => {
   res.json({
-    token: jwt.sign({ sub: req.user.id }, process.env.AGENT_CHAT_SECRET, {
+    token: jwt.sign({ sub: req.user.id }, process.env.EXTRA_AUTH_SECRET, {
       expiresIn: "1h", // required: tokens minted for us must expire
     }),
   });
@@ -77,8 +77,8 @@ app.get("/agent-chat/token", requireLogin, (req, res) => {
 ```
 
 ```bash
-AGENT_AUTH_MODE=mint
-AGENT_AUTH_SECRET=<32+ random characters>
+EXTRA_AUTH_MODE=mint
+EXTRA_AUTH_SECRET=<32+ random characters>
 ```
 
 ```html
@@ -113,12 +113,12 @@ user out — and, in a single-page app, when it signs one *in* without a reload.
 
 | Variable | Default | |
 |---|---|---|
-| `AGENT_AUTH_MODE` | `anonymous` | `anonymous`, `host_token`, or `mint` |
-| `AGENT_AUTH_SECRET` | — | Signing key, 32+ characters. Required unless anonymous |
-| `AGENT_AUTH_COOKIE` | — | Your session cookie's name (`host_token` only) |
-| `AGENT_AUTH_CLAIM_USER_ID` | `sub` | Claim holding the user id. Also `_EMAIL`, `_DISPLAY_NAME`, `_ROLES` |
-| `AGENT_AUTH_MAX_TTL_SECONDS` | `3600` | Longest token accepted in `mint` mode |
-| `AGENT_AUTH_ANONYMOUS_SECRET` | derived | Signs anonymous passes. Set it to survive a secret rotation |
+| `EXTRA_AUTH_MODE` | `anonymous` | `anonymous`, `host_token`, or `mint` |
+| `EXTRA_AUTH_SECRET` | — | Signing key, 32+ characters. Required unless anonymous |
+| `EXTRA_AUTH_COOKIE` | — | Your session cookie's name (`host_token` only) |
+| `EXTRA_AUTH_CLAIM_USER_ID` | `sub` | Claim holding the user id. Also `_EMAIL`, `_DISPLAY_NAME`, `_ROLES` |
+| `EXTRA_AUTH_MAX_TTL_SECONDS` | `3600` | Longest token accepted in `mint` mode |
+| `EXTRA_AUTH_ANONYMOUS_SECRET` | derived | Signs anonymous passes. Set it to survive a secret rotation |
 
-Rotating `AGENT_AUTH_SECRET` is safe: widgets fetch a fresh token on their next
+Rotating `EXTRA_AUTH_SECRET` is safe: widgets fetch a fresh token on their next
 request.

--- a/examples/starter/.env.example
+++ b/examples/starter/.env.example
@@ -29,8 +29,12 @@ OPENAI_BASE_URL=http://host.docker.internal:11434/v1
 # budget is so the user sees it coming.
 # CONTEXT_MAX_TOKENS=2000
 
+# Optional — storage configuration (defaults to SQLite chat.db):
+# EXTRA_DB_BACKEND=postgres
+# EXTRA_DB_URL=postgresql://user:pass@host/db
+
 # Optional — the starter runs anonymously: each browser gets a signed visitor
 # pass and its own conversations, with nothing to configure. To tie chats to
 # your product's real users instead, see docs/identity.mdx.
-# AGENT_AUTH_MODE=host_token
-# AGENT_AUTH_SECRET=copy-your-apps-jwt-secret-here-32-chars-min
+# EXTRA_AUTH_MODE=host_token
+# EXTRA_AUTH_SECRET=copy-your-apps-jwt-secret-here-32-chars-min

--- a/src/agent_manager/api/app.py
+++ b/src/agent_manager/api/app.py
@@ -64,7 +64,7 @@ def create_app(config_path: str, settings: Settings | None = None) -> FastAPI:
     app = FastAPI(lifespan=lifespan)
     app.state.caller_identity = CallerIdentity(
         resolver=build_identity_resolver(settings),
-        cookie_name=settings.agent_auth_cookie,
+        cookie_name=settings.extra_auth_cookie,
     )
 
     @app.get("/health")

--- a/src/agent_manager/composition.py
+++ b/src/agent_manager/composition.py
@@ -50,7 +50,7 @@ def build_identity_resolver(settings: Settings) -> IdentityResolver:
     return IdentityResolver(
         anonymous=AnonymousIdentitySource(
             anonymous_secret(settings),
-            ttl_seconds=settings.agent_auth_anonymous_ttl_seconds,
+            ttl_seconds=settings.extra_auth_anonymous_ttl_seconds,
         ),
         host=_build_host_identity_source(settings),
     )
@@ -59,45 +59,45 @@ def build_identity_resolver(settings: Settings) -> IdentityResolver:
 def anonymous_secret(settings: Settings) -> str:
     """Derived from the host secret rather than reused, so a host that can mint
     tokens still cannot mint passes."""
-    if settings.agent_auth_anonymous_secret:
-        return settings.agent_auth_anonymous_secret
-    if settings.agent_auth_secret:
+    if settings.extra_auth_anonymous_secret:
+        return settings.extra_auth_anonymous_secret
+    if settings.extra_auth_secret:
         return hmac.new(
-            settings.agent_auth_secret.encode(),
+            settings.extra_auth_secret.encode(),
             ANONYMOUS_KEY_DERIVATION_INFO,
             hashlib.sha256,
         ).hexdigest()
     logger.warning(
-        "No AGENT_AUTH_SECRET or AGENT_AUTH_ANONYMOUS_SECRET set;"
+        "No EXTRA_AUTH_SECRET or EXTRA_AUTH_ANONYMOUS_SECRET set;"
         " signing visitor passes with an ephemeral key that will not survive a restart."
     )
     return secrets.token_hex(EPHEMERAL_SECRET_BYTES)
 
 
 def _build_host_identity_source(settings: Settings) -> IdentitySource | None:
-    if settings.agent_auth_mode is AuthMode.ANONYMOUS:
+    if settings.extra_auth_mode is AuthMode.ANONYMOUS:
         return None
-    if not settings.agent_auth_secret:
-        raise ValueError(f"AGENT_AUTH_SECRET is required for auth mode {settings.agent_auth_mode}")
+    if not settings.extra_auth_secret:
+        raise ValueError(f"EXTRA_AUTH_SECRET is required for auth mode {settings.extra_auth_mode}")
 
-    mints_for_us = settings.agent_auth_mode is AuthMode.MINT
+    mints_for_us = settings.extra_auth_mode is AuthMode.MINT
     verifier = TokenVerifier(
-        StaticSecretKeySource(settings.agent_auth_secret),
+        StaticSecretKeySource(settings.extra_auth_secret),
         TokenPolicy(
-            issuer=settings.agent_auth_issuer,
-            audience=settings.agent_auth_audience,
+            issuer=settings.extra_auth_issuer,
+            audience=settings.extra_auth_audience,
             require_expiry=mints_for_us,
-            max_ttl_seconds=settings.agent_auth_max_ttl_seconds if mints_for_us else None,
+            max_ttl_seconds=settings.extra_auth_max_ttl_seconds if mints_for_us else None,
         ),
     )
     return HostIdentitySource(
         verifier,
         ClaimMapping(
-            user_id=settings.agent_auth_claim_user_id,
-            email=settings.agent_auth_claim_email,
-            display_name=settings.agent_auth_claim_display_name,
-            roles=settings.agent_auth_claim_roles,
-            organization_id=settings.agent_auth_claim_organization_id,
+            user_id=settings.extra_auth_claim_user_id,
+            email=settings.extra_auth_claim_email,
+            display_name=settings.extra_auth_claim_display_name,
+            roles=settings.extra_auth_claim_roles,
+            organization_id=settings.extra_auth_claim_organization_id,
         ),
     )
 

--- a/src/agent_manager/config.py
+++ b/src/agent_manager/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import warnings
 from enum import StrEnum
 from typing import Annotated, Any, Literal
 
@@ -10,6 +12,36 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 ONE_HOUR_SECONDS = 3_600
 THIRTY_DAYS_SECONDS = 2_592_000
+
+_DEPRECATED_ENV_VARS: tuple[tuple[str, str, str], ...] = (
+    ("AGENT_DB_BACKEND", "EXTRA_DB_BACKEND", "extra_db_backend"),
+    ("AGENT_DB_URL", "EXTRA_DB_URL", "extra_db_url"),
+    ("AGENT_AUTH_MODE", "EXTRA_AUTH_MODE", "extra_auth_mode"),
+    ("AGENT_AUTH_SECRET", "EXTRA_AUTH_SECRET", "extra_auth_secret"),
+    ("AGENT_AUTH_ANONYMOUS_SECRET", "EXTRA_AUTH_ANONYMOUS_SECRET", "extra_auth_anonymous_secret"),
+    (
+        "AGENT_AUTH_ANONYMOUS_TTL_SECONDS",
+        "EXTRA_AUTH_ANONYMOUS_TTL_SECONDS",
+        "extra_auth_anonymous_ttl_seconds",
+    ),
+    ("AGENT_AUTH_MAX_TTL_SECONDS", "EXTRA_AUTH_MAX_TTL_SECONDS", "extra_auth_max_ttl_seconds"),
+    ("AGENT_AUTH_ISSUER", "EXTRA_AUTH_ISSUER", "extra_auth_issuer"),
+    ("AGENT_AUTH_AUDIENCE", "EXTRA_AUTH_AUDIENCE", "extra_auth_audience"),
+    ("AGENT_AUTH_COOKIE", "EXTRA_AUTH_COOKIE", "extra_auth_cookie"),
+    ("AGENT_AUTH_CLAIM_USER_ID", "EXTRA_AUTH_CLAIM_USER_ID", "extra_auth_claim_user_id"),
+    ("AGENT_AUTH_CLAIM_EMAIL", "EXTRA_AUTH_CLAIM_EMAIL", "extra_auth_claim_email"),
+    (
+        "AGENT_AUTH_CLAIM_DISPLAY_NAME",
+        "EXTRA_AUTH_CLAIM_DISPLAY_NAME",
+        "extra_auth_claim_display_name",
+    ),
+    ("AGENT_AUTH_CLAIM_ROLES", "EXTRA_AUTH_CLAIM_ROLES", "extra_auth_claim_roles"),
+    (
+        "AGENT_AUTH_CLAIM_ORGANIZATION_ID",
+        "EXTRA_AUTH_CLAIM_ORGANIZATION_ID",
+        "extra_auth_claim_organization_id",
+    ),
+)
 
 
 class AuthMode(StrEnum):
@@ -37,8 +69,8 @@ def normalize_database_url(url: str, backend: str) -> str:
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-    agent_db_backend: Literal["sqlite", "postgres"] = "sqlite"
-    agent_db_url: str | None = None
+    extra_db_backend: Literal["sqlite", "postgres"] = "sqlite"
+    extra_db_url: str | None = None
     database_url: str = "sqlite+aiosqlite:///chat.db"
     context_window: int = 10
     context_max_chars: int | None = None
@@ -50,23 +82,50 @@ class Settings(BaseSettings):
     # e.g. CORS_ORIGINS=https://acmecorp.com,https://www.acmecorp.com
     cors_origins: Annotated[list[str], NoDecode] = []
 
-    agent_auth_mode: AuthMode = AuthMode.ANONYMOUS
-    agent_auth_secret: str | None = None
-    # Derived from `agent_auth_secret` when unset, so visitor passes are never
+    extra_auth_mode: AuthMode = AuthMode.ANONYMOUS
+    extra_auth_secret: str | None = None
+    # Derived from `extra_auth_secret` when unset, so visitor passes are never
     # signed with the host's key.
-    agent_auth_anonymous_secret: str | None = None
-    agent_auth_anonymous_ttl_seconds: int = THIRTY_DAYS_SECONDS
-    agent_auth_max_ttl_seconds: int = ONE_HOUR_SECONDS
-    agent_auth_issuer: str | None = None
-    agent_auth_audience: str | None = None
+    extra_auth_anonymous_secret: str | None = None
+    extra_auth_anonymous_ttl_seconds: int = THIRTY_DAYS_SECONDS
+    extra_auth_max_ttl_seconds: int = ONE_HOUR_SECONDS
+    extra_auth_issuer: str | None = None
+    extra_auth_audience: str | None = None
     # Name of the host's session cookie. Only reachable when the manager is
     # served from the host's own origin — see `get_principal`.
-    agent_auth_cookie: str | None = None
-    agent_auth_claim_user_id: str = "sub"
-    agent_auth_claim_email: str = "email"
-    agent_auth_claim_display_name: str = "name"
-    agent_auth_claim_roles: str = "roles"
-    agent_auth_claim_organization_id: str = "org_id"
+    extra_auth_cookie: str | None = None
+    extra_auth_claim_user_id: str = "sub"
+    extra_auth_claim_email: str = "email"
+    extra_auth_claim_display_name: str = "name"
+    extra_auth_claim_roles: str = "roles"
+    extra_auth_claim_organization_id: str = "org_id"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _backfill_deprecated_agent_vars(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+        for old_env, new_env, new_key in _DEPRECATED_ENV_VARS:
+            if new_key in data:
+                continue
+            old_key = old_env.lower()
+            if old_key in data:
+                warnings.warn(
+                    f"{old_key} is deprecated; rename it to {new_key}.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                data[new_key] = data[old_key]
+                continue
+            old_val = os.getenv(old_env)
+            if old_val is not None:
+                warnings.warn(
+                    f"{old_env} is deprecated; rename it to {new_env}.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                data[new_key] = old_val
+        return data
 
     @field_validator("cors_origins", mode="before")
     @classmethod
@@ -75,9 +134,9 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _require_secret_for_host_identity(self) -> Settings:
-        if self.agent_auth_mode is not AuthMode.ANONYMOUS and not self.agent_auth_secret:
+        if self.extra_auth_mode is not AuthMode.ANONYMOUS and not self.extra_auth_secret:
             raise ValueError(
-                f"AGENT_AUTH_SECRET is required when AGENT_AUTH_MODE={self.agent_auth_mode}"
+                f"EXTRA_AUTH_SECRET is required when EXTRA_AUTH_MODE={self.extra_auth_mode}"
             )
         return self
 
@@ -89,4 +148,4 @@ class Settings(BaseSettings):
 
     @property
     def effective_database_url(self) -> str:
-        return normalize_database_url(self.agent_db_url or self.database_url, self.agent_db_backend)
+        return normalize_database_url(self.extra_db_url or self.database_url, self.extra_db_backend)

--- a/src/agent_manager/config.py
+++ b/src/agent_manager/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import warnings
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NamedTuple
 
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -13,30 +13,43 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 ONE_HOUR_SECONDS = 3_600
 THIRTY_DAYS_SECONDS = 2_592_000
 
-_DEPRECATED_ENV_VARS: tuple[tuple[str, str, str], ...] = (
-    ("AGENT_DB_BACKEND", "EXTRA_DB_BACKEND", "extra_db_backend"),
-    ("AGENT_DB_URL", "EXTRA_DB_URL", "extra_db_url"),
-    ("AGENT_AUTH_MODE", "EXTRA_AUTH_MODE", "extra_auth_mode"),
-    ("AGENT_AUTH_SECRET", "EXTRA_AUTH_SECRET", "extra_auth_secret"),
-    ("AGENT_AUTH_ANONYMOUS_SECRET", "EXTRA_AUTH_ANONYMOUS_SECRET", "extra_auth_anonymous_secret"),
-    (
+
+class _EnvAlias(NamedTuple):
+    """Maps one deprecated environment variable name to its canonical replacement."""
+
+    old: str  # e.g. "AGENT_AUTH_MODE"  — the legacy env var operators may still have set
+    new: str  # e.g. "EXTRA_AUTH_MODE"  — the canonical env var they should migrate to
+    field: str  # e.g. "extra_auth_mode"  — the pydantic Settings field name
+
+
+_DEPRECATED_ENV_VARS: tuple[_EnvAlias, ...] = (
+    _EnvAlias("AGENT_DB_BACKEND", "EXTRA_DB_BACKEND", "extra_db_backend"),
+    _EnvAlias("AGENT_DB_URL", "EXTRA_DB_URL", "extra_db_url"),
+    _EnvAlias("AGENT_AUTH_MODE", "EXTRA_AUTH_MODE", "extra_auth_mode"),
+    _EnvAlias("AGENT_AUTH_SECRET", "EXTRA_AUTH_SECRET", "extra_auth_secret"),
+    _EnvAlias(
+        "AGENT_AUTH_ANONYMOUS_SECRET", "EXTRA_AUTH_ANONYMOUS_SECRET", "extra_auth_anonymous_secret"
+    ),
+    _EnvAlias(
         "AGENT_AUTH_ANONYMOUS_TTL_SECONDS",
         "EXTRA_AUTH_ANONYMOUS_TTL_SECONDS",
         "extra_auth_anonymous_ttl_seconds",
     ),
-    ("AGENT_AUTH_MAX_TTL_SECONDS", "EXTRA_AUTH_MAX_TTL_SECONDS", "extra_auth_max_ttl_seconds"),
-    ("AGENT_AUTH_ISSUER", "EXTRA_AUTH_ISSUER", "extra_auth_issuer"),
-    ("AGENT_AUTH_AUDIENCE", "EXTRA_AUTH_AUDIENCE", "extra_auth_audience"),
-    ("AGENT_AUTH_COOKIE", "EXTRA_AUTH_COOKIE", "extra_auth_cookie"),
-    ("AGENT_AUTH_CLAIM_USER_ID", "EXTRA_AUTH_CLAIM_USER_ID", "extra_auth_claim_user_id"),
-    ("AGENT_AUTH_CLAIM_EMAIL", "EXTRA_AUTH_CLAIM_EMAIL", "extra_auth_claim_email"),
-    (
+    _EnvAlias(
+        "AGENT_AUTH_MAX_TTL_SECONDS", "EXTRA_AUTH_MAX_TTL_SECONDS", "extra_auth_max_ttl_seconds"
+    ),
+    _EnvAlias("AGENT_AUTH_ISSUER", "EXTRA_AUTH_ISSUER", "extra_auth_issuer"),
+    _EnvAlias("AGENT_AUTH_AUDIENCE", "EXTRA_AUTH_AUDIENCE", "extra_auth_audience"),
+    _EnvAlias("AGENT_AUTH_COOKIE", "EXTRA_AUTH_COOKIE", "extra_auth_cookie"),
+    _EnvAlias("AGENT_AUTH_CLAIM_USER_ID", "EXTRA_AUTH_CLAIM_USER_ID", "extra_auth_claim_user_id"),
+    _EnvAlias("AGENT_AUTH_CLAIM_EMAIL", "EXTRA_AUTH_CLAIM_EMAIL", "extra_auth_claim_email"),
+    _EnvAlias(
         "AGENT_AUTH_CLAIM_DISPLAY_NAME",
         "EXTRA_AUTH_CLAIM_DISPLAY_NAME",
         "extra_auth_claim_display_name",
     ),
-    ("AGENT_AUTH_CLAIM_ROLES", "EXTRA_AUTH_CLAIM_ROLES", "extra_auth_claim_roles"),
-    (
+    _EnvAlias("AGENT_AUTH_CLAIM_ROLES", "EXTRA_AUTH_CLAIM_ROLES", "extra_auth_claim_roles"),
+    _EnvAlias(
         "AGENT_AUTH_CLAIM_ORGANIZATION_ID",
         "EXTRA_AUTH_CLAIM_ORGANIZATION_ID",
         "extra_auth_claim_organization_id",
@@ -59,10 +72,22 @@ class AuthMode(StrEnum):
 
 
 def normalize_database_url(url: str, backend: str) -> str:
-    if backend == "sqlite" and url.startswith("sqlite:///"):
-        return "sqlite+aiosqlite:///" + url.removeprefix("sqlite:///")
-    if backend == "postgres" and url.startswith("postgresql://"):
-        return "postgresql+asyncpg://" + url.removeprefix("postgresql://")
+    if backend == "sqlite":
+        if url.startswith("sqlite:///"):
+            return "sqlite+aiosqlite:///" + url.removeprefix("sqlite:///")
+        if not url.startswith("sqlite+"):
+            raise ValueError(
+                f"EXTRA_DB_URL {url!r} does not look like a sqlite URL "
+                f"(expected 'sqlite:///' or 'sqlite+aiosqlite:///')."
+            )
+    if backend == "postgres":
+        if url.startswith("postgresql://"):
+            return "postgresql+asyncpg://" + url.removeprefix("postgresql://")
+        if not url.startswith("postgresql+"):
+            raise ValueError(
+                f"EXTRA_DB_URL {url!r} does not look like a postgresql URL "
+                f"(expected 'postgresql://' or 'postgresql+asyncpg://')."
+            )
     return url
 
 
@@ -105,26 +130,28 @@ class Settings(BaseSettings):
     def _backfill_deprecated_agent_vars(cls, data: object) -> object:
         if not isinstance(data, dict):
             return data
-        for old_env, new_env, new_key in _DEPRECATED_ENV_VARS:
-            if new_key in data:
+        for alias in _DEPRECATED_ENV_VARS:
+            if alias.field in data:
                 continue
-            old_key = old_env.lower()
+            # Also accept the deprecated name as a Python kwarg (e.g. in tests or
+            # programmatic callers that haven't migrated yet).
+            old_key = alias.old.lower()
             if old_key in data:
                 warnings.warn(
-                    f"{old_key} is deprecated; rename it to {new_key}.",
+                    f"{alias.old} is deprecated; rename it to {alias.new}.",
                     DeprecationWarning,
-                    stacklevel=1,
+                    stacklevel=2,
                 )
-                data[new_key] = data[old_key]
+                data[alias.field] = data[old_key]
                 continue
-            old_val = os.getenv(old_env)
+            old_val = os.getenv(alias.old)
             if old_val is not None:
                 warnings.warn(
-                    f"{old_env} is deprecated; rename it to {new_env}.",
+                    f"{alias.old} is deprecated; rename it to {alias.new}.",
                     DeprecationWarning,
-                    stacklevel=1,
+                    stacklevel=2,
                 )
-                data[new_key] = old_val
+                data[alias.field] = old_val
         return data
 
     @field_validator("cors_origins", mode="before")

--- a/src/agentctl/main.py
+++ b/src/agentctl/main.py
@@ -201,15 +201,15 @@ def token(user: str, ttl: int) -> None:
     from agent_manager.infrastructure.auth import encode_token
 
     settings = Settings()
-    if not settings.agent_auth_secret:
-        click.echo("✗ AGENT_AUTH_SECRET is not set; there is no key to sign with.", err=True)
+    if not settings.extra_auth_secret:
+        click.echo("✗ EXTRA_AUTH_SECRET is not set; there is no key to sign with.", err=True)
         sys.exit(1)
 
     issued = encode_token(
-        settings.agent_auth_secret,
+        settings.extra_auth_secret,
         subject=user,
         ttl_seconds=ttl,
-        claims={settings.agent_auth_claim_user_id: user},
+        claims={settings.extra_auth_claim_user_id: user},
     )
     click.echo(f"  expires: {issued.expires_at.isoformat()}", err=True)
     click.echo(issued.token)

--- a/tests/agent_manager/conftest.py
+++ b/tests/agent_manager/conftest.py
@@ -30,10 +30,10 @@ def build_test_app(service: ConversationService, **settings: Any) -> FastAPI:
     app = FastAPI()
     app.state.service = service
     config = Settings.from_values(
-        **{"agent_auth_mode": AuthMode.MINT, "agent_auth_secret": AUTH_SECRET, **settings}
+        **{"extra_auth_mode": AuthMode.MINT, "extra_auth_secret": AUTH_SECRET, **settings}
     )
     app.state.caller_identity = CallerIdentity(
-        resolver=build_identity_resolver(config), cookie_name=config.agent_auth_cookie
+        resolver=build_identity_resolver(config), cookie_name=config.extra_auth_cookie
     )
     app.include_router(router)
     return app

--- a/tests/agent_manager/test_auth.py
+++ b/tests/agent_manager/test_auth.py
@@ -169,13 +169,13 @@ def _settings(**overrides: Any) -> Settings:
 
 
 def test_host_identity_requires_a_configured_secret() -> None:
-    with pytest.raises(ValidationError, match="AGENT_AUTH_SECRET"):
-        _settings(agent_auth_mode=AuthMode.HOST_TOKEN)
+    with pytest.raises(ValidationError, match="EXTRA_AUTH_SECRET"):
+        _settings(extra_auth_mode=AuthMode.HOST_TOKEN)
 
 
 def test_visitor_passes_are_not_signed_with_the_host_key() -> None:
     """A host that can mint tokens still must not be able to mint passes."""
-    settings = _settings(agent_auth_mode=AuthMode.MINT, agent_auth_secret=SECRET)
+    settings = _settings(extra_auth_mode=AuthMode.MINT, extra_auth_secret=SECRET)
 
     assert anonymous_secret(settings) != SECRET
 

--- a/tests/agent_manager/test_auth.py
+++ b/tests/agent_manager/test_auth.py
@@ -181,6 +181,7 @@ def test_visitor_passes_are_not_signed_with_the_host_key() -> None:
 
 
 def test_a_visitor_pass_round_trips_but_a_host_token_does_not_become_one() -> None:
+    # Intentionally uses deprecated kwarg aliases to verify backward-compat fallback.
     resolver = build_identity_resolver(
         _settings(agent_auth_mode=AuthMode.MINT, agent_auth_secret=SECRET)
     )
@@ -198,6 +199,7 @@ def test_mint_mode_accepts_the_token_our_own_docs_tell_hosts_to_produce() -> Non
     """Pins docs/identity.mdx against the code. The documented snippet signs
     `sub` with `expiresIn`; Node's jsonwebtoken adds `iat` itself. Drop the
     expiry from the docs and mint mode rejects every token a host produces."""
+    # Intentionally uses deprecated kwarg aliases to verify backward-compat fallback.
     resolver = build_identity_resolver(
         _settings(agent_auth_mode=AuthMode.MINT, agent_auth_secret=SECRET)
     )

--- a/tests/agent_manager/test_config.py
+++ b/tests/agent_manager/test_config.py
@@ -72,6 +72,10 @@ def test_agent_auth_deprecated_env_vars(monkeypatch: pytest.MonkeyPatch) -> None
 def test_extra_vars_take_precedence_over_deprecated_agent_vars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("EXTRA_DB_URL", raising=False)
+    monkeypatch.delenv("AGENT_DB_URL", raising=False)
+    monkeypatch.delenv("EXTRA_AUTH_SECRET", raising=False)
+    monkeypatch.delenv("AGENT_AUTH_SECRET", raising=False)
     monkeypatch.setenv("EXTRA_DB_BACKEND", "sqlite")
     monkeypatch.setenv("AGENT_DB_BACKEND", "postgres")
     monkeypatch.setenv("EXTRA_AUTH_MODE", "anonymous")
@@ -92,3 +96,24 @@ def test_postgres_url_normalizes_to_async_driver() -> None:
         normalize_database_url("postgresql://u:p@localhost/db", "postgres")
         == "postgresql+asyncpg://u:p@localhost/db"
     )
+
+
+def test_already_async_urls_pass_through() -> None:
+    assert (
+        normalize_database_url("sqlite+aiosqlite:///chat.db", "sqlite")
+        == "sqlite+aiosqlite:///chat.db"
+    )
+    assert (
+        normalize_database_url("postgresql+asyncpg://u:p@localhost/db", "postgres")
+        == "postgresql+asyncpg://u:p@localhost/db"
+    )
+
+
+def test_mismatched_sqlite_scheme_raises() -> None:
+    with pytest.raises(ValueError, match="EXTRA_DB_URL"):
+        normalize_database_url("postgres://u:p@localhost/db", "sqlite")
+
+
+def test_mismatched_postgres_scheme_raises() -> None:
+    with pytest.raises(ValueError, match="EXTRA_DB_URL"):
+        normalize_database_url("sqlite:///chat.db", "postgres")

--- a/tests/agent_manager/test_config.py
+++ b/tests/agent_manager/test_config.py
@@ -8,16 +8,79 @@ from agent_manager.config import Settings, normalize_database_url
 def test_default_database_is_persistent_sqlite_file(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("EXTRA_DB_BACKEND", raising=False)
+    monkeypatch.delenv("EXTRA_DB_URL", raising=False)
     monkeypatch.delenv("AGENT_DB_BACKEND", raising=False)
     monkeypatch.delenv("AGENT_DB_URL", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
 
     settings = Settings()
 
-    assert settings.agent_db_backend == "sqlite"
-    assert settings.agent_db_url is None
+    assert settings.extra_db_backend == "sqlite"
+    assert settings.extra_db_url is None
     assert settings.effective_database_url == "sqlite+aiosqlite:///chat.db"
     assert settings.context_max_tokens is None
+
+
+def test_extra_db_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXTRA_DB_BACKEND", "postgres")
+    monkeypatch.setenv("EXTRA_DB_URL", "postgresql://u:p@localhost/db")
+
+    settings = Settings()
+
+    assert settings.extra_db_backend == "postgres"
+    assert settings.extra_db_url == "postgresql://u:p@localhost/db"
+    assert settings.effective_database_url == "postgresql+asyncpg://u:p@localhost/db"
+
+
+def test_extra_auth_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXTRA_AUTH_MODE", "mint")
+    monkeypatch.setenv("EXTRA_AUTH_SECRET", "super-secret-key-32-chars-long!")
+
+    settings = Settings()
+
+    assert settings.extra_auth_mode == "mint"
+    assert settings.extra_auth_secret == "super-secret-key-32-chars-long!"
+
+
+def test_agent_db_deprecated_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXTRA_DB_BACKEND", raising=False)
+    monkeypatch.delenv("EXTRA_DB_URL", raising=False)
+    monkeypatch.setenv("AGENT_DB_BACKEND", "postgres")
+    monkeypatch.setenv("AGENT_DB_URL", "postgresql://u:p@localhost/db")
+
+    with pytest.deprecated_call():
+        settings = Settings()
+
+    assert settings.extra_db_backend == "postgres"
+    assert settings.extra_db_url == "postgresql://u:p@localhost/db"
+
+
+def test_agent_auth_deprecated_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXTRA_AUTH_MODE", raising=False)
+    monkeypatch.delenv("EXTRA_AUTH_SECRET", raising=False)
+    monkeypatch.setenv("AGENT_AUTH_MODE", "mint")
+    monkeypatch.setenv("AGENT_AUTH_SECRET", "super-secret-key-32-chars-long!")
+
+    with pytest.deprecated_call():
+        settings = Settings()
+
+    assert settings.extra_auth_mode == "mint"
+    assert settings.extra_auth_secret == "super-secret-key-32-chars-long!"
+
+
+def test_extra_vars_take_precedence_over_deprecated_agent_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXTRA_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("AGENT_DB_BACKEND", "postgres")
+    monkeypatch.setenv("EXTRA_AUTH_MODE", "anonymous")
+    monkeypatch.setenv("AGENT_AUTH_MODE", "mint")
+
+    settings = Settings()
+
+    assert settings.extra_db_backend == "sqlite"
+    assert settings.extra_auth_mode == "anonymous"
 
 
 def test_sqlite_url_normalizes_to_async_driver() -> None:

--- a/tests/cli/test_run_persistence.py
+++ b/tests/cli/test_run_persistence.py
@@ -171,8 +171,8 @@ def test_agentctl_run_persists_messages_and_reuses_session_context(
 ) -> None:
     spec = _write_spec(tmp_path)
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'chat.db'}"
-    monkeypatch.setenv("AGENT_DB_BACKEND", "sqlite")
-    monkeypatch.setenv("AGENT_DB_URL", db_url)
+    monkeypatch.setenv("EXTRA_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("EXTRA_DB_URL", db_url)
     monkeypatch.setattr(main_mod, "LangGraphEngine", FakeRuntimeEngine)
     FakeRuntimeEngine.prompts.clear()
     FakeRuntimeEngine.histories.clear()
@@ -225,8 +225,8 @@ def test_agentctl_run_without_session_prints_reusable_generated_session(
 ) -> None:
     spec = _write_spec(tmp_path)
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'generated.db'}"
-    monkeypatch.setenv("AGENT_DB_BACKEND", "sqlite")
-    monkeypatch.setenv("AGENT_DB_URL", db_url)
+    monkeypatch.setenv("EXTRA_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("EXTRA_DB_URL", db_url)
     monkeypatch.setattr(main_mod, "LangGraphEngine", FakeRuntimeEngine)
     FakeRuntimeEngine.prompts.clear()
     FakeRuntimeEngine.histories.clear()
@@ -255,8 +255,8 @@ def test_agentctl_run_failure_keeps_user_message_without_assistant_response(
 ) -> None:
     spec = _write_spec(tmp_path)
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'failure.db'}"
-    monkeypatch.setenv("AGENT_DB_BACKEND", "sqlite")
-    monkeypatch.setenv("AGENT_DB_URL", db_url)
+    monkeypatch.setenv("EXTRA_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("EXTRA_DB_URL", db_url)
     monkeypatch.setattr(main_mod, "LangGraphEngine", FailingRuntimeEngine)
     FailingRuntimeEngine.prompts.clear()
     FailingRuntimeEngine.histories.clear()


### PR DESCRIPTION
Closes #95.

### Summary
Renames AGENT_DB_BACKEND and AGENT_DB_URL environment variables to EXTRA_DB_BACKEND and EXTRA_DB_URL in src/agent_manager/config.py to match the Extra product brand name.

### Fixes & Changes
1. src/agent_manager/config.py:
   - Renamed agent_db_backend and agent_db_url settings fields to extra_db_backend and extra_db_url.
   - Added`@model_validator(mode="before") method _backfill_deprecated_agent_vars using module-level constants _DEPRECATED_ENV_VARS.
   - Emits a DeprecationWarning when legacy AGENT_DB_ environment variables are present and falls back to them when EXTRA_DB_ is absent.
   - Preserves precedence for EXTRA_DB_ if both old and new environment variables are set.
   - 
2. tests/agent_manager/test_config.py:
   - Added unit tests for EXTRA_DB_ environment variable parsing.
   - Added tests verifying AGENT_DB_ deprecation warnings and fallback behavior.
   - Added test verifying EXTRA_DB_ precedence over deprecated AGENT_DB_.
3. tests/cli/test_run_persistence.py:
   - Updated CLI persistence tests to use EXTRA_DB_BACKEND and EXTRA_DB_URL.

### Verification
- pytest: 572 passed
- ruff check: All checks passed
- mypy: Success (no issues found)
