### PR TITLE
feat(dev): native development loop with watch and IDE debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ Thumbs.db
 # IDE / Editors
 # =========================
 .idea/
-.vscode/
+.vscode/*
+!.vscode/launch.json
 *.iml
 
 # =========================

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  // No file watcher here, unlike `make dev`: a process that restarts under you
+  // ends the debug session.
+  "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "agents",
+      "type": "promptString",
+      "description": "Path to agents.yaml",
+      "default": "${workspaceFolder}/examples/starter/agents.yaml"
+    }
+  ],
+  "configurations": [
+    {
+      "name": "Debug manager (playground :8100)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "agent_manager.cli",
+      "args": ["--config", "${input:agents}", "--host", "127.0.0.1"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Debug engine API (:8090)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "agentctl.main",
+      "args": ["serve", "--config", "${input:agents}", "--host", "127.0.0.1"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,38 @@ EXAMPLE ?= examples/starter
 CONFIG ?= agents.yaml
 FLAGSHIP := $(EXAMPLE)/$(CONFIG)
 
+# What the `dev-*` targets serve, and where its env comes from. Both accept a
+# path anywhere: make dev AGENTS=~/work/their/agents.yaml ENV_FILE=~/dev.env
+# (`override` is needed: a shell leaves `~` alone in `VAR=~/...`, and a
+# command-line variable otherwise wins over any assignment here).
+AGENTS ?= $(FLAGSHIP)
+ENV_FILE ?=
+override AGENTS := $(patsubst ~/%,$(HOME)/%,$(AGENTS))
+override ENV_FILE := $(patsubst ~/%,$(HOME)/%,$(ENV_FILE))
+# The MCP server each example bundles (see its docker-compose.yml entrypoint).
+MCP_MODULE ?= $(if $(findstring starter,$(EXAMPLE)),mcps.bank.server,mcps.local_knowledge_mcp.server)
+
 # Every example must stay offline-valid — `make validate` checks them all.
 EXAMPLES := examples/starter examples/enterprise-knowledge-assistant
 
 IMAGE := ghcr.io/extra-org/extra:local
-COMPOSE := CONFIG=$(CONFIG) docker compose -f $(EXAMPLE)/docker-compose.yml
+
+# A container can't reach the host's loopback, so `make up` rewrites a localhost
+# base URL to host.docker.internal. Any other value passes through untouched.
+DOCKER_BASE_URL := $(shell sed -n 's/^OPENAI_BASE_URL=//p' $(EXAMPLE)/.env 2>/dev/null \
+	| sed -e 's|//127\.0\.0\.1|//host.docker.internal|' -e 's|//localhost|//host.docker.internal|')
+COMPOSE := CONFIG=$(CONFIG) $(if $(DOCKER_BASE_URL),OPENAI_BASE_URL=$(DOCKER_BASE_URL)) \
+	docker compose -f $(EXAMPLE)/docker-compose.yml
 
 .DEFAULT_GOAL := help
+# Bootstrap the `.env` beside the spec, but only when that's the file in use and
+# there's an example to copy from.
+ENV_DIR := $(patsubst %/,%,$(dir $(AGENTS)))
+DEV_ENV := $(if $(ENV_FILE),,$(if $(wildcard $(ENV_DIR)/.env.example),$(ENV_DIR)/.env))
+
 .PHONY: help install generate-ai sync-ai sync-skills format-check format lint typecheck test \
-        generate-check check clean validate inspect build validate-image up up-ui down logs
+        generate-check check clean validate inspect build validate-image up up-ui down logs \
+        dev dev-engine dev-mcp dev-widget
 
 help: ## Show available targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -90,14 +113,30 @@ up-ui: validate-image $(EXAMPLE)/.env ## Run the example in manager mode: playgr
 	$(COMPOSE) --profile ui up -d
 	@echo "playground: http://localhost:8100/playground"
 
+# Development: the servers run natively, one per terminal, so an IDE debugger
+# attaches to an ordinary process. watchfiles restarts them on save, which is
+# why they need no reload flag of their own. Port: `PORT=8200 make dev`.
+dev-mcp: ## Run the example's bundled MCP server on 127.0.0.1:8765.
+	cd $(EXAMPLE) && $(PYTHON) -m $(MCP_MODULE)
+
+dev: $(DEV_ENV) ## Run the manager natively: playground on http://localhost:8100/playground
+	watchfiles --filter python "agent-manager --config $(AGENTS) --host 127.0.0.1 $(if $(ENV_FILE),--env $(ENV_FILE))" $(SRC) $(ENV_DIR)
+
+dev-engine: $(DEV_ENV) ## Run the engine natively: API on http://localhost:8090
+	watchfiles --filter python "agentctl serve --config $(AGENTS) --host 127.0.0.1 $(if $(ENV_FILE),--env $(ENV_FILE))" $(SRC) $(ENV_DIR)
+
+dev-widget: ## Rebuild the chat widget on every save.
+	npm run watch:widget
+
 down: ## Stop the example stack.
 	$(COMPOSE) --profile engine --profile ui down
 
 logs: ## Follow logs from the example stack.
 	$(COMPOSE) --profile engine --profile ui logs -f
 
-$(EXAMPLE)/.env:
-	@cp $(EXAMPLE)/.env.example $@
+# No prerequisite on purpose: bootstraps a missing .env, never overwrites one.
+%/.env:
+	@cp $(@D)/.env.example $@
 	@echo "Created $@ — fill in the required keys, then run make again."
 	@exit 1
 

--- a/docs.json
+++ b/docs.json
@@ -56,6 +56,7 @@
       {
         "group": "Reference",
         "pages": [
+          "docs/development",
           "docs/cli",
           "docs/api",
           "docs/roadmap"

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -41,6 +41,13 @@ pick the next task → read its skill(s) → make a small change → run `make c
 | `make inspect` | Offline: summarize the flagship example (agents/MCPs/hooks).  |
 | `make clean`   | Remove caches and build artifacts.                           |
 
+## Running it locally
+
+`make dev-mcp` + `make dev` (and `make dev-widget` for the chat widget), one per
+terminal — restarts on save, IDE debugger attaches. See
+[development.mdx](development.mdx). `make up` / `make up-ui` run the Docker
+stack: use those to verify the image, not to develop.
+
 Current CLI checks:
 
 ```bash

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -1,0 +1,110 @@
+---
+title: Development
+description: Run Extra from source — backend, frontend, and a debugger.
+---
+
+Run Extra from source: the servers restart on save and any IDE debugs them.
+
+## Setup (once)
+
+Python 3.11+ and Node 18+. Docker is only needed for `make up`.
+
+```bash
+make install   # editable install + dev tools
+npm install    # widget toolchain
+```
+
+The starter example defaults to local [Ollama](https://ollama.com)
+(`ollama pull qwen2.5:14b`), so no paid API key is needed, and its `.env` is
+created on first run.
+
+## Backend
+
+One terminal each:
+
+```bash
+make dev-mcp   # the MCP server the starter example calls   :8765
+make dev       # agent-manager: playground, API, engine    :8100
+```
+
+The API is at http://localhost:8100 — `/health`, `/conversations`, and the rest
+of the [HTTP API](/docs/api). The playground at
+http://localhost:8100/playground serves the widget against it, which is the
+quickest way to exercise the backend by hand.
+
+## Frontend
+
+```bash
+make dev-widget   # esbuild --watch on the chat widget
+```
+
+The widget (`src/agent_manager/api/static/widget/`, TypeScript + React) bundles
+into `widget.js`, which `agent-manager` serves — so `make dev` must be running.
+No dev server, no HMR: save, then refresh http://localhost:8100/playground.
+
+| Command                    | Does                                    |
+| -------------------------- | --------------------------------------- |
+| `npm run build:widget`     | One-off bundle — run it before opening a PR |
+| `npm run typecheck:widget` | Type-check                              |
+| `npm run test:widget`      | Unit tests (node)                       |
+| `npm run test:widget:e2e`  | Playwright end-to-end tests             |
+
+`widget-demo.html`, `widget-demo-inline.html`, and the other demo pages exercise
+the embed modes without the playground: http://localhost:8100/widget-demo.html.
+
+## Debugging
+
+- **VS Code / Cursor**: <kbd>F5</kbd> → *Debug manager* or *Debug engine API*.
+  It asks for the spec path and defaults to the starter example.
+- **PyCharm**: a plain Python run configuration — see below.
+
+Both run without the file watcher, so a code change needs a restart. Free the
+port first: stop `make dev`, and `make down` if the Docker stack is up.
+
+### PyCharm run configuration
+
+*Run → Edit Configurations → + → Python*:
+
+| Field             | Value                                                        |
+| ----------------- | ------------------------------------------------------------ |
+| Script path       | `src/agent_manager/cli.py` — check the dropdown says *Script path*, not *Module name* (as a module it's `agent_manager.cli`) |
+| Parameters        | `--config examples/starter/agents.yaml --host 127.0.0.1`      |
+| Working directory | the repository root — `chat.db` and `.env` resolve against it |
+
+Debug it, open http://localhost:8100/playground, send a message — breakpoints
+hit.
+
+For the engine, the script is `src/agentctl/main.py` and the parameters start
+with the subcommand: `serve --config examples/starter/agents.yaml --host
+127.0.0.1`.
+
+For your own system, put its spec path in Parameters. Its `.env`, plugins, and
+tools load into the same process, so you can break in your code too; start its
+MCP servers yourself.
+
+## Before a PR
+
+```bash
+make check   # format, lint, mypy, pytest, stale-stub check
+```
+
+Touched `.ai/`? Run `make generate-ai` and commit the regenerated adapters.
+
+## Notes
+
+- **Port already in use** — `make up`'s Docker stack binds 8090/8100 too. Stop
+  it with `make down`, or move the dev server: `PORT=8200 make dev`. Both
+  servers read `PORT` (shell or `.env`).
+- **Tool calls fail** — `make dev-mcp` isn't running. The example's
+  `agents.yaml` declares it as `bank_core: http://127.0.0.1:8765/mcp`.
+- **Engine only, no UI** — `make dev-engine` serves the stateless API on `:8090`.
+- **Run your own `agents.yaml`, not the example** — point `AGENTS` at any path:
+
+  ```bash
+  make dev AGENTS=~/work/my-system/agents.yaml
+  ```
+
+  The `.env`, plugins, and tools beside it load, and edits there restart the
+  server — so you can debug another project's system from this checkout. Start
+  its MCP servers yourself; `make dev-mcp` only knows the bundled examples.
+- **An `.env` somewhere else** — `make dev ENV_FILE=~/secrets/dev.env`.

--- a/examples/enterprise-knowledge-assistant/docker-compose.yml
+++ b/examples/enterprise-knowledge-assistant/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - .:/workspace
     env_file:
       - .env
+    environment:
+      - OPENAI_BASE_URL
     network_mode: "service:mcp"
     depends_on:
       - mcp
@@ -28,6 +30,8 @@ services:
       - .:/workspace
     env_file:
       - .env
+    environment:
+      - OPENAI_BASE_URL
     network_mode: "service:mcp"
     depends_on:
       - mcp

--- a/examples/starter/.env.example
+++ b/examples/starter/.env.example
@@ -8,9 +8,9 @@
 # non-empty value works.
 OPENAI_API_KEY=ollama
 
-# host.docker.internal reaches Ollama on your machine from inside the container,
-# which is how `make up` runs it. Running without Docker? Use 127.0.0.1 instead.
-OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+# Ollama on this machine. A container can't reach 127.0.0.1, so `make up`
+# rewrites it to host.docker.internal — the same value works either way.
+OPENAI_BASE_URL=http://127.0.0.1:11434/v1
 
 # For a hosted provider, set provider + name in agents.yaml and the key here:
 #

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -102,11 +102,11 @@ defaults:
 
 ```
 OPENAI_API_KEY=ollama
-OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+OPENAI_BASE_URL=http://127.0.0.1:11434/v1
 ```
 
-`host.docker.internal` is how a container reaches Ollama on your machine, which
-is what `make up` does. Running without Docker, use `127.0.0.1` instead.
+A container can't reach the host's loopback, so `make up` rewrites this to
+`host.docker.internal`.
 
 For a hosted provider, set `provider` and `name`, drop `OPENAI_BASE_URL`, and
 put the real key in `.env`.

--- a/examples/starter/docker-compose.yml
+++ b/examples/starter/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - .:/workspace
     env_file:
       - .env
+    environment:
+      - OPENAI_BASE_URL
     network_mode: "service:mcp"
     depends_on:
       - mcp
@@ -28,6 +30,8 @@ services:
       - .:/workspace
     env_file:
       - .env
+    environment:
+      - OPENAI_BASE_URL
     network_mode: "service:mcp"
     depends_on:
       - mcp

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "typecheck:widget": "tsc -p tsconfig.widget.json --noEmit",
     "typecheck:e2e": "tsc -p tsconfig.e2e.json --noEmit",
     "build:widget": "esbuild src/agent_manager/api/static/widget/index.ts --bundle --format=esm --target=es2020 --outfile=src/agent_manager/api/static/widget.js",
+    "watch:widget": "npm run build:widget -- --watch",
     "test:widget": "node src/agent_manager/api/static/widget.test.mjs",
     "test:widget:e2e": "playwright test"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "watchfiles>=0.21",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "ruff>=0.16.2,<0.17.0",


### PR DESCRIPTION
## Why

`make up` builds an image and runs the stack in Docker. That is the right way to *try* Extra, but as a contributor loop it means rebuilding on every change, no restart on save, and remote-debug plumbing to break on a line.

## What

Run the servers natively — one terminal each, restart on save, and any IDE debugger attaches to an ordinary local process.

| Command | Runs | Port |
| --- | --- | --- |
| `make dev` | `agent-manager` — playground, API, engine | 8100 |
| `make dev-engine` | `agentctl serve` — stateless engine, no UI | 8090 |
| `make dev-mcp` | the example's bundled MCP server | 8765 |
| `make dev-widget` | esbuild `--watch` on the chat widget | — |

- **No source changes.** `watchfiles` (a dev dependency, and uvicorn's own reload engine) wraps the existing CLIs, so restart-on-save needs no dev-only code path in the servers. An earlier draft added `--reload` flags plus an env-var/factory dance in both API modules; it was ~50 lines of production code to replace one word in the Makefile.
- **Any spec, any env file.** `make dev AGENTS=~/work/their/agents.yaml ENV_FILE=~/dev.env` — their `.env`, plugins, and tools load into the debugged process, and both trees are watched.
- **IDE debugging.** `.vscode/launch.json` ships two F5 configurations; `docs/development.mdx` documents the equivalent PyCharm run configuration.
- **`.env` that works both ways.** The starter example now defaults to `127.0.0.1`, so it runs natively out of the box; `make up` rewrites a loopback base URL to `host.docker.internal` and passes any other value (a hosted provider) through untouched.
- **Docs.** New `docs/development.mdx` under Reference: setup, backend, frontend, debugging, and a short notes section for ports / MCP / external specs.

## Verified

`make dev-mcp` + `make dev` + `make dev-widget` on a clean tree: `/health`, `/playground`, and `/widget.js` all 200; saving a `.py` file restarts the server; editing widget source rebuilds `widget.js`; `PORT=8200 make dev` and `ENV_FILE=...` both take effect; `make -n up` injects `host.docker.internal`; PyCharm and VS Code both stop on a breakpoint. `make validate`, format, lint, and mypy are clean.

Note: `tests/cli/test_run_persistence.py::test_agentctl_run_without_session_prints_reusable_generated_session` fails on `main` as well — click 8.2 removed `mix_stderr`. Untouched here; worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)