### PR TITLE
Fix/hitm approval actions

### DIFF
--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -365,14 +365,46 @@ The `/decision` endpoint accepts a free-text `decision` (`allow`,
 single boundary; an unrecognized value returns 400. `/approve` and `/reject` are
 convenience routes for the two most common typed decisions. To grant
 `ALLOW_FOR_SESSION`, use `/decision` with `"allow for this session"`.
+If `/invoke` or `/stream` supplied `X-Session-ID`, every later decision request
+for that run must supply the same header. Omitting or changing it fails closed
+with 403 before the approval is claimed.
+
+The conversation API (`agent_manager/api/routes.py`) exposes the same engine
+capability inside the conversation ownership boundary:
+
+```text
+POST /conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision
+```
+
+Its body carries one typed value: `allow_once`, `deny`, or
+`allow_for_session`. The route authorizes the conversation owner before resume,
+and the engine checks the stored approval session reference before atomically
+claiming it. A completed resume is persisted as the assistant turn; if resume
+reaches another approval, that new pending request is returned instead.
+Assistant persistence uses a deterministic per-run message id. If execution
+completed but the response or first database write failed, retrying the same
+decision recovers the result from the completed graph checkpoint and does not
+duplicate the assistant turn or tool execution.
+
+The bundled widget renders these decisions as **Approve**, **Deny**, and
+**Approve for this session**. The last option reuses the existing session
+permission key, so later calls to the same provider-qualified tool by the same
+agent in the same conversation do not prompt again.
 
 A pending-approval payload contains `run_id`, `approval_id`, `agent_id`,
 `tool_name`, a human-readable `description` (stating the tool has **not** run
-yet), `provider`, and **masked** `arguments`. Approval endpoints validate that the
-run and approval exist, the approval belongs to the run, the caller is authorized,
-the approval is still pending, and the run is resumable. Errors map to stable
-status codes (404 / 403 / 409 / 400) without leaking internals. Secrets, tokens,
-and unmasked arguments are never persisted or returned.
+yet), `provider`, optional `server_id`, and **masked** `arguments`. The streaming
+and non-streaming forms expose the same safe identity fields. Approval endpoints
+validate that the run and approval exist, the approval belongs to the run, the
+caller is authorized, the approval is still pending, and the run is resumable.
+Errors map to stable status codes (404 / 403 / 409 / 400) without leaking
+internals. Secrets, tokens, and unmasked arguments are never persisted or
+returned.
+
+Token usage is accumulated on the run across every execution leg: the initial
+leg that reaches an interrupt and each later resume. A completed conversation
+turn therefore persists the full reported usage and remains subject to the same
+conversation-budget accounting as a run that never paused.
 
 ## 9. Security notes
 

--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -188,6 +188,11 @@ When a call requires approval, the `ApprovalProvider` for this runtime
 
 To resume, `Engine.resume(run_id, approval_id, decision)`:
 
+> **Compatibility note:** Session-bound approvals now fail closed. Callers of
+> `resume(...)` and the approval HTTP endpoints must propagate the same session
+> identity used when the approval was created (for the engine API, via
+> `caller_session_id` / `X-Session-ID`). Omitting or changing it returns 403.
+
 1. **Atomically claims** the approval (`PENDING → RESUMING`) — exactly one caller
    wins (see §7).
 2. Resumes the **same** LangGraph thread from its checkpoint via

--- a/docs/WIDGET_ARCHITECTURE.md
+++ b/docs/WIDGET_ARCHITECTURE.md
@@ -89,6 +89,7 @@ POST /conversations
 GET  /conversations/{id}/messages
 POST /conversations/{id}/messages
 POST /conversations/{id}/messages/stream
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/decision
 ```
 
 The non-streaming endpoint remains as a fallback. The streaming endpoint returns
@@ -101,7 +102,17 @@ Streaming events include:
 - `route` — update the visited agent/sub-agent path.
 - `tool_started`, `tool_succeeded`, `tool_failed` — update tool activity.
 - `final` — authoritative final answer and metadata.
+- `pending_approval` — sanitized tool request, provider/server identity, masked
+  arguments, and the identifiers required to resume it.
 - `error` — stream failure.
+
+When a stream pauses for approval, the assistant entry renders three actions:
+**Approve** (`allow_once`), **Deny** (`deny`), and **Approve for this session**
+(`allow_for_session`). While a decision is in flight the controls are disabled;
+the completed resume replaces the approval card in place rather than starting a
+second conversation turn. Decision retries are idempotent: a completed graph
+result is recovered from its checkpoint and the assistant message is appended
+once by its stable run-derived id.
 
 ## Agent Connection Behavior
 
@@ -122,6 +133,8 @@ Automated coverage verifies:
 - The widget renders and remains accessible in floating and inline modes.
 - Messages are sent through the conversation API.
 - Streaming SSE responses update the assistant message.
+- All three approval actions resume the existing run without duplicate requests.
+- Session approval suppresses the next prompt for the same scoped tool.
 - Stale conversation ids are recovered automatically.
 - Browser demos still work through Playwright.
 - The backend stream endpoint emits SSE frames.

--- a/docs/widget.mdx
+++ b/docs/widget.mdx
@@ -152,16 +152,17 @@ The widget connects to the streaming endpoint (`POST /conversations/{id}/message
 ## Tool approvals
 
 When a tool requires human approval, the widget pauses the current run and
-shows three actions:
+shows the tool's human-readable description and three actions:
 
 - **Approve** — allow only this tool invocation.
 - **Deny** — reject this invocation without running the tool.
 - **Approve for this session** — allow this invocation and stop asking for the
   same scoped tool during the current conversation.
 
-The decision resumes the existing run; it does not submit the user message a
-second time. Session approval remains scoped by the backend to the current
-system, identity, conversation, agent, and provider-qualified tool.
+The decision resumes the existing run through the conversation approval API; it
+does not resend the user's message. Hosts must keep the same authenticated
+conversation identity for the decision. Afterward, the run either completes or
+shows the next approval request.
 
 ---
 

--- a/docs/widget.mdx
+++ b/docs/widget.mdx
@@ -149,6 +149,20 @@ Only safe metadata is exposed — no internal reasoning, no prompt content.
 
 The widget connects to the streaming endpoint (`POST /conversations/{id}/messages/stream`) and renders tokens as they arrive. If streaming fails before a usable answer, it falls back to the standard endpoint automatically.
 
+## Tool approvals
+
+When a tool requires human approval, the widget pauses the current run and
+shows three actions:
+
+- **Approve** — allow only this tool invocation.
+- **Deny** — reject this invocation without running the tool.
+- **Approve for this session** — allow this invocation and stop asking for the
+  same scoped tool during the current conversation.
+
+The decision resumes the existing run; it does not submit the user message a
+second time. Session approval remains scoped by the backend to the current
+system, identity, conversation, agent, and provider-qualified tool.
+
 ---
 
 ## Session recovery

--- a/examples/enterprise-knowledge-assistant/run_local_mcp_approval.py
+++ b/examples/enterprise-knowledge-assistant/run_local_mcp_approval.py
@@ -234,6 +234,7 @@ class ApprovalDemo:
                 pending.approval_id,
                 decision,
                 caller_user_id=CALLER.user_id,
+                caller_session_id=self.session_id,
             )
 
         await self._complete_turn(turn, result)

--- a/examples/hitl-approval-demo/run_demo.py
+++ b/examples/hitl-approval-demo/run_demo.py
@@ -166,6 +166,7 @@ class DemoRunner:
                 pending.approval_id,
                 decision,
                 caller_user_id=USER_ID,
+                caller_session_id=session_id,
             )
         else:
             print(f"model_tool_request_observed: {bool(result.used_tools)}")

--- a/examples/interactive_mcp_control/run.py
+++ b/examples/interactive_mcp_control/run.py
@@ -105,6 +105,7 @@ class InteractiveApp:
                     pending.approval_id,
                     decision,
                     caller_user_id=USER_ID,
+                    caller_session_id=self.session_id,
                 )
                 if decision == ApprovalDecision.DENY:
                     print(

--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 _RID_OK = re.compile(r"[^A-Za-z0-9._-]")
+_INTERNAL_ERROR_MESSAGE = "Internal server error"
 
 
 def _begin_request(x_request_id: str | None) -> str:
@@ -335,15 +336,29 @@ def create_app(
         )
 
     async def _decide(
-        run_id: str, approval_id: str, decision: ApprovalDecision, user_id: str | None
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision,
+        user_id: str | None,
+        session_id: str | None,
     ) -> InvokeResponse:
         engine = _hitl_engine()
         try:
-            result = await engine.resume(run_id, approval_id, decision, caller_user_id=user_id)
+            result = await engine.resume(
+                run_id,
+                approval_id,
+                decision,
+                caller_user_id=user_id,
+                caller_session_id=_run_context(session_id, run_id=run_id).conversation_id,
+            )
         except ApprovalError as exc:
             raise _map_approval_error(exc) from exc
-        except Exception as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        except Exception:
+            logger.exception(
+                "approval decision failed",
+                extra={"run_id": run_id, "approval_id": approval_id},
+            )
+            raise HTTPException(status_code=500, detail=_INTERNAL_ERROR_MESSAGE) from None
         return InvokeResponse(
             system_name=result.system_name,
             answer=result.answer,
@@ -355,28 +370,47 @@ def create_app(
         )
 
     @app.post("/runs/{run_id}/approvals/{approval_id}/decision", response_model=InvokeResponse)
-    async def decide(run_id: str, approval_id: str, body: ApprovalDecisionBody) -> InvokeResponse:
+    async def decide(
+        run_id: str,
+        approval_id: str,
+        body: ApprovalDecisionBody,
+        x_session_id: str | None = Header(default=None),
+    ) -> InvokeResponse:
         # The single free-text → typed decision boundary for the API.
         try:
             decision = parse_decision(body.decision)
         except InvalidDecision as exc:
             raise _map_approval_error(exc) from exc
-        return await _decide(run_id, approval_id, decision, body.user_id)
+        return await _decide(run_id, approval_id, decision, body.user_id, x_session_id)
 
     @app.post("/runs/{run_id}/approvals/{approval_id}/approve", response_model=InvokeResponse)
     async def approve(
         run_id: str,
         approval_id: str,
         body: ApprovalDecisionRequest = _DEFAULT_APPROVAL_REQUEST_BODY,
+        x_session_id: str | None = Header(default=None),
     ) -> InvokeResponse:
-        return await _decide(run_id, approval_id, ApprovalDecision.ALLOW_ONCE, body.user_id)
+        return await _decide(
+            run_id,
+            approval_id,
+            ApprovalDecision.ALLOW_ONCE,
+            body.user_id,
+            x_session_id,
+        )
 
     @app.post("/runs/{run_id}/approvals/{approval_id}/reject", response_model=InvokeResponse)
     async def reject(
         run_id: str,
         approval_id: str,
         body: ApprovalDecisionRequest = _DEFAULT_APPROVAL_REQUEST_BODY,
+        x_session_id: str | None = Header(default=None),
     ) -> InvokeResponse:
-        return await _decide(run_id, approval_id, ApprovalDecision.DENY, body.user_id)
+        return await _decide(
+            run_id,
+            approval_id,
+            ApprovalDecision.DENY,
+            body.user_id,
+            x_session_id,
+        )
 
     return app

--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -18,13 +18,10 @@ from pydantic import BaseModel
 
 from agent_engine.approvals.decision import ApprovalDecision, parse_decision
 from agent_engine.approvals.errors import (
-    ApprovalAlreadyProcessed,
     ApprovalError,
-    ApprovalNotFound,
-    ApprovalRunMismatch,
     InvalidDecision,
-    RunNotFound,
-    UnauthorizedApprover,
+    approval_http_status,
+    approval_public_message,
 )
 from agent_engine.approvals.session_store import (
     InMemorySessionApprovalRepository,
@@ -95,15 +92,10 @@ def _pending_model(pa: PendingApproval | None) -> PendingApprovalModel | None:
 
 def _map_approval_error(exc: ApprovalError) -> HTTPException:
     """Map approval-lifecycle errors to stable HTTP responses (no internals)."""
-    status = {
-        RunNotFound: 404,
-        ApprovalNotFound: 404,
-        ApprovalRunMismatch: 404,
-        UnauthorizedApprover: 403,
-        ApprovalAlreadyProcessed: 409,
-        InvalidDecision: 400,
-    }.get(type(exc), 409)
-    return HTTPException(status_code=status, detail=str(exc))
+    return HTTPException(
+        status_code=approval_http_status(exc),
+        detail=approval_public_message(exc),
+    )
 
 
 class InvokeRequest(BaseModel):

--- a/src/agent_engine/approvals/errors.py
+++ b/src/agent_engine/approvals/errors.py
@@ -76,3 +76,23 @@ class CheckpointNotFound(ApprovalError):
     def __init__(self, thread_id: str) -> None:
         self.thread_id = thread_id
         super().__init__(f"no checkpoint found for thread: {thread_id}")
+
+
+_HTTP_POLICY: dict[type[ApprovalError], tuple[int, str]] = {
+    RunNotFound: (404, "run not found"),
+    ApprovalNotFound: (404, "approval not found"),
+    ApprovalRunMismatch: (404, "approval not found"),
+    UnauthorizedApprover: (403, "not authorized to decide this approval"),
+    ApprovalAlreadyProcessed: (409, "approval already processed"),
+    InvalidDecision: (400, "invalid approval decision"),
+}
+
+
+def approval_http_status(exc: ApprovalError) -> int:
+    """Return the stable HTTP status for an approval-lifecycle failure."""
+    return _HTTP_POLICY.get(type(exc), (409, "approval could not be processed"))[0]
+
+
+def approval_public_message(exc: ApprovalError) -> str:
+    """Return a sanitized client message without exposing exception details."""
+    return _HTTP_POLICY.get(type(exc), (409, "approval could not be processed"))[1]

--- a/src/agent_engine/approvals/invocation.py
+++ b/src/agent_engine/approvals/invocation.py
@@ -85,6 +85,7 @@ class ToolInvocation:
     organization_id: str = ""
     run_id: str | None = None
     approval_id: str | None = None
+    human_description: str = ""
 
     @property
     def tool_identity(self) -> str:
@@ -118,8 +119,7 @@ class ToolInvocation:
         States plainly that the tool has not run yet, so the approver understands
         they are authorizing a pending action rather than reviewing a past one.
         """
-        where = f" on server '{self.server_id}'" if self.server_id else ""
-        return (
-            f"Agent '{self.agent_id}' wants to call tool '{self.tool_name}'"
-            f"{where}. It has NOT been executed yet and needs your approval."
+        summary = (
+            self.human_description.strip() or "Use this tool to complete the requested action."
         )
+        return f"{summary} This action has not been executed."

--- a/src/agent_engine/approvals/manager.py
+++ b/src/agent_engine/approvals/manager.py
@@ -215,12 +215,30 @@ class ApprovalManager:
     async def get_approval(self, run_id: str, approval_id: str) -> ApprovalRecord:
         return await self._load_for_run(run_id, approval_id)
 
+    async def get_authorized(
+        self,
+        *,
+        run_id: str,
+        approval_id: str,
+        caller_user_id: str | None = None,
+        caller_auth_ref: str | None = None,
+    ) -> ApprovalRecord:
+        """Return an approval only when the caller matches its stored scope."""
+        record = await self._load_for_run(run_id, approval_id)
+        self._ensure_authorized(
+            record,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_auth_ref,
+        )
+        return record
+
     async def claim(
         self,
         *,
         run_id: str,
         approval_id: str,
         caller_user_id: str | None = None,
+        caller_auth_ref: str | None = None,
     ) -> ApprovalRecord:
         """Validate and atomically claim an approval for resume.
 
@@ -229,9 +247,13 @@ class ApprovalManager:
         :class:`ApprovalAlreadyProcessed`. On success the run and approval both
         move to RESUMING.
         """
-        record = await self._load_for_run(run_id, approval_id)
-        if record.authorized_user_id is not None and record.authorized_user_id != caller_user_id:
-            raise UnauthorizedApprover(approval_id)
+        record = await self.get_authorized(
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_auth_ref,
+        )
+
         try:
             claimed = await self._approvals.claim(approval_id)
         except InvalidStateTransition as exc:
@@ -255,6 +277,18 @@ class ApprovalManager:
             tool_call_id=claimed.tool_call_id,
         )
         return claimed
+
+    @staticmethod
+    def _ensure_authorized(
+        record: ApprovalRecord,
+        *,
+        caller_user_id: str | None,
+        caller_auth_ref: str | None,
+    ) -> None:
+        if record.authorized_user_id is not None and record.authorized_user_id != caller_user_id:
+            raise UnauthorizedApprover(record.approval_id)
+        if record.auth_ref is not None and record.auth_ref != caller_auth_ref:
+            raise UnauthorizedApprover(record.approval_id)
 
     async def finalize(self, approval_id: str, *, approved: bool) -> ApprovalRecord:
         target = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED

--- a/src/agent_engine/approvals/models.py
+++ b/src/agent_engine/approvals/models.py
@@ -91,6 +91,8 @@ class RunRecord:
     thread_id: str
     system_name: str
     status: RunStatus = RunStatus.RUNNING
+    input_tokens: int | None = None
+    output_tokens: int | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
 

--- a/src/agent_engine/engine/engine.py
+++ b/src/agent_engine/engine/engine.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
-from typing import Self
+from typing import Protocol, Self, runtime_checkable
 
+from agent_engine.approvals.decision import ApprovalDecision
 from agent_engine.core.spec import SystemSpec
-from agent_engine.engine.types import ChatMessage, RunResult
+from agent_engine.engine.types import ChatMessage, PendingApproval, RunResult
 from agent_engine.runtime.hooks.models import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
 
@@ -40,3 +41,29 @@ class Engine(ABC):
 
     async def __aexit__(self, *args: object) -> None:
         await self.close()
+
+
+@runtime_checkable
+class ApprovalEngine(Protocol):
+    """Optional engine capability for inspecting and resuming HITL runs."""
+
+    async def get_pending_approval(self, run_id: str) -> PendingApproval | None: ...
+
+    async def get_processed_result(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult | None: ...
+
+    async def resume(
+        self,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision | str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult: ...

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -20,7 +20,7 @@ from agent_engine.approvals.coordinator import ApprovalCoordinator
 from agent_engine.approvals.decision import ApprovalDecision, parse_decision
 from agent_engine.approvals.errors import RunNotFound
 from agent_engine.approvals.manager import ApprovalManager, ToolExecutionManager
-from agent_engine.approvals.models import ApprovalRecord
+from agent_engine.approvals.models import ApprovalRecord, RunStatus
 from agent_engine.approvals.repository import (
     InMemoryApprovalRepository,
     InMemoryToolExecutionRepository,
@@ -205,6 +205,9 @@ def _pending_approval_event(system_name: str, result: RunResult) -> RunStreamEve
         agent_id=approval.agent_id,
         tool_name=approval.tool_name,
         description=approval.description,
+        provider=approval.provider,
+        server_id=approval.server_id,
+        arguments=dict(approval.arguments),
     )
 
 
@@ -394,10 +397,13 @@ class LangGraphEngine(Engine):
         return cast(dict[str, Any], await app.ainvoke(graph_input, self._thread_config(ctx)))
 
     def _completed_result(
-        self, result: dict[str, Any], *, tokens: TokenUsage | None = None
+        self,
+        result: dict[str, Any],
+        *,
+        token_usage: tuple[int | None, int | None] = (None, None),
     ) -> RunResult:
         """Map the graph's raw output onto the public run result."""
-        input_tokens, output_tokens = tokens.totals() if tokens is not None else (None, None)
+        input_tokens, output_tokens = token_usage
         return RunResult(
             system_name=self._system_name,
             visited=result.get("visited", []),
@@ -406,6 +412,23 @@ class LangGraphEngine(Engine):
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+
+    async def _record_token_usage(
+        self,
+        ctx: RunContext,
+        tokens: TokenUsage,
+    ) -> tuple[int | None, int | None]:
+        """Persist one execution leg and return cumulative usage for the run."""
+        assert ctx.run_id is not None
+        input_tokens, output_tokens = tokens.totals()
+        run = await self._run_repository.add_token_usage(
+            ctx.run_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        if run is None:
+            raise RunNotFound(ctx.run_id)
+        return run.input_tokens, run.output_tokens
 
     async def run(
         self,
@@ -423,10 +446,11 @@ class LangGraphEngine(Engine):
         with self._run_scope(ctx, sinks=StreamSinks(token=tokens.add)):
             try:
                 result = await self._invoke_graph(app, ctx, state)
-                pending = await self._pending_result(ctx, result)
+                token_usage = await self._record_token_usage(ctx, tokens)
+                pending = await self._pending_result(ctx, result, token_usage=token_usage)
                 if pending is not None:
                     return pending
-                run_result = self._completed_result(result, tokens=tokens)
+                run_result = self._completed_result(result, token_usage=token_usage)
                 await lifecycle.succeed(ctx, run_result)
                 return run_result
             except Exception as exc:
@@ -446,7 +470,13 @@ class LangGraphEngine(Engine):
             configurable={"thread_id": ctx.run_id},
         )
 
-    async def _pending_result(self, ctx: RunContext, result: Any) -> RunResult | None:
+    async def _pending_result(
+        self,
+        ctx: RunContext,
+        result: Any,
+        *,
+        token_usage: tuple[int | None, int | None] = (None, None),
+    ) -> RunResult | None:
         """If the graph suspended at an approval interrupt, return a pending
         RunResult built from the persisted approval; otherwise return None."""
         interrupts = result.get("__interrupt__") if isinstance(result, dict) else None
@@ -470,6 +500,8 @@ class LangGraphEngine(Engine):
             visited=result.get("visited", []),
             answer="",
             used_tools=tuple(result.get("used_tools", [])),
+            input_tokens=token_usage[0],
+            output_tokens=token_usage[1],
             status="pending_approval",
             pending_approval=_pending_approval(approval),
         )
@@ -486,6 +518,37 @@ class LangGraphEngine(Engine):
         approval = await self._approval_manager.get_pending(run_id)
         return _pending_approval(approval) if approval is not None else None
 
+    async def get_processed_result(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult | None:
+        """Recover the result left by an already-processed approval decision."""
+        app, _ = self._require_built("recovering a processed approval")
+        await self._approval_manager.get_authorized(
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_session_id,
+        )
+        run = await self._run_repository.get(run_id)
+        if run is None:
+            raise RunNotFound(run_id)
+        if run.status not in {RunStatus.COMPLETED, RunStatus.PENDING_APPROVAL}:
+            return None
+        ctx = RunContext(run_id=run_id)
+        snapshot = await app.aget_state(self._thread_config(ctx))
+        values = snapshot.values
+        if not isinstance(values, dict):
+            return None
+        token_usage = (run.input_tokens, run.output_tokens)
+        if run.status == RunStatus.PENDING_APPROVAL:
+            return await self._pending_result(ctx, values, token_usage=token_usage)
+        return self._completed_result(values, token_usage=token_usage)
+
     async def resume(
         self,
         run_id: str,
@@ -493,6 +556,7 @@ class LangGraphEngine(Engine):
         decision: ApprovalDecision | str,
         *,
         caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
     ) -> RunResult:
         """Apply a human decision to a pending tool call and resume the same run.
 
@@ -506,7 +570,10 @@ class LangGraphEngine(Engine):
         app, lifecycle = self._require_built("resuming")
         kind = parse_decision(decision)
         approval = await self._approval_manager.claim(
-            run_id=run_id, approval_id=approval_id, caller_user_id=caller_user_id
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_session_id,
         )
         approved = kind != ApprovalDecision.DENY
         ctx = RunContext(
@@ -524,15 +591,17 @@ class LangGraphEngine(Engine):
             approval_id=approval_id,
             decision=kind.value,
         )
-        with self._run_scope(ctx, sinks=None):
+        tokens = TokenUsage()
+        with self._run_scope(ctx, sinks=StreamSinks(token=tokens.add)):
             try:
                 resume_command: Command[Any] = Command(resume={"decision": kind.value})
                 result = await self._invoke_graph(app, ctx, resume_command)
+                token_usage = await self._record_token_usage(ctx, tokens)
                 await self._approval_manager.finalize(approval_id, approved=approved)
-                pending = await self._pending_result(ctx, result)
+                pending = await self._pending_result(ctx, result, token_usage=token_usage)
                 if pending is not None:
                     return pending
-                run_result = self._completed_result(result)
+                run_result = self._completed_result(result, token_usage=token_usage)
                 await lifecycle.succeed(ctx, run_result)
                 log(
                     logger,
@@ -606,11 +675,12 @@ class LangGraphEngine(Engine):
         """
         try:
             result = await self._invoke_graph(app, ctx, state)
-            pending = await self._pending_result(ctx, result)
+            token_usage = await self._record_token_usage(ctx, tokens)
+            pending = await self._pending_result(ctx, result, token_usage=token_usage)
             if pending is not None:
                 channel.emit(_pending_approval_event(self._system_name, pending))
                 return
-            run_result = self._completed_result(result, tokens=tokens)
+            run_result = self._completed_result(result, token_usage=token_usage)
             await lifecycle.succeed(
                 ctx,
                 run_result,

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -546,7 +546,19 @@ class LangGraphEngine(Engine):
             return None
         token_usage = (run.input_tokens, run.output_tokens)
         if run.status == RunStatus.PENDING_APPROVAL:
-            return await self._pending_result(ctx, values, token_usage=token_usage)
+            approval = await self.get_pending_approval(run_id)
+            if approval is None:
+                return None
+            return RunResult(
+                system_name=self._system_name,
+                visited=values.get("visited", []),
+                answer="",
+                used_tools=tuple(values.get("used_tools", [])),
+                input_tokens=token_usage[0],
+                output_tokens=token_usage[1],
+                status="pending_approval",
+                pending_approval=approval,
+            )
         return self._completed_result(values, token_usage=token_usage)
 
     async def resume(

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -122,6 +122,7 @@ class _ToolCall:
     tool_call_id: str
     run_id: str
     exec_id: str
+    description: str
 
 
 def _elapsed_ms(start: float) -> int:
@@ -265,6 +266,7 @@ class AgentNode:
             tool_call_id=tool_call_id,
             run_id=run_id,
             exec_id=execution_id_for(tool_call_id),
+            description=tool.description,
         )
 
     def _enforce_limits(self, call: _ToolCall) -> str | None:
@@ -485,6 +487,7 @@ class AgentNode:
             organization_id=organization_id or "",
             run_id=run_context.run_id if run_context else None,
             approval_id=(approval_id_value if isinstance(approval_id_value, str) else None),
+            human_description=call.description,
         )
         outcome = await self._approval_coordinator.resolve(
             invocation, auto_mode=self._spec.auto_mode

--- a/src/agent_engine/engine/types.py
+++ b/src/agent_engine/engine/types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
-from agent_engine.runtime.tool_models import ToolUsageRecord
+from agent_engine.runtime.tool_models import ToolProviderName, ToolUsageRecord
 
 
 class ChatRole(StrEnum):
@@ -34,7 +34,7 @@ class PendingApproval:
     agent_id: str
     tool_name: str
     description: str
-    provider: str = "local"
+    provider: ToolProviderName = "local"
     server_id: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
 

--- a/src/agent_engine/runs/in_memory.py
+++ b/src/agent_engine/runs/in_memory.py
@@ -101,6 +101,24 @@ class InMemoryRunRepository:
         self._evict_expired_batch(now)
         return changed
 
+    async def add_token_usage(
+        self,
+        run_id: str,
+        *,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> RunRecord | None:
+        """Accumulate reported usage without introducing a suspension point."""
+        entry = self._get_unexpired_entry(run_id)
+        if entry is None:
+            return None
+        record = entry.record
+        if input_tokens is not None:
+            record.input_tokens = (record.input_tokens or 0) + input_tokens
+        if output_tokens is not None:
+            record.output_tokens = (record.output_tokens or 0) + output_tokens
+        return record
+
     def _get_unexpired_entry(self, run_id: str, now: float | None = None) -> _StoredRun | None:
         entry = self._runs.get(run_id)
         if (

--- a/src/agent_engine/runs/repository.py
+++ b/src/agent_engine/runs/repository.py
@@ -39,3 +39,17 @@ class RunRepository(Protocol):
         without modifying stored state.
         """
         ...
+
+    async def add_token_usage(
+        self,
+        run_id: str,
+        *,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> RunRecord | None:
+        """Atomically add one execution leg's reported usage to a run.
+
+        ``None`` means the provider did not report that value. It does not erase
+        usage recorded by an earlier execution leg.
+        """
+        ...

--- a/src/agent_engine/runtime/streaming.py
+++ b/src/agent_engine/runtime/streaming.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from agent_engine.runtime.tool_models import ToolProviderName, ToolUsageRecord, ToolUsageStatus
 
@@ -82,3 +82,4 @@ class RunStreamEvent:
     approval_id: str | None = None
     agent_id: str | None = None
     description: str | None = None
+    arguments: dict[str, Any] | None = None

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -13,13 +13,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from agent_engine.approvals.errors import (
-    ApprovalAlreadyProcessed,
     ApprovalError,
-    ApprovalNotFound,
-    ApprovalRunMismatch,
-    InvalidDecision,
-    RunNotFound,
-    UnauthorizedApprover,
+    approval_http_status,
+    approval_public_message,
 )
 from agent_engine.engine.types import PendingApproval, RunResult
 from agent_engine.runtime.streaming import RunStreamEvent
@@ -70,15 +66,6 @@ _HTTP_ERRORS: dict[type[Exception], tuple[int, Any]] = {
     ConversationAlreadyExists: (409, "conversation id already taken"),
     ConversationTokenBudgetExceeded: (429, _BUDGET_EXCEEDED_DETAIL),
     ConversationLinkRefused: (403, "a visitor cannot adopt another visitor"),
-}
-
-_APPROVAL_HTTP_ERRORS: dict[type[ApprovalError], tuple[int, str]] = {
-    RunNotFound: (404, "run not found"),
-    ApprovalNotFound: (404, "approval not found"),
-    ApprovalRunMismatch: (404, "approval not found"),
-    UnauthorizedApprover: (403, "not authorized to decide this approval"),
-    ApprovalAlreadyProcessed: (409, "approval already processed"),
-    InvalidDecision: (400, "invalid approval decision"),
 }
 
 
@@ -240,10 +227,10 @@ async def decide_approval(
             "approval decision rejected",
             extra={"run_id": run_id, "approval_id": approval_id},
         )
-        status, detail = _APPROVAL_HTTP_ERRORS.get(
-            type(exc), (409, "approval could not be processed")
-        )
-        raise HTTPException(status_code=status, detail=detail) from None
+        raise HTTPException(
+            status_code=approval_http_status(exc),
+            detail=approval_public_message(exc),
+        ) from None
     except Exception:
         logger.exception(
             "approval decision failed",

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -12,16 +12,28 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
+from agent_engine.approvals.errors import (
+    ApprovalAlreadyProcessed,
+    ApprovalError,
+    ApprovalNotFound,
+    ApprovalRunMismatch,
+    InvalidDecision,
+    RunNotFound,
+    UnauthorizedApprover,
+)
+from agent_engine.engine.types import PendingApproval, RunResult
 from agent_engine.runtime.streaming import RunStreamEvent
 from agent_manager.api.deps import CallerIdentity, get_caller_identity, get_principal, get_service
 from agent_manager.api.schemas import (
     AnonymousPassResponse,
+    ApprovalDecisionRequest,
     ConversationSummary,
     CreateConversationRequest,
     CreateConversationResponse,
     LinkAnonymousRequest,
     LinkAnonymousResponse,
     MessageOut,
+    PendingApprovalOut,
     SendMessageRequest,
     SendMessageResponse,
     StreamEventOut,
@@ -58,6 +70,15 @@ _HTTP_ERRORS: dict[type[Exception], tuple[int, Any]] = {
     ConversationAlreadyExists: (409, "conversation id already taken"),
     ConversationTokenBudgetExceeded: (429, _BUDGET_EXCEEDED_DETAIL),
     ConversationLinkRefused: (403, "a visitor cannot adopt another visitor"),
+}
+
+_APPROVAL_HTTP_ERRORS: dict[type[ApprovalError], tuple[int, str]] = {
+    RunNotFound: (404, "run not found"),
+    ApprovalNotFound: (404, "approval not found"),
+    ApprovalRunMismatch: (404, "approval not found"),
+    UnauthorizedApprover: (403, "not authorized to decide this approval"),
+    ApprovalAlreadyProcessed: (409, "approval already processed"),
+    InvalidDecision: (400, "invalid approval decision"),
 }
 
 
@@ -148,6 +169,33 @@ def _client_tool_record(t: Any) -> ToolRecord:
     return ToolRecord(**fields)
 
 
+def _pending_approval(pa: PendingApproval | None) -> PendingApprovalOut | None:
+    if pa is None:
+        return None
+    return PendingApprovalOut(
+        run_id=pa.run_id,
+        approval_id=pa.approval_id,
+        agent_id=pa.agent_id,
+        tool_name=pa.tool_name,
+        description=pa.description,
+        provider=pa.provider,
+        server_id=pa.server_id,
+        arguments=pa.arguments,
+    )
+
+
+def _run_response(result: RunResult) -> SendMessageResponse:
+    pending = _pending_approval(result.pending_approval)
+    return SendMessageResponse(
+        answer=result.answer,
+        visited=list(result.visited),
+        used_tools=[_client_tool_record(t) for t in result.used_tools],
+        status=result.status,
+        run_id=pending.run_id if pending is not None else None,
+        pending_approval=pending,
+    )
+
+
 @router.post("/conversations/{conversation_id}/messages", response_model=SendMessageResponse)
 async def send_message(
     conversation_id: str, body: SendMessageRequest, service: Service, caller: Caller
@@ -161,11 +209,48 @@ async def send_message(
     except Exception:  # engine failure
         logger.exception("conversation request failed")
         raise HTTPException(status_code=500, detail=_INTERNAL_ERROR_MESSAGE) from None
-    return SendMessageResponse(
-        answer=result.answer,
-        visited=list(result.visited),
-        used_tools=[_client_tool_record(t) for t in result.used_tools],
-    )
+    return _run_response(result)
+
+
+@router.post(
+    "/conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision",
+    response_model=SendMessageResponse,
+)
+async def decide_approval(
+    conversation_id: str,
+    run_id: str,
+    approval_id: str,
+    body: ApprovalDecisionRequest,
+    service: Service,
+    caller: Caller,
+) -> SendMessageResponse:
+    try:
+        with _as_http_error():
+            result = await service.decide_approval(
+                conversation_id,
+                run_id,
+                approval_id,
+                body.decision,
+                caller,
+            )
+    except HTTPException:
+        raise
+    except ApprovalError as exc:
+        logger.info(
+            "approval decision rejected",
+            extra={"run_id": run_id, "approval_id": approval_id},
+        )
+        status, detail = _APPROVAL_HTTP_ERRORS.get(
+            type(exc), (409, "approval could not be processed")
+        )
+        raise HTTPException(status_code=status, detail=detail) from None
+    except Exception:
+        logger.exception(
+            "approval decision failed",
+            extra={"run_id": run_id, "approval_id": approval_id},
+        )
+        raise HTTPException(status_code=500, detail=_INTERNAL_ERROR_MESSAGE) from None
+    return _run_response(result)
 
 
 def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
@@ -182,6 +267,11 @@ def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
         used_tools=(
             [_client_tool_record(tool) for tool in event.used_tools] if event.used_tools else None
         ),
+        run_id=event.run_id,
+        approval_id=event.approval_id,
+        agent_id=event.agent_id,
+        description=event.description,
+        arguments=event.arguments,
     )
 
 

--- a/src/agent_manager/api/schemas.py
+++ b/src/agent_manager/api/schemas.py
@@ -7,9 +7,11 @@ through unchanged.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from agent_engine.approvals.decision import ApprovalDecision
 from agent_manager.domain import BudgetSeverity, Role
 
 
@@ -64,10 +66,28 @@ class ToolRecord(BaseModel):
     error: str | None = None
 
 
+class PendingApprovalOut(BaseModel):
+    run_id: str
+    approval_id: str
+    agent_id: str
+    tool_name: str
+    description: str
+    provider: str
+    server_id: str | None = None
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
 class SendMessageResponse(BaseModel):
     answer: str
     visited: list[str]
     used_tools: list[ToolRecord]
+    status: str = "completed"
+    run_id: str | None = None
+    pending_approval: PendingApprovalOut | None = None
+
+
+class ApprovalDecisionRequest(BaseModel):
+    decision: ApprovalDecision
 
 
 class TokenBudgetResponse(BaseModel):
@@ -88,3 +108,8 @@ class StreamEventOut(BaseModel):
     error: str | None = None
     system_name: str | None = None
     used_tools: list[ToolRecord] | None = None
+    run_id: str | None = None
+    approval_id: str | None = None
+    agent_id: str | None = None
+    description: str | None = None
+    arguments: dict[str, Any] | None = None

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -52173,12 +52173,17 @@ var AgentChatClient = class {
       method: "POST",
       body: JSON.stringify({ message })
     });
-    const data = await response.json();
-    return {
-      answer: String(data.answer || ""),
-      visited: Array.isArray(data.visited) ? data.visited : void 0,
-      used_tools: Array.isArray(data.used_tools) ? data.used_tools : void 0
-    };
+    return parseRunResponse(await response.json());
+  }
+  async decideApproval(conversationId, runId, approvalId, decision) {
+    const response = await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/decision`,
+      {
+        method: "POST",
+        body: JSON.stringify({ decision })
+      }
+    );
+    return parseRunResponse(await response.json());
   }
   async getUsage(conversationId) {
     const response = await this.request(`/conversations/${conversationId}/usage`);
@@ -52221,6 +52226,16 @@ var AgentChatClient = class {
     }
   }
 };
+function parseRunResponse(data) {
+  return {
+    answer: String(data.answer || ""),
+    visited: Array.isArray(data.visited) ? data.visited : void 0,
+    used_tools: Array.isArray(data.used_tools) ? data.used_tools : void 0,
+    status: data.status === "pending_approval" ? "pending_approval" : "completed",
+    run_id: data.run_id == null ? null : String(data.run_id),
+    pending_approval: typeof data.pending_approval === "object" && data.pending_approval !== null ? data.pending_approval : null
+  };
+}
 function parseSseFrame(frame) {
   const dataLines = frame.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => line.slice("data:".length).trimStart());
   if (!dataLines.length) return null;
@@ -53157,6 +53172,26 @@ function reduceStreamEvent(entry, event) {
         route: event.route ?? entry.route,
         tools: event.used_tools ?? entry.tools
       };
+    case "pending_approval":
+      if (!event.run_id || !event.approval_id || !event.agent_id || !event.tool_name) {
+        throw new Error("invalid pending approval event");
+      }
+      return {
+        ...entry,
+        typing: false,
+        route: event.route ?? entry.route,
+        tools: event.used_tools ?? entry.tools,
+        approval: {
+          run_id: event.run_id,
+          approval_id: event.approval_id,
+          agent_id: event.agent_id,
+          tool_name: event.tool_name,
+          description: event.description ?? `${event.agent_id} wants to use ${event.tool_name}.`,
+          provider: event.provider,
+          server_id: event.server_id,
+          arguments: event.arguments
+        }
+      };
     case "error":
       throw new Error(event.error || "stream failed");
     default:
@@ -53223,6 +53258,10 @@ function useConversation(client, endpoint, onReplaced) {
     },
     [client, replace2]
   );
+  const decideApproval = (0, import_react9.useCallback)(
+    (conversationId, runId, approvalId, decision) => client.decideApproval(conversationId, runId, approvalId, decision),
+    [client]
+  );
   const loadHistory = (0, import_react9.useCallback)(
     async (conversationId) => {
       try {
@@ -53261,13 +53300,25 @@ function useConversation(client, endpoint, onReplaced) {
       ensureId,
       send,
       stream,
+      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,
       switchTo,
       startNew
     }),
-    [peekId, ensureId, send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew]
+    [
+      peekId,
+      ensureId,
+      send,
+      stream,
+      decideApproval,
+      loadHistory,
+      loadUsage,
+      listThreads,
+      switchTo,
+      startNew
+    ]
   );
 }
 
@@ -53281,6 +53332,17 @@ var toEntry = (message) => ({
   id: newId(),
   role: message.role === "user" ? "user" : "ai",
   text: message.content
+});
+var applyRunResponse = (entry, response) => ({
+  ...entry,
+  text: response.answer,
+  typing: false,
+  error: false,
+  route: response.visited ?? entry.route,
+  tools: response.used_tools ?? entry.tools,
+  approval: response.pending_approval ?? void 0,
+  approvalSubmitting: false,
+  approvalError: void 0
 });
 function AgentChatApp({
   client,
@@ -53299,10 +53361,12 @@ function AgentChatApp({
   const [activeId, setActiveId] = (0, import_react10.useState)("");
   const entries = entriesById[activeId] ?? [];
   const usage = usageById[activeId] ?? null;
+  const awaitingApproval = entries.some((entry) => entry.approval !== void 0);
   const [threads, setThreads] = (0, import_react10.useState)([]);
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
   const launcherRef = (0, import_react10.useRef)(null);
   const inputRef = (0, import_react10.useRef)(null);
+  const approvalRequestsRef = (0, import_react10.useRef)(/* @__PURE__ */ new Set());
   const onReplaced = (0, import_react10.useCallback)((staleId, freshId) => {
     setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
     setActiveId((current) => current === staleId ? freshId : current);
@@ -53339,8 +53403,8 @@ function AgentChatApp({
     if (inline) void loadHistory();
   }, [inline, loadHistory]);
   (0, import_react10.useEffect)(() => {
-    if (open) inputRef.current?.focus({ preventScroll: true });
-  }, [open, loaded, sending]);
+    if (open && !awaitingApproval) inputRef.current?.focus({ preventScroll: true });
+  }, [open, loaded, sending, awaitingApproval]);
   const openChat = (0, import_react10.useCallback)(async () => {
     if (inline) return;
     setOpen(true);
@@ -53380,14 +53444,14 @@ function AgentChatApp({
     async (cid, text10, entryId) => {
       try {
         const answer = await conversation.send(cid, text10);
-        replaceEntry(cid, entryId, {
-          id: entryId,
-          role: "ai",
-          text: answer.answer,
-          route: answer.visited,
-          tools: answer.used_tools
-        });
-        onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
+        replaceEntry(
+          cid,
+          entryId,
+          applyRunResponse({ id: entryId, role: "ai", text: "" }, answer)
+        );
+        if (!answer.pending_approval) {
+          onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
+        }
       } catch (error) {
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
@@ -53399,6 +53463,49 @@ function AgentChatApp({
     },
     [conversation, onAnswer, replaceEntry]
   );
+  const decideApproval = (0, import_react10.useCallback)(
+    async (cid, entryId, approval, decision) => {
+      if (approvalRequestsRef.current.has(approval.approval_id)) return;
+      approvalRequestsRef.current.add(approval.approval_id);
+      putEntries(
+        cid,
+        (prev) => prev.map(
+          (entry) => entry.id === entryId ? { ...entry, approvalSubmitting: true, approvalError: void 0 } : entry
+        )
+      );
+      try {
+        const result = await conversation.decideApproval(
+          cid,
+          approval.run_id,
+          approval.approval_id,
+          decision
+        );
+        putEntries(
+          cid,
+          (prev) => prev.map((entry) => entry.id === entryId ? applyRunResponse(entry, result) : entry)
+        );
+        if (!result.pending_approval) {
+          onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
+        }
+      } catch (error) {
+        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
+        putEntries(
+          cid,
+          (prev) => prev.map(
+            (entry) => entry.id === entryId ? {
+              ...entry,
+              approvalSubmitting: false,
+              approvalError: is4xx ? error.message : GENERIC_ERROR
+            } : entry
+          )
+        );
+      } finally {
+        approvalRequestsRef.current.delete(approval.approval_id);
+        void refreshUsage(cid);
+      }
+    },
+    [conversation, onAnswer, putEntries, refreshUsage]
+  );
   const submit = (0, import_react10.useCallback)(
     async (text10) => {
       const cid = await conversation.ensureId();
@@ -53406,21 +53513,33 @@ function AgentChatApp({
       const pending = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
       setSending(true);
+      let entry = pending;
+      let receivedEvent = false;
+      let completed = false;
       try {
-        let entry = pending;
         for await (const event of conversation.stream(cid, text10)) {
+          receivedEvent = true;
+          completed || (completed = event.type === "final");
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
         }
         replaceEntry(cid, pending.id, { ...entry, typing: false });
-        onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        if (!entry.approval) {
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        }
       } catch (error) {
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
           setBudgetExceeded(true);
         }
-        if (is4xx) {
-          replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: error.message, error: true });
+        if (completed) {
+          replaceEntry(cid, pending.id, { ...entry, typing: false });
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        } else if (entry.approval) {
+          replaceEntry(cid, pending.id, { ...entry, typing: false });
+        } else if (is4xx || receivedEvent) {
+          const message = is4xx ? error.message : GENERIC_ERROR;
+          replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: message, error: true });
         } else {
           await sendWithoutStreaming(cid, text10, pending.id);
         }
@@ -53494,17 +53613,24 @@ function AgentChatApp({
                 ),
                 /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Conversation, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(ConversationContent, { children: [
                   entries.length === 0 ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Welcome, { title: config.greeting || DEFAULT_GREETING }) : null,
-                  entries.map((entry) => /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(ChatMessage, { entry }, entry.id))
+                  entries.map((entry) => /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+                    ChatMessage,
+                    {
+                      entry,
+                      onApproval: (approval, decision) => void decideApproval(activeId, entry.id, approval, decision)
+                    },
+                    entry.id
+                  ))
                 ] }) }),
                 /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(PromptInput, { onSubmit: (message) => void submit(message.text), children: [
                   /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
                     PromptInputTextarea,
                     {
                       "aria-label": "Message",
-                      disabled: sending || budgetExceeded,
+                      disabled: sending || budgetExceeded || awaitingApproval,
                       inputRef,
                       onSubmit: () => inputRef.current?.form?.requestSubmit(),
-                      placeholder: budgetExceeded ? "Context limit reached." : "Message..."
+                      placeholder: budgetExceeded ? "Context limit reached." : awaitingApproval ? "Respond to the approval request above." : "Message..."
                     }
                   ),
                   /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(PromptInputFooter, { children: [
@@ -53512,7 +53638,7 @@ function AgentChatApp({
                       usage ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(BudgetMeter, { usage }) : null,
                       /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "prompt-hint", children: "Enter to send \xB7 Shift+Enter for a new line" })
                     ] }),
-                    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(PromptInputSubmit, { disabled: sending || budgetExceeded })
+                    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(PromptInputSubmit, { disabled: sending || budgetExceeded || awaitingApproval })
                   ] })
                 ] }),
                 /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "powered", children: "Powered by Extra" })
@@ -53553,7 +53679,10 @@ function Launcher({
     }
   );
 }
-function ChatMessage({ entry }) {
+function ChatMessage({
+  entry,
+  onApproval
+}) {
   const from = entry.role === "user" ? "user" : "assistant";
   if (entry.error) {
     return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from, children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "msg-error", role: "alert", children: entry.text }) });
@@ -53565,9 +53694,64 @@ function ChatMessage({ entry }) {
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Message, { from: "assistant", typing: thinking, children: [
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(AgentActivity, { route: entry.route, tools: entry.tools }),
     thinking ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(ThinkingDots, {}) : /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(import_jsx_runtime4.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageResponse, { children: entry.text }) }),
+      entry.approval ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+        ApprovalRequest,
+        {
+          approval: entry.approval,
+          error: entry.approvalError,
+          submitting: Boolean(entry.approvalSubmitting),
+          onDecision: (decision) => onApproval(entry.approval, decision)
+        }
+      ) : null,
+      entry.text.trim() ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageResponse, { children: entry.text }) }) : null,
       entry.text.trim() ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageActions, { text: entry.text }) : null
     ] })
+  ] });
+}
+function ApprovalRequest({
+  approval,
+  submitting,
+  error,
+  onDecision
+}) {
+  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("section", { className: "approval-card", "aria-busy": submitting, "aria-label": "Tool approval request", children: [
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-title", children: "Approval required" }),
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-tool", children: approval.tool_name }),
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-description", children: approval.description }),
+    error ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-error", role: "alert", children: error }) : null,
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "approval-actions", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+        "button",
+        {
+          className: "approval-button primary",
+          disabled: submitting,
+          onClick: () => onDecision("allow_once"),
+          type: "button",
+          children: "Approve"
+        }
+      ),
+      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+        "button",
+        {
+          className: "approval-button danger",
+          disabled: submitting,
+          onClick: () => onDecision("deny"),
+          type: "button",
+          children: "Deny"
+        }
+      ),
+      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+        "button",
+        {
+          className: "approval-button",
+          disabled: submitting,
+          onClick: () => onDecision("allow_for_session"),
+          type: "button",
+          children: "Approve for this session"
+        }
+      )
+    ] }),
+    submitting ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "approval-status", children: "Applying decision\u2026" }) : null
   ] });
 }
 function ThinkingDots() {
@@ -53861,6 +54045,31 @@ function styles(config) {
     .tool-badge.output-error { color: #991b1b; background: #fee2e2; }
     .tool-content { border-top: 1px solid #e4e4e7; padding: 8px 10px; }
     .tool-error { color: #991b1b; font-size: 12px; white-space: pre-wrap; }
+    .approval-card { border: 1px solid #e4e4e7; border-radius: 10px; background: #fafafa;
+      padding: 10px 11px; white-space: normal; box-shadow: 0 1px 2px rgba(0,0,0,.03); }
+    .approval-title { margin: 0; color: #3f3f46; font-size: 12.5px; font-weight: 600;
+      display: flex; align-items: center; gap: 7px; }
+    .approval-title::before { width: 6px; height: 6px; border-radius: 50%; background: #f59e0b;
+      content: ""; flex: 0 0 auto; }
+    .approval-tool { display: inline-block; margin: 6px 0 0; border: 1px solid #e4e4e7;
+      border-radius: 6px; background: #fff; color: #27272a; padding: 2px 6px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px; font-weight: 500; line-height: 1.4; overflow-wrap: anywhere; }
+    .approval-description { margin: 7px 0 0; color: #71717a; font-size: 12.5px;
+      line-height: 1.45; }
+    .approval-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+      margin-top: 10px; }
+    .approval-button { min-height: 30px; border: 1px solid #d4d4d8; border-radius: 7px;
+      background: #fff; color: #52525b; cursor: pointer; font-family: inherit; font-size: 12px;
+      font-weight: 500; padding: 5px 9px; transition: background .12s, color .12s, opacity .12s; }
+    .approval-button:hover:not(:disabled) { background: #f4f4f5; }
+    .approval-button.primary { border-color: ${config.color}; background: ${config.color}; color: #fff; }
+    .approval-button.primary:hover:not(:disabled) { opacity: .88; }
+    .approval-button.danger { border-color: transparent; background: transparent; color: #71717a; }
+    .approval-button.danger:hover:not(:disabled) { background: #f4f4f5; color: #18181b; }
+    .approval-button:disabled { cursor: default; opacity: .55; }
+    .approval-error { margin: 8px 0 0; color: #b91c1c; font-size: 12px; }
+    .approval-status { display: block; margin-top: 8px; color: #71717a; font-size: 12px; }
     .msg-error { margin-top: 2px; border: 1px solid #fecaca; background: #fef2f2;
       color: #b91c1c; border-radius: 8px; padding: 10px 12px; font-size: 13.5px;
       line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2;
@@ -53934,6 +54143,7 @@ function styles(config) {
       .launcher svg,
       .close,
       .send,
+      .approval-button,
       .panel {
         transition: none;
       }

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -53258,10 +53258,6 @@ function useConversation(client, endpoint, onReplaced) {
     },
     [client, replace2]
   );
-  const decideApproval = (0, import_react9.useCallback)(
-    (conversationId, runId, approvalId, decision) => client.decideApproval(conversationId, runId, approvalId, decision),
-    [client]
-  );
   const loadHistory = (0, import_react9.useCallback)(
     async (conversationId) => {
       try {
@@ -53300,7 +53296,6 @@ function useConversation(client, endpoint, onReplaced) {
       ensureId,
       send,
       stream,
-      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -53312,7 +53307,6 @@ function useConversation(client, endpoint, onReplaced) {
       ensureId,
       send,
       stream,
-      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -53327,6 +53321,12 @@ var import_jsx_runtime4 = __toESM(require_jsx_runtime(), 1);
 var DEFAULT_GREETING = "How can I help you today?";
 var GENERIC_ERROR = "Something went wrong. Please try again.";
 var COPIED_RESET_MS = 2e3;
+var isTerminalApprovalError = (error) => error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500 && ![408, 425, 429].includes(error.status);
+var terminalApprovalMessage = (status) => {
+  if (status === 403) return "You are not authorized to decide this approval.";
+  if (status === 409) return "This approval was already processed. You can continue chatting.";
+  return "This approval is no longer available. You can continue chatting.";
+};
 var newId = randomId;
 var toEntry = (message) => ({
   id: newId(),
@@ -53474,7 +53474,7 @@ function AgentChatApp({
         )
       );
       try {
-        const result = await conversation.decideApproval(
+        const result = await client.decideApproval(
           cid,
           approval.run_id,
           approval.approval_id,
@@ -53488,14 +53488,21 @@ function AgentChatApp({
           onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
         }
       } catch (error) {
-        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
+        const terminal = isTerminalApprovalError(error);
         putEntries(
           cid,
           (prev) => prev.map(
-            (entry) => entry.id === entryId ? {
+            (entry) => entry.id === entryId ? terminal ? {
+              ...entry,
+              text: terminalApprovalMessage(error.status),
+              error: true,
+              approval: void 0,
+              approvalSubmitting: false,
+              approvalError: void 0
+            } : {
               ...entry,
               approvalSubmitting: false,
-              approvalError: is4xx ? error.message : GENERIC_ERROR
+              approvalError: GENERIC_ERROR
             } : entry
           )
         );
@@ -53504,7 +53511,7 @@ function AgentChatApp({
         void refreshUsage(cid);
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage]
+    [client, onAnswer, putEntries, refreshUsage]
   );
   const submit = (0, import_react10.useCallback)(
     async (text10) => {
@@ -53716,8 +53723,11 @@ function ApprovalRequest({
 }) {
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("section", { className: "approval-card", "aria-busy": submitting, "aria-label": "Tool approval request", children: [
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-title", children: "Approval required" }),
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-tool", children: approval.tool_name }),
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-description", children: approval.description }),
+    /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("p", { className: "approval-tool", children: [
+      "Tool: ",
+      approval.tool_name
+    ] }),
     error ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-error", role: "alert", children: error }) : null,
     /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "approval-actions", children: [
       /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(

--- a/src/agent_manager/api/static/widget.test.mjs
+++ b/src/agent_manager/api/static/widget.test.mjs
@@ -325,6 +325,9 @@ globalThis.fetch = async (url, options = {}) => {
   fetchCalls.push({ url, options });
   if (url.endsWith("/conversations")) return jsonResponse({ conversation_id: "conv-1" });
   if (url.endsWith("/messages")) return jsonResponse({ answer: "hello back" });
+  if (url.endsWith("/runs/run-1/approvals/approval-1/decision")) {
+    return jsonResponse({ answer: "approved", status: "completed", pending_approval: null });
+  }
   throw new Error(`unexpected fetch: ${url}`);
 };
 let client = new AgentChatClient("https://api.example", new TokenSource("https://api.example"));
@@ -335,6 +338,18 @@ assert.equal(fetchCalls[0].url, "https://api.example/conversations");
 assert.equal(fetchCalls[1].url, "https://api.example/conversations/conv-1/messages");
 assert.equal(JSON.parse(fetchCalls[1].options.body).message, "hello");
 assert.equal(sendResponse.answer, "hello back");
+const approvalResponse = await client.decideApproval(
+  conversationId,
+  "run-1",
+  "approval-1",
+  "allow_for_session",
+);
+assert.equal(
+  fetchCalls[2].url,
+  "https://api.example/conversations/conv-1/runs/run-1/approvals/approval-1/decision",
+);
+assert.equal(JSON.parse(fetchCalls[2].options.body).decision, "allow_for_session");
+assert.equal(approvalResponse.answer, "approved");
 
 resetPage();
 globalThis.fetch = async (url) => {

--- a/src/agent_manager/api/static/widget/api/AgentChatClient.ts
+++ b/src/agent_manager/api/static/widget/api/AgentChatClient.ts
@@ -1,5 +1,6 @@
 import type { TokenSource } from "../auth/tokenSource";
 import type {
+  ApprovalDecision,
   ChatMessage,
   TokenBudget,
   SendMessageResponse,
@@ -90,12 +91,23 @@ export class AgentChatClient {
       body: JSON.stringify({ message }),
     });
 
-    const data = await response.json();
-    return {
-      answer: String(data.answer || ""),
-      visited: Array.isArray(data.visited) ? (data.visited as string[]) : undefined,
-      used_tools: Array.isArray(data.used_tools) ? data.used_tools : undefined,
-    };
+    return parseRunResponse(await response.json());
+  }
+
+  async decideApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+    decision: ApprovalDecision,
+  ): Promise<SendMessageResponse> {
+    const response = await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/decision`,
+      {
+        method: "POST",
+        body: JSON.stringify({ decision }),
+      },
+    );
+    return parseRunResponse(await response.json());
   }
 
   async getUsage(conversationId: string): Promise<TokenBudget> {
@@ -141,6 +153,20 @@ export class AgentChatClient {
       reader.releaseLock();
     }
   }
+}
+
+function parseRunResponse(data: Record<string, unknown>): SendMessageResponse {
+  return {
+    answer: String(data.answer || ""),
+    visited: Array.isArray(data.visited) ? (data.visited as string[]) : undefined,
+    used_tools: Array.isArray(data.used_tools) ? data.used_tools : undefined,
+    status: data.status === "pending_approval" ? "pending_approval" : "completed",
+    run_id: data.run_id == null ? null : String(data.run_id),
+    pending_approval:
+      typeof data.pending_approval === "object" && data.pending_approval !== null
+        ? (data.pending_approval as SendMessageResponse["pending_approval"])
+        : null,
+  };
 }
 
 function parseSseFrame(frame: string): StreamEvent | null {

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -48,6 +48,18 @@ const DEFAULT_GREETING = "How can I help you today?";
 const GENERIC_ERROR = "Something went wrong. Please try again.";
 const COPIED_RESET_MS = 2000;
 
+const isTerminalApprovalError = (error: unknown): error is AgentChatHttpError =>
+  error instanceof AgentChatHttpError &&
+  error.status >= 400 &&
+  error.status < 500 &&
+  ![408, 425, 429].includes(error.status);
+
+const terminalApprovalMessage = (status: number): string => {
+  if (status === 403) return "You are not authorized to decide this approval.";
+  if (status === 409) return "This approval was already processed. You can continue chatting.";
+  return "This approval is no longer available. You can continue chatting.";
+};
+
 const newId = randomId;
 
 const toEntry = (message: ChatMessage): MessageEntry => ({
@@ -239,7 +251,7 @@ export function AgentChatApp({
         ),
       );
       try {
-        const result = await conversation.decideApproval(
+        const result = await client.decideApproval(
           cid,
           approval.run_id,
           approval.approval_id,
@@ -252,15 +264,24 @@ export function AgentChatApp({
           onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
         }
       } catch (error) {
-        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
+        const terminal = isTerminalApprovalError(error);
         putEntries(cid, (prev) =>
           prev.map((entry) =>
             entry.id === entryId
-              ? {
-                  ...entry,
-                  approvalSubmitting: false,
-                  approvalError: is4xx ? error.message : GENERIC_ERROR,
-                }
+              ? terminal
+                ? {
+                    ...entry,
+                    text: terminalApprovalMessage(error.status),
+                    error: true,
+                    approval: undefined,
+                    approvalSubmitting: false,
+                    approvalError: undefined,
+                  }
+                : {
+                    ...entry,
+                    approvalSubmitting: false,
+                    approvalError: GENERIC_ERROR,
+                  }
               : entry,
           ),
         );
@@ -269,7 +290,7 @@ export function AgentChatApp({
         void refreshUsage(cid);
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage],
+    [client, onAnswer, putEntries, refreshUsage],
   );
 
   const submit = useCallback(
@@ -527,8 +548,8 @@ function ApprovalRequest({
   return (
     <section className="approval-card" aria-busy={submitting} aria-label="Tool approval request">
       <p className="approval-title">Approval required</p>
-      <p className="approval-tool">{approval.tool_name}</p>
       <p className="approval-description">{approval.description}</p>
+      <p className="approval-tool">Tool: {approval.tool_name}</p>
       {error ? (
         <p className="approval-error" role="alert">
           {error}

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -16,10 +16,13 @@ import { getStoredConversationId } from "../storage/conversationStorage";
 import type {
   AgentChatAnswerDetail,
   AgentChatConfig,
+  ApprovalDecision,
   ChatMessage,
-  TokenBudget,
   MessageEntry,
+  PendingApproval,
+  SendMessageResponse,
   ThreadSummary,
+  TokenBudget,
   ToolRecord,
 } from "../types";
 import {
@@ -53,6 +56,21 @@ const toEntry = (message: ChatMessage): MessageEntry => ({
   text: message.content,
 });
 
+const applyRunResponse = (
+  entry: MessageEntry,
+  response: SendMessageResponse,
+): MessageEntry => ({
+  ...entry,
+  text: response.answer,
+  typing: false,
+  error: false,
+  route: response.visited ?? entry.route,
+  tools: response.used_tools ?? entry.tools,
+  approval: response.pending_approval ?? undefined,
+  approvalSubmitting: false,
+  approvalError: undefined,
+});
+
 export interface AgentChatAppProps {
   client: AgentChatClient;
   config: AgentChatConfig;
@@ -78,11 +96,13 @@ export function AgentChatApp({
   const [activeId, setActiveId] = useState("");
   const entries = entriesById[activeId] ?? [];
   const usage = usageById[activeId] ?? null;
+  const awaitingApproval = entries.some((entry) => entry.approval !== undefined);
 
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [threadsOpen, setThreadsOpen] = useState(false);
   const launcherRef = useRef<HTMLButtonElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const approvalRequestsRef = useRef(new Set<string>());
 
   // A vanished conversation is replaced mid-turn; carry its messages onto the
   // id the turn actually ran under so the view does not go blank.
@@ -130,8 +150,8 @@ export function AgentChatApp({
   }, [inline, loadHistory]);
 
   useEffect(() => {
-    if (open) inputRef.current?.focus({ preventScroll: true });
-  }, [open, loaded, sending]);
+    if (open && !awaitingApproval) inputRef.current?.focus({ preventScroll: true });
+  }, [open, loaded, sending, awaitingApproval]);
 
   const openChat = useCallback(async () => {
     if (inline) return;
@@ -182,14 +202,14 @@ export function AgentChatApp({
     async (cid: string, text: string, entryId: string) => {
       try {
         const answer = await conversation.send(cid, text);
-        replaceEntry(cid, entryId, {
-          id: entryId,
-          role: "ai",
-          text: answer.answer,
-          route: answer.visited,
-          tools: answer.used_tools,
-        });
-        onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
+        replaceEntry(
+          cid,
+          entryId,
+          applyRunResponse({ id: entryId, role: "ai", text: "" }, answer),
+        );
+        if (!answer.pending_approval) {
+          onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
+        }
       } catch (error) {
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
@@ -202,6 +222,56 @@ export function AgentChatApp({
     [conversation, onAnswer, replaceEntry],
   );
 
+  const decideApproval = useCallback(
+    async (
+      cid: string,
+      entryId: string,
+      approval: PendingApproval,
+      decision: ApprovalDecision,
+    ) => {
+      if (approvalRequestsRef.current.has(approval.approval_id)) return;
+      approvalRequestsRef.current.add(approval.approval_id);
+      putEntries(cid, (prev) =>
+        prev.map((entry) =>
+          entry.id === entryId
+            ? { ...entry, approvalSubmitting: true, approvalError: undefined }
+            : entry,
+        ),
+      );
+      try {
+        const result = await conversation.decideApproval(
+          cid,
+          approval.run_id,
+          approval.approval_id,
+          decision,
+        );
+        putEntries(cid, (prev) =>
+          prev.map((entry) => (entry.id === entryId ? applyRunResponse(entry, result) : entry)),
+        );
+        if (!result.pending_approval) {
+          onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
+        }
+      } catch (error) {
+        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
+        putEntries(cid, (prev) =>
+          prev.map((entry) =>
+            entry.id === entryId
+              ? {
+                  ...entry,
+                  approvalSubmitting: false,
+                  approvalError: is4xx ? error.message : GENERIC_ERROR,
+                }
+              : entry,
+          ),
+        );
+      } finally {
+        approvalRequestsRef.current.delete(approval.approval_id);
+        void refreshUsage(cid);
+      }
+    },
+    [conversation, onAnswer, putEntries, refreshUsage],
+  );
+
   const submit = useCallback(
     async (text: string) => {
       const cid = await conversation.ensureId();
@@ -209,21 +279,33 @@ export function AgentChatApp({
       const pending: MessageEntry = { id: newId(), role: "ai", text: "", typing: true };
       putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text }, pending]);
       setSending(true);
+      let entry = pending;
+      let receivedEvent = false;
+      let completed = false;
       try {
-        let entry = pending;
         for await (const event of conversation.stream(cid, text)) {
+          receivedEvent = true;
+          completed ||= event.type === "final";
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
         }
         replaceEntry(cid, pending.id, { ...entry, typing: false });
-        onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        if (!entry.approval) {
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        }
       } catch (error) {
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
           setBudgetExceeded(true);
         }
-        if (is4xx) {
-          replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: error.message, error: true });
+        if (completed) {
+          replaceEntry(cid, pending.id, { ...entry, typing: false });
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        } else if (entry.approval) {
+          replaceEntry(cid, pending.id, { ...entry, typing: false });
+        } else if (is4xx || receivedEvent) {
+          const message = is4xx ? error.message : GENERIC_ERROR;
+          replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: message, error: true });
         } else {
           await sendWithoutStreaming(cid, text, pending.id);
         }
@@ -303,24 +385,36 @@ export function AgentChatApp({
                 <Welcome title={config.greeting || DEFAULT_GREETING} />
               ) : null}
               {entries.map((entry) => (
-                <ChatMessage key={entry.id} entry={entry} />
+                <ChatMessage
+                  key={entry.id}
+                  entry={entry}
+                  onApproval={(approval, decision) =>
+                    void decideApproval(activeId, entry.id, approval, decision)
+                  }
+                />
               ))}
             </ConversationContent>
           </Conversation>
           <PromptInput onSubmit={(message) => void submit(message.text)}>
             <PromptInputTextarea
               aria-label="Message"
-              disabled={sending || budgetExceeded}
+              disabled={sending || budgetExceeded || awaitingApproval}
               inputRef={inputRef}
               onSubmit={() => inputRef.current?.form?.requestSubmit()}
-              placeholder={budgetExceeded ? "Context limit reached." : "Message..."}
+              placeholder={
+                budgetExceeded
+                  ? "Context limit reached."
+                  : awaitingApproval
+                    ? "Respond to the approval request above."
+                    : "Message..."
+              }
             />
             <PromptInputFooter>
               <div className="footer-start">
                 {usage ? <BudgetMeter usage={usage} /> : null}
                 <span className="prompt-hint">Enter to send · Shift+Enter for a new line</span>
               </div>
-              <PromptInputSubmit disabled={sending || budgetExceeded} />
+              <PromptInputSubmit disabled={sending || budgetExceeded || awaitingApproval} />
             </PromptInputFooter>
           </PromptInput>
           <div className="powered">Powered by Extra</div>
@@ -363,7 +457,13 @@ function Launcher({
   );
 }
 
-function ChatMessage({ entry }: { entry: MessageEntry }) {
+function ChatMessage({
+  entry,
+  onApproval,
+}: {
+  entry: MessageEntry;
+  onApproval: (approval: PendingApproval, decision: ApprovalDecision) => void;
+}) {
   const from = entry.role === "user" ? "user" : "assistant";
 
   if (entry.error) {
@@ -393,13 +493,75 @@ function ChatMessage({ entry }: { entry: MessageEntry }) {
         <ThinkingDots />
       ) : (
         <>
-          <MessageContent>
-            <MessageResponse>{entry.text}</MessageResponse>
-          </MessageContent>
+          {entry.approval ? (
+            <ApprovalRequest
+              approval={entry.approval}
+              error={entry.approvalError}
+              submitting={Boolean(entry.approvalSubmitting)}
+              onDecision={(decision) => onApproval(entry.approval as PendingApproval, decision)}
+            />
+          ) : null}
+          {entry.text.trim() ? (
+            <MessageContent>
+              <MessageResponse>{entry.text}</MessageResponse>
+            </MessageContent>
+          ) : null}
           {entry.text.trim() ? <MessageActions text={entry.text} /> : null}
         </>
       )}
     </Message>
+  );
+}
+
+function ApprovalRequest({
+  approval,
+  submitting,
+  error,
+  onDecision,
+}: {
+  approval: PendingApproval;
+  submitting: boolean;
+  error?: string;
+  onDecision: (decision: ApprovalDecision) => void;
+}) {
+  return (
+    <section className="approval-card" aria-busy={submitting} aria-label="Tool approval request">
+      <p className="approval-title">Approval required</p>
+      <p className="approval-tool">{approval.tool_name}</p>
+      <p className="approval-description">{approval.description}</p>
+      {error ? (
+        <p className="approval-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div className="approval-actions">
+        <button
+          className="approval-button primary"
+          disabled={submitting}
+          onClick={() => onDecision("allow_once")}
+          type="button"
+        >
+          Approve
+        </button>
+        <button
+          className="approval-button danger"
+          disabled={submitting}
+          onClick={() => onDecision("deny")}
+          type="button"
+        >
+          Deny
+        </button>
+        <button
+          className="approval-button"
+          disabled={submitting}
+          onClick={() => onDecision("allow_for_session")}
+          type="button"
+        >
+          Approve for this session
+        </button>
+      </div>
+      {submitting ? <span className="approval-status">Applying decision…</span> : null}
+    </section>
   );
 }
 

--- a/src/agent_manager/api/static/widget/react/streamReducer.ts
+++ b/src/agent_manager/api/static/widget/react/streamReducer.ts
@@ -23,6 +23,26 @@ export function reduceStreamEvent(entry: MessageEntry, event: StreamEvent): Mess
         route: event.route ?? entry.route,
         tools: event.used_tools ?? entry.tools,
       };
+    case "pending_approval":
+      if (!event.run_id || !event.approval_id || !event.agent_id || !event.tool_name) {
+        throw new Error("invalid pending approval event");
+      }
+      return {
+        ...entry,
+        typing: false,
+        route: event.route ?? entry.route,
+        tools: event.used_tools ?? entry.tools,
+        approval: {
+          run_id: event.run_id,
+          approval_id: event.approval_id,
+          agent_id: event.agent_id,
+          tool_name: event.tool_name,
+          description: event.description ?? `${event.agent_id} wants to use ${event.tool_name}.`,
+          provider: event.provider,
+          server_id: event.server_id,
+          arguments: event.arguments,
+        },
+      };
     case "error":
       throw new Error(event.error || "stream failed");
     default:

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -7,7 +7,6 @@ import {
   setStoredConversationId,
 } from "../storage/conversationStorage";
 import type {
-  ApprovalDecision,
   ChatMessage,
   TokenBudget,
   SendMessageResponse,
@@ -26,12 +25,6 @@ export interface Conversation {
   ensureId(): Promise<string>;
   send(conversationId: string, text: string): Promise<SendMessageResponse>;
   stream(conversationId: string, text: string): AsyncGenerator<StreamEvent>;
-  decideApproval(
-    conversationId: string,
-    runId: string,
-    approvalId: string,
-    decision: ApprovalDecision,
-  ): Promise<SendMessageResponse>;
   loadHistory(conversationId: string): Promise<ChatMessage[]>;
   loadUsage(conversationId: string): Promise<TokenBudget | null>;
   listThreads(): Promise<ThreadSummary[]>;
@@ -100,16 +93,6 @@ export function useConversation(
     [client, replace],
   );
 
-  const decideApproval = useCallback(
-    (
-      conversationId: string,
-      runId: string,
-      approvalId: string,
-      decision: ApprovalDecision,
-    ) => client.decideApproval(conversationId, runId, approvalId, decision),
-    [client],
-  );
-
   const loadHistory = useCallback(
     async (conversationId: string) => {
       try {
@@ -153,7 +136,6 @@ export function useConversation(
       ensureId,
       send,
       stream,
-      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -165,7 +147,6 @@ export function useConversation(
       ensureId,
       send,
       stream,
-      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -7,6 +7,7 @@ import {
   setStoredConversationId,
 } from "../storage/conversationStorage";
 import type {
+  ApprovalDecision,
   ChatMessage,
   TokenBudget,
   SendMessageResponse,
@@ -25,6 +26,12 @@ export interface Conversation {
   ensureId(): Promise<string>;
   send(conversationId: string, text: string): Promise<SendMessageResponse>;
   stream(conversationId: string, text: string): AsyncGenerator<StreamEvent>;
+  decideApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+    decision: ApprovalDecision,
+  ): Promise<SendMessageResponse>;
   loadHistory(conversationId: string): Promise<ChatMessage[]>;
   loadUsage(conversationId: string): Promise<TokenBudget | null>;
   listThreads(): Promise<ThreadSummary[]>;
@@ -93,6 +100,16 @@ export function useConversation(
     [client, replace],
   );
 
+  const decideApproval = useCallback(
+    (
+      conversationId: string,
+      runId: string,
+      approvalId: string,
+      decision: ApprovalDecision,
+    ) => client.decideApproval(conversationId, runId, approvalId, decision),
+    [client],
+  );
+
   const loadHistory = useCallback(
     async (conversationId: string) => {
       try {
@@ -136,13 +153,24 @@ export function useConversation(
       ensureId,
       send,
       stream,
+      decideApproval,
       loadHistory,
       loadUsage,
       listThreads,
       switchTo,
       startNew,
     }),
-    [peekId, ensureId, send, stream, loadHistory, loadUsage, listThreads, switchTo, startNew],
+    [
+      peekId,
+      ensureId,
+      send,
+      stream,
+      decideApproval,
+      loadHistory,
+      loadUsage,
+      listThreads,
+      switchTo,
+      startNew,
+    ],
   );
 }
-

--- a/src/agent_manager/api/static/widget/styles/styles.ts
+++ b/src/agent_manager/api/static/widget/styles/styles.ts
@@ -138,6 +138,31 @@ export function styles(config: AgentChatConfig): string {
     .tool-badge.output-error { color: #991b1b; background: #fee2e2; }
     .tool-content { border-top: 1px solid #e4e4e7; padding: 8px 10px; }
     .tool-error { color: #991b1b; font-size: 12px; white-space: pre-wrap; }
+    .approval-card { border: 1px solid #e4e4e7; border-radius: 10px; background: #fafafa;
+      padding: 10px 11px; white-space: normal; box-shadow: 0 1px 2px rgba(0,0,0,.03); }
+    .approval-title { margin: 0; color: #3f3f46; font-size: 12.5px; font-weight: 600;
+      display: flex; align-items: center; gap: 7px; }
+    .approval-title::before { width: 6px; height: 6px; border-radius: 50%; background: #f59e0b;
+      content: ""; flex: 0 0 auto; }
+    .approval-tool { display: inline-block; margin: 6px 0 0; border: 1px solid #e4e4e7;
+      border-radius: 6px; background: #fff; color: #27272a; padding: 2px 6px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px; font-weight: 500; line-height: 1.4; overflow-wrap: anywhere; }
+    .approval-description { margin: 7px 0 0; color: #71717a; font-size: 12.5px;
+      line-height: 1.45; }
+    .approval-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+      margin-top: 10px; }
+    .approval-button { min-height: 30px; border: 1px solid #d4d4d8; border-radius: 7px;
+      background: #fff; color: #52525b; cursor: pointer; font-family: inherit; font-size: 12px;
+      font-weight: 500; padding: 5px 9px; transition: background .12s, color .12s, opacity .12s; }
+    .approval-button:hover:not(:disabled) { background: #f4f4f5; }
+    .approval-button.primary { border-color: ${config.color}; background: ${config.color}; color: #fff; }
+    .approval-button.primary:hover:not(:disabled) { opacity: .88; }
+    .approval-button.danger { border-color: transparent; background: transparent; color: #71717a; }
+    .approval-button.danger:hover:not(:disabled) { background: #f4f4f5; color: #18181b; }
+    .approval-button:disabled { cursor: default; opacity: .55; }
+    .approval-error { margin: 8px 0 0; color: #b91c1c; font-size: 12px; }
+    .approval-status { display: block; margin-top: 8px; color: #71717a; font-size: 12px; }
     .msg-error { margin-top: 2px; border: 1px solid #fecaca; background: #fef2f2;
       color: #b91c1c; border-radius: 8px; padding: 10px 12px; font-size: 13.5px;
       line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2;
@@ -211,6 +236,7 @@ export function styles(config: AgentChatConfig): string {
       .launcher svg,
       .close,
       .send,
+      .approval-button,
       .panel {
         transition: none;
       }

--- a/src/agent_manager/api/static/widget/types.ts
+++ b/src/agent_manager/api/static/widget/types.ts
@@ -1,6 +1,7 @@
 export type AgentChatPosition = "bottom-right" | "bottom-left";
 export type AgentChatMode = "floating" | "inline";
 export type ChatRole = "user" | "assistant" | "system" | "tool" | "orchestrator" | "agent";
+export type ApprovalDecision = "allow_once" | "deny" | "allow_for_session";
 
 export interface AgentChatConfig {
   endpoint: string;
@@ -54,6 +55,20 @@ export interface MessageEntry {
   error?: boolean;
   route?: string[];
   tools?: ToolRecord[];
+  approval?: PendingApproval;
+  approvalSubmitting?: boolean;
+  approvalError?: string;
+}
+
+export interface PendingApproval {
+  run_id: string;
+  approval_id: string;
+  agent_id: string;
+  tool_name: string;
+  description: string;
+  provider?: string;
+  server_id?: string | null;
+  arguments?: Record<string, unknown>;
 }
 
 export interface ToolRecord {
@@ -71,6 +86,9 @@ export interface SendMessageResponse {
   visited?: string[];
   /** Tools observed during the run. */
   used_tools?: ToolRecord[];
+  status?: "completed" | "pending_approval";
+  run_id?: string | null;
+  pending_approval?: PendingApproval | null;
 }
 
 export interface StreamEvent {
@@ -81,6 +99,7 @@ export interface StreamEvent {
     | "tool_succeeded"
     | "tool_failed"
     | "final"
+    | "pending_approval"
     | "error";
   content?: string;
   route?: string[];
@@ -91,6 +110,11 @@ export interface StreamEvent {
   error?: string;
   system_name?: string;
   used_tools?: ToolRecord[];
+  run_id?: string;
+  approval_id?: string;
+  agent_id?: string;
+  description?: string;
+  arguments?: Record<string, unknown>;
 }
 
 /** Detail of the `agent-chat:answer` event a host page can listen for. */

--- a/src/agent_manager/application/service.py
+++ b/src/agent_manager/application/service.py
@@ -12,7 +12,9 @@ from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from agent_engine.engine.engine import Engine
+from agent_engine.approvals.decision import ApprovalDecision
+from agent_engine.approvals.errors import ApprovalAlreadyProcessed
+from agent_engine.engine.engine import ApprovalEngine, Engine
 from agent_engine.engine.types import ChatMessage, RunResult
 from agent_engine.runtime.hooks import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
@@ -199,13 +201,57 @@ class ConversationService:
         if result.pending_approval is not None:
             raise ValueError("cannot complete a conversation turn while approval is pending")
         await self._persist_assistant_turn(
-            turn,
+            session_id=turn.session_id,
+            run_id=turn.run_id,
+            user_id=turn.user_id,
             content=result.answer,
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
             visited=result.visited,
             used_tools=result.used_tools,
         )
+
+    async def decide_approval(
+        self,
+        conversation_id: str,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision,
+        principal: Principal,
+    ) -> RunResult:
+        """Resume one pending run as the owner of its conversation."""
+        session = await self._authorize(conversation_id, principal)
+        engine = self._require_approval_engine()
+        try:
+            result = await engine.resume(
+                run_id,
+                approval_id,
+                decision,
+                caller_user_id=session.user_id,
+                caller_session_id=session.session_id,
+            )
+        except ApprovalAlreadyProcessed:
+            recovered = await engine.get_processed_result(
+                run_id,
+                approval_id,
+                caller_user_id=session.user_id,
+                caller_session_id=session.session_id,
+            )
+            if recovered is None:
+                raise
+            result = recovered
+        if result.pending_approval is None:
+            await self._persist_assistant_turn(
+                session_id=session.session_id,
+                run_id=run_id,
+                user_id=session.user_id,
+                content=result.answer,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                visited=result.visited,
+                used_tools=result.used_tools,
+            )
+        return result
 
     async def stream(
         self, conversation_id: str, text: str, principal: Principal
@@ -230,7 +276,9 @@ class ConversationService:
         finally:
             if final is not None:
                 await self._persist_assistant_turn(
-                    turn,
+                    session_id=turn.session_id,
+                    run_id=turn.run_id,
+                    user_id=turn.user_id,
                     content=final.content or "",
                     input_tokens=final.input_tokens,
                     output_tokens=final.output_tokens,
@@ -240,8 +288,10 @@ class ConversationService:
 
     async def _persist_assistant_turn(
         self,
-        turn: PreparedConversationTurn,
         *,
+        session_id: str,
+        run_id: str,
+        user_id: str | None,
         content: str,
         input_tokens: int | None,
         output_tokens: int | None,
@@ -249,12 +299,16 @@ class ConversationService:
         used_tools: Sequence[ToolUsageRecord],
     ) -> None:
         """Persist one normalized final assistant response."""
-        await self._repository.append_message(
+        message_id = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"agent-manager:{session_id}:{run_id}:assistant",
+        ).hex
+        await self._repository.append_message_if_absent(
             ConversationMessage(
-                message_id=uuid.uuid4().hex,
-                session_id=turn.session_id,
-                run_id=turn.run_id,
-                user_id=turn.user_id,
+                message_id=message_id,
+                session_id=session_id,
+                run_id=run_id,
+                user_id=user_id,
                 role=Role.ASSISTANT,
                 content=content,
                 created_at=datetime.now(UTC),
@@ -274,6 +328,11 @@ class ConversationService:
             external_user_id=principal.external_id,
             display_name=principal.display_name,
         )
+
+    def _require_approval_engine(self) -> ApprovalEngine:
+        if not isinstance(self._engine, ApprovalEngine):
+            raise RuntimeError("the configured engine does not support approval resume")
+        return self._engine
 
     async def _require(self, conversation_id: str) -> ConversationSession:
         session = await self._repository.get_session(conversation_id)

--- a/src/agent_manager/domain/repository.py
+++ b/src/agent_manager/domain/repository.py
@@ -81,6 +81,16 @@ class Repository(ABC):
     ) -> ConversationSnapshot: ...
 
     @abstractmethod
+    async def append_message_if_absent(
+        self,
+        message: ConversationMessage,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        """Atomically append by ``message_id`` and report whether it was created."""
+        ...
+
+    @abstractmethod
     async def list_conversation_messages(
         self, session_id: str, limit: int | None = None
     ) -> list[ConversationMessage]:

--- a/src/agent_manager/infrastructure/persistence/memory_repository.py
+++ b/src/agent_manager/infrastructure/persistence/memory_repository.py
@@ -150,6 +150,22 @@ class MemoryRepository(Repository):
         self._snapshots[message.session_id] = snapshot
         return snapshot
 
+    async def append_message_if_absent(
+        self,
+        message: ConversationMessage,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        """Append once under the adapter's single-event-loop execution model."""
+        if any(
+            existing.message_id == message.message_id
+            for messages in self._messages.values()
+            for existing in messages
+        ):
+            return False
+        await self.append_message(message, snapshot_ttl_seconds=snapshot_ttl_seconds)
+        return True
+
     async def add_message(self, conversation_id: str, role: Role, content: str) -> None:
         await self.append_message(
             ConversationMessage(

--- a/src/agent_manager/infrastructure/persistence/memory_repository.py
+++ b/src/agent_manager/infrastructure/persistence/memory_repository.py
@@ -159,8 +159,7 @@ class MemoryRepository(Repository):
         """Append once under the adapter's single-event-loop execution model."""
         if any(
             existing.message_id == message.message_id
-            for messages in self._messages.values()
-            for existing in messages
+            for existing in self._messages.get(message.session_id, [])
         ):
             return False
         await self.append_message(message, snapshot_ttl_seconds=snapshot_ttl_seconds)

--- a/src/agent_manager/infrastructure/persistence/sql_repository.py
+++ b/src/agent_manager/infrastructure/persistence/sql_repository.py
@@ -212,6 +212,26 @@ class SqlRepository(Repository):
             assert snapshot is not None
             return snapshot
 
+    async def append_message_if_absent(
+        self,
+        message: ConversationMessage,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        """Use the message primary key as the adapter's atomic idempotency boundary."""
+        try:
+            await self.append_message(
+                message,
+                snapshot_ttl_seconds=snapshot_ttl_seconds,
+            )
+        except IntegrityError:
+            async with self._sessions() as session:
+                existing = await session.get(ConversationMessageRow, message.message_id)
+            if existing is None:
+                raise
+            return False
+        return True
+
     async def list_conversation_messages(
         self, session_id: str, limit: int | None = None
     ) -> list[ConversationMessage]:

--- a/src/agentctl/chat.py
+++ b/src/agentctl/chat.py
@@ -23,12 +23,13 @@ import json
 import sys
 import uuid
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
 import click
 
 from agent_engine.approvals.decision import ApprovalDecision, parse_decision
 from agent_engine.approvals.errors import InvalidDecision
+from agent_engine.engine.engine import ApprovalEngine
 from agent_engine.engine.types import PendingApproval, RunResult
 from agentctl.session import SpecError, load_and_validate, load_env
 
@@ -51,22 +52,6 @@ ReadLine = Callable[[str], str]
 
 class _StopChat(Exception):
     """Internal control flow for leaving the console from a nested prompt."""
-
-
-@runtime_checkable
-class _ApprovalEngine(Protocol):
-    """HITL operations exposed by the concrete local engine."""
-
-    async def get_pending_approval(self, run_id: str) -> PendingApproval | None: ...
-
-    async def resume(
-        self,
-        run_id: str,
-        approval_id: str,
-        decision: ApprovalDecision | str,
-        *,
-        caller_user_id: str | None = None,
-    ) -> RunResult: ...
 
 
 # click.echo's signature is broad; we only use (message, *, err). Keep a simple wrapper.
@@ -257,12 +242,13 @@ async def _resolve_local_approvals(
             pending.approval_id,
             decision,
             caller_user_id=context.user_id if context is not None else None,
+            caller_session_id=context.conversation_id if context is not None else None,
         )
     return result
 
 
-def _require_approval_engine(engine: Engine) -> _ApprovalEngine:
-    if not isinstance(engine, _ApprovalEngine):
+def _require_approval_engine(engine: Engine) -> ApprovalEngine:
+    if not isinstance(engine, ApprovalEngine):
         raise RuntimeError("This engine does not support resuming approval requests.")
     return engine
 

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -8,14 +8,22 @@ from collections.abc import AsyncIterator, Sequence
 import pytest
 from fastapi.testclient import TestClient
 
+from agent_engine.approvals.decision import ApprovalDecision
+from agent_engine.approvals.errors import ApprovalAlreadyProcessed
 from agent_engine.engine.engine import Engine
-from agent_engine.engine.types import ChatMessage, RunResult
+from agent_engine.engine.types import ChatMessage, PendingApproval, RunResult
 from agent_engine.runtime.hooks.models import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
 from agent_engine.runtime.tool_models import ToolUsageRecord
 from agent_manager.application import ConversationService
 from agent_manager.config import AuthMode
-from agent_manager.domain import TokenBudgetUsage, thread_title
+from agent_manager.domain import (
+    ConversationMessage,
+    Principal,
+    Role,
+    TokenBudgetUsage,
+    thread_title,
+)
 from agent_manager.infrastructure.persistence.memory_repository import MemoryRepository
 from tests.agent_manager.conftest import (
     HOST_COOKIE,
@@ -24,6 +32,103 @@ from tests.agent_manager.conftest import (
     build_test_app,
     session_cookie,
 )
+
+
+class _ApprovalRecordingEngine(RecordingEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pending: PendingApproval | None = None
+        self.resume_calls: list[
+            tuple[str, str, ApprovalDecision | str, str | None, str | None]
+        ] = []
+        self.completed_results: dict[str, RunResult] = {}
+
+    def _pending_result(self, context: RunContext | None) -> RunResult:
+        assert context is not None and context.run_id is not None
+        self.pending = PendingApproval(
+            run_id=context.run_id,
+            approval_id="approval-1",
+            agent_id="writer",
+            tool_name="send_email",
+            description="Writer wants to call send_email. It has not been executed yet.",
+        )
+        return RunResult(
+            system_name="stub",
+            visited=["writer"],
+            answer="",
+            status="pending_approval",
+            pending_approval=self.pending,
+        )
+
+    async def run(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> RunResult:
+        del message, history
+        self.contexts.append(context)
+        return self._pending_result(context)
+
+    async def stream(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        del message, history
+        self.contexts.append(context)
+        pending = self._pending_result(context).pending_approval
+        assert pending is not None
+        yield RunStreamEvent(
+            type="pending_approval",
+            route=("writer",),
+            run_id=pending.run_id,
+            approval_id=pending.approval_id,
+            agent_id=pending.agent_id,
+            tool_name=pending.tool_name,
+            description=pending.description,
+            provider="mcp",
+            server_id="mail-server",
+            arguments={"recipient": "masked@example.test", "token": "***"},
+        )
+
+    async def get_pending_approval(self, run_id: str) -> PendingApproval | None:
+        return self.pending if self.pending is not None and self.pending.run_id == run_id else None
+
+    async def get_processed_result(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult | None:
+        del approval_id, caller_user_id, caller_session_id
+        return self.completed_results.get(run_id)
+
+    async def resume(
+        self,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision | str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult:
+        self.resume_calls.append((run_id, approval_id, decision, caller_user_id, caller_session_id))
+        answer = "The tool request was denied." if decision == ApprovalDecision.DENY else "sent"
+        result = RunResult(
+            system_name="stub",
+            visited=["writer"],
+            answer=answer,
+            input_tokens=5,
+            output_tokens=2,
+        )
+        self.completed_results[run_id] = result
+        return result
 
 
 @pytest.fixture
@@ -363,6 +468,229 @@ def test_stream_surfaces_sse_events_and_persists_final_answer(client: TestClient
     assert [(m["role"], m["content"]) for m in messages] == [
         ("user", "hello"),
         ("assistant", "answer:hello"),
+    ]
+
+
+def test_stream_surfaces_pending_approval_details() -> None:
+    engine = _ApprovalRecordingEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app)
+    headers = bearer("user-1")
+    client.post(
+        "/conversations",
+        json={"session_id": "session-1"},
+        headers=headers,
+    )
+
+    response = client.post(
+        "/conversations/session-1/messages/stream",
+        json={"message": "send it"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert 'event: pending_approval\ndata: {"type": "pending_approval"' in response.text
+    assert '"run_id":' in response.text
+    assert '"approval_id": "approval-1"' in response.text
+    assert '"agent_id": "writer"' in response.text
+    assert '"tool_name": "send_email"' in response.text
+    assert "has not been executed yet" in response.text
+    assert '"provider": "mcp"' in response.text
+    assert '"server_id": "mail-server"' in response.text
+    assert '"arguments": {"recipient": "masked@example.test", "token": "***"}' in response.text
+    assert "event: done\ndata: [DONE]" in response.text
+
+
+@pytest.mark.parametrize(
+    ("decision", "expected_answer"),
+    [
+        (ApprovalDecision.ALLOW_ONCE, "sent"),
+        (ApprovalDecision.DENY, "The tool request was denied."),
+        (ApprovalDecision.ALLOW_FOR_SESSION, "sent"),
+    ],
+)
+def test_conversation_approval_actions_resume_and_persist(
+    decision: ApprovalDecision,
+    expected_answer: str,
+) -> None:
+    engine = _ApprovalRecordingEngine()
+    repository = MemoryRepository()
+    app = build_test_app(ConversationService(engine, repository))
+    client = TestClient(app)
+    headers = bearer("user-1")
+    client.post(
+        "/conversations",
+        json={"session_id": "session-1"},
+        headers=headers,
+    )
+    pending_response = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+        headers=headers,
+    )
+    pending = pending_response.json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision",
+        json={"decision": decision.value},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert response.json()["pending_approval"] is None
+    assert response.json()["answer"] == expected_answer
+    assert engine.resume_calls == [
+        (
+            pending["run_id"],
+            "approval-1",
+            decision,
+            Principal.external("user-1").user_id,
+            "session-1",
+        )
+    ]
+    messages = client.get("/conversations/session-1/messages", headers=headers).json()
+    assert [(message["role"], message["content"]) for message in messages] == [
+        ("user", "send it"),
+        ("assistant", expected_answer),
+    ]
+    assert client.get("/conversations/session-1/usage", headers=headers).json()["used_tokens"] == 7
+
+
+def test_conversation_approval_refuses_a_different_caller() -> None:
+    engine = _ApprovalRecordingEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app)
+    owner = bearer("owner")
+    client.post(
+        "/conversations",
+        json={"session_id": "session-1"},
+        headers=owner,
+    )
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+        headers=owner,
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision",
+        json={"decision": ApprovalDecision.ALLOW_ONCE.value},
+        headers=bearer("intruder"),
+    )
+
+    assert response.status_code == 403
+    assert engine.resume_calls == []
+
+
+def test_conversation_approval_sanitizes_engine_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FailingApprovalEngine(_ApprovalRecordingEngine):
+        async def resume(
+            self,
+            run_id: str,
+            approval_id: str,
+            decision: ApprovalDecision | str,
+            *,
+            caller_user_id: str | None = None,
+            caller_session_id: str | None = None,
+        ) -> RunResult:
+            del run_id, approval_id, decision, caller_user_id, caller_session_id
+            raise RuntimeError("private approval failure")
+
+    engine = FailingApprovalEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app, headers=bearer("user-1"))
+    client.post("/conversations", json={"session_id": "session-1"})
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision",
+        json={"decision": ApprovalDecision.ALLOW_ONCE.value},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error"
+    assert "private approval failure" not in response.text
+    assert "private approval failure" in caplog.text
+
+
+def test_conversation_approval_retry_recovers_result_without_duplicate_message() -> None:
+    class RetryAwareEngine(_ApprovalRecordingEngine):
+        async def resume(
+            self,
+            run_id: str,
+            approval_id: str,
+            decision: ApprovalDecision | str,
+            *,
+            caller_user_id: str | None = None,
+            caller_session_id: str | None = None,
+        ) -> RunResult:
+            if run_id in self.completed_results:
+                raise ApprovalAlreadyProcessed(approval_id, "approved")
+            return await super().resume(
+                run_id,
+                approval_id,
+                decision,
+                caller_user_id=caller_user_id,
+                caller_session_id=caller_session_id,
+            )
+
+    class FailFirstAssistantWrite(MemoryRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_assistant_write = True
+
+        async def append_message_if_absent(
+            self,
+            message: ConversationMessage,
+            *,
+            snapshot_ttl_seconds: int | None = None,
+        ) -> bool:
+            if message.role == Role.ASSISTANT and self.fail_assistant_write:
+                self.fail_assistant_write = False
+                raise RuntimeError("temporary database failure")
+            return await super().append_message_if_absent(
+                message,
+                snapshot_ttl_seconds=snapshot_ttl_seconds,
+            )
+
+    engine = RetryAwareEngine()
+    repository = FailFirstAssistantWrite()
+    app = build_test_app(ConversationService(engine, repository))
+    client = TestClient(app)
+    headers = bearer("user-1")
+    client.post("/conversations", json={"session_id": "session-1"}, headers=headers)
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+        headers=headers,
+    ).json()["pending_approval"]
+    endpoint = (
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision"
+    )
+    request = {"decision": ApprovalDecision.ALLOW_ONCE.value}
+
+    failed = client.post(endpoint, json=request, headers=headers)
+    recovered = client.post(endpoint, json=request, headers=headers)
+    repeated = client.post(endpoint, json=request, headers=headers)
+
+    assert failed.status_code == 500
+    assert recovered.status_code == 200
+    assert repeated.status_code == 200
+    assert recovered.json()["answer"] == "sent"
+    messages = client.get("/conversations/session-1/messages", headers=headers).json()
+    assert [(message["role"], message["content"]) for message in messages] == [
+        ("user", "send it"),
+        ("assistant", "sent"),
     ]
 
 

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from agent_engine.approvals.decision import ApprovalDecision
-from agent_engine.approvals.errors import ApprovalAlreadyProcessed
+from agent_engine.approvals.errors import ApprovalAlreadyProcessed, ApprovalNotFound
 from agent_engine.engine.engine import Engine
 from agent_engine.engine.types import ChatMessage, PendingApproval, RunResult
 from agent_engine.runtime.hooks.models import RunContext
@@ -620,6 +620,40 @@ def test_conversation_approval_sanitizes_engine_failure(
     assert response.json()["detail"] == "Internal server error"
     assert "private approval failure" not in response.text
     assert "private approval failure" in caplog.text
+
+
+def test_conversation_approval_sanitizes_typed_approval_failure() -> None:
+    class MissingApprovalEngine(_ApprovalRecordingEngine):
+        async def resume(
+            self,
+            run_id: str,
+            approval_id: str,
+            decision: ApprovalDecision | str,
+            *,
+            caller_user_id: str | None = None,
+            caller_session_id: str | None = None,
+        ) -> RunResult:
+            del run_id, decision, caller_user_id, caller_session_id
+            raise ApprovalNotFound(f"private-{approval_id}")
+
+    engine = MissingApprovalEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app, headers=bearer("user-1"))
+    client.post("/conversations", json={"session_id": "session-1"})
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision",
+        json={"decision": ApprovalDecision.ALLOW_ONCE.value},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "approval not found"
+    assert "private" not in response.text
 
 
 def test_conversation_approval_retry_recovers_result_without_duplicate_message() -> None:

--- a/tests/agent_manager/test_repository_contract.py
+++ b/tests/agent_manager/test_repository_contract.py
@@ -123,6 +123,26 @@ async def test_messages_in_insertion_order(repo: Repository) -> None:
     ]
 
 
+async def test_append_message_if_absent_is_idempotent(repo: Repository) -> None:
+    await repo.create_session("sess-1")
+    message = ConversationMessage(
+        message_id="stable-message",
+        session_id="sess-1",
+        run_id="run-1",
+        role=Role.ASSISTANT,
+        content="done",
+        created_at=datetime.now(UTC),
+    )
+
+    created = await repo.append_message_if_absent(message)
+    duplicate = await repo.append_message_if_absent(message)
+
+    assert created is True
+    assert duplicate is False
+    stored = await repo.list_conversation_messages("sess-1")
+    assert stored == [message]
+
+
 async def test_limit_returns_most_recent_oldest_first(repo: Repository) -> None:
     cid = await repo.create_conversation()
     for i in range(5):

--- a/tests/api/test_approval_endpoints.py
+++ b/tests/api/test_approval_endpoints.py
@@ -8,6 +8,7 @@ through ``create_app`` via a real, minimal ``agents.yaml``.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
@@ -54,6 +55,18 @@ class FakeChatModel:
             if isinstance(m, ToolMessage):
                 return AIMessage(content=f"done: {m.content}")
         return AIMessage(content="done")
+
+
+class FailingAfterApprovalModel(FakeChatModel):
+    """Pause for approval, then fail without exposing the internal message."""
+
+    def bind_tools(self, tools: list[Any]) -> FailingAfterApprovalModel:
+        return FailingAfterApprovalModel([t.name for t in tools])
+
+    def _respond(self, messages: list[Any]) -> AIMessage:
+        if any(isinstance(message, ToolMessage) for message in messages):
+            raise RuntimeError("private failure after approval")
+        return super()._respond(messages)
 
 
 def _write_config(base_dir: Path) -> Path:
@@ -111,8 +124,11 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         yield test_client
 
 
-def _trigger_pending_approval(client: TestClient) -> tuple[str, str]:
-    response = client.post("/invoke", json={"message": "hi"})
+def _trigger_pending_approval(
+    client: TestClient, *, session_id: str | None = None
+) -> tuple[str, str]:
+    headers = {"X-Session-ID": session_id} if session_id is not None else None
+    response = client.post("/invoke", json={"message": "hi"}, headers=headers)
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "pending_approval"
@@ -153,3 +169,54 @@ def test_decision_endpoint_still_requires_a_body(client: TestClient) -> None:
     response = client.post(f"/runs/{run_id}/approvals/{approval_id}/decision")
 
     assert response.status_code == 422
+
+
+def test_session_bound_approval_requires_the_same_session(client: TestClient) -> None:
+    run_id, approval_id = _trigger_pending_approval(client, session_id="session-1")
+
+    omitted = client.post(f"/runs/{run_id}/approvals/{approval_id}/approve")
+    wrong = client.post(
+        f"/runs/{run_id}/approvals/{approval_id}/approve",
+        headers={"X-Session-ID": "session-2"},
+    )
+    allowed = client.post(
+        f"/runs/{run_id}/approvals/{approval_id}/approve",
+        headers={"X-Session-ID": "session-1"},
+    )
+
+    assert omitted.status_code == 403
+    assert wrong.status_code == 403
+    assert allowed.status_code == 200
+
+
+def test_approval_endpoint_sanitizes_unexpected_resume_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from langchain_openai import ChatOpenAI
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setattr(
+        ChatOpenAI,
+        "bind_tools",
+        lambda self, tools, **_: FailingAfterApprovalModel([tool.name for tool in tools]),
+    )
+    logged_exceptions: list[BaseException] = []
+
+    def capture_exception(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        exc = sys.exc_info()[1]
+        assert exc is not None
+        logged_exceptions.append(exc)
+
+    monkeypatch.setattr("agent_engine.api.app.logger.exception", capture_exception)
+    app = create_app(str(_write_config(tmp_path)))
+
+    with TestClient(app) as test_client:
+        run_id, approval_id = _trigger_pending_approval(test_client)
+        response = test_client.post(f"/runs/{run_id}/approvals/{approval_id}/approve")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error"
+    assert "private failure after approval" not in response.text
+    assert [str(exc) for exc in logged_exceptions] == ["private failure after approval"]

--- a/tests/api/test_approval_endpoints.py
+++ b/tests/api/test_approval_endpoints.py
@@ -185,6 +185,8 @@ def test_session_bound_approval_requires_the_same_session(client: TestClient) ->
     )
 
     assert omitted.status_code == 403
+    assert omitted.json()["detail"] == "not authorized to decide this approval"
+    assert approval_id not in omitted.text
     assert wrong.status_code == 403
     assert allowed.status_code == 200
 

--- a/tests/approvals/test_api_contracts.py
+++ b/tests/approvals/test_api_contracts.py
@@ -3,25 +3,37 @@ pending-approval response model."""
 
 from __future__ import annotations
 
-from agent_engine.api.app import _map_approval_error, _pending_model
+from agent_engine.api.app import _pending_model
 from agent_engine.approvals.errors import (
     ApprovalAlreadyProcessed,
+    ApprovalError,
     ApprovalNotFound,
     ApprovalRunMismatch,
     InvalidDecision,
     RunNotFound,
     UnauthorizedApprover,
+    approval_http_status,
+    approval_public_message,
 )
 from agent_engine.engine.types import PendingApproval
 
 
 def test_error_status_mapping() -> None:
-    assert _map_approval_error(RunNotFound("r")).status_code == 404
-    assert _map_approval_error(ApprovalNotFound("a")).status_code == 404
-    assert _map_approval_error(ApprovalRunMismatch("a", "r")).status_code == 404
-    assert _map_approval_error(UnauthorizedApprover("a")).status_code == 403
-    assert _map_approval_error(ApprovalAlreadyProcessed("a", "approved")).status_code == 409
-    assert _map_approval_error(InvalidDecision("maybe")).status_code == 400
+    assert approval_http_status(RunNotFound("r")) == 404
+    assert approval_http_status(ApprovalNotFound("a")) == 404
+    assert approval_http_status(ApprovalRunMismatch("a", "r")) == 404
+    assert approval_http_status(UnauthorizedApprover("a")) == 403
+    assert approval_http_status(ApprovalAlreadyProcessed("a", "approved")) == 409
+    assert approval_http_status(InvalidDecision("maybe")) == 400
+
+
+def test_error_messages_are_stable_and_sanitized() -> None:
+    exc = ApprovalRunMismatch("private-approval-id", "private-run-id")
+    assert approval_public_message(exc) == "approval not found"
+    assert "private" not in approval_public_message(exc)
+    assert approval_public_message(ApprovalError("private internal failure")) == (
+        "approval could not be processed"
+    )
 
 
 def test_pending_model_none_passthrough() -> None:

--- a/tests/approvals/test_engine_hitl.py
+++ b/tests/approvals/test_engine_hitl.py
@@ -76,12 +76,19 @@ class FakeChatModel:
                         id=f"call_{input_text}",
                     )
                 ],
+                usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
             )
         # Echo the last tool result so tests can see what reached the model.
         for m in reversed(messages):
             if isinstance(m, ToolMessage):
-                return AIMessage(content=f"done: {m.content}")
-        return AIMessage(content="done")
+                return AIMessage(
+                    content=f"done: {m.content}",
+                    usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+                )
+        return AIMessage(
+            content="done",
+            usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+        )
 
 
 class ChangingToolCallIdModel(FakeChatModel):
@@ -176,14 +183,18 @@ async def test_allow_once_resumes_same_run_and_executes_once(tmp_path: Path) -> 
         await engine.build(_spec("send_email"))
         pending = await engine.run("hi", context=RunContext(run_id="run-1"))
         assert pending.pending_approval is not None
+        assert (pending.input_tokens, pending.output_tokens) == (2, 1)
         approval_id = pending.pending_approval.approval_id
 
         resumed = await engine.resume("run-1", approval_id, "allow once")
+        recovered = await engine.get_processed_result("run-1", approval_id)
 
     assert resumed.status == "completed"
     assert "sent: go" in resumed.answer
     assert _executions(counter) == 1  # executed exactly once
     assert resumed.visited == ["writer"]  # same run, agent not re-selected as a new route
+    assert (resumed.input_tokens, resumed.output_tokens) == (6, 3)
+    assert recovered == resumed
 
 
 async def test_resume_is_stable_when_provider_changes_tool_call_id(tmp_path: Path) -> None:
@@ -237,6 +248,7 @@ async def test_allow_for_session_suppresses_later_prompt_same_conversation(
             pending.pending_approval.approval_id,
             "allow for this session",
             caller_user_id="user-1",
+            caller_session_id="conv-1",
         )
         assert resumed.status == "completed"
 
@@ -283,6 +295,7 @@ async def test_session_permission_survives_engine_reconstruction(tmp_path: Path)
             pending.pending_approval.approval_id,
             "allow for this session",
             caller_user_id="user-1",
+            caller_session_id="conv-1",
         )
 
     async with LangGraphEngine(

--- a/tests/approvals/test_engine_hitl.py
+++ b/tests/approvals/test_engine_hitl.py
@@ -113,6 +113,33 @@ class ChangingToolCallIdModel(FakeChatModel):
         return response
 
 
+class ChainedApprovalModel(FakeChatModel):
+    """Calls two different tools in sequence before returning an answer."""
+
+    def bind_tools(self, tools: list[Any]) -> ChainedApprovalModel:
+        return ChainedApprovalModel([tool.name for tool in tools])
+
+    def _respond(self, messages: list[Any]) -> AIMessage:
+        completed_calls = sum(isinstance(message, ToolMessage) for message in messages)
+        if completed_calls < len(self._tool_names):
+            tool_name = self._tool_names[completed_calls]
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    LCToolCall(
+                        name=tool_name,
+                        args={"message": tool_name},
+                        id=f"provider-call-{tool_name}",
+                    )
+                ],
+                usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+            )
+        return AIMessage(
+            content="done",
+            usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+        )
+
+
 def _factory(provider: str, name: str, temperature: float | None, **_: Any) -> BaseChatModel:
     return cast(BaseChatModel, FakeChatModel())
 
@@ -121,6 +148,12 @@ def _changing_id_factory(
     provider: str, name: str, temperature: float | None, **_: Any
 ) -> BaseChatModel:
     return cast(BaseChatModel, ChangingToolCallIdModel())
+
+
+def _chained_factory(
+    provider: str, name: str, temperature: float | None, **_: Any
+) -> BaseChatModel:
+    return cast(BaseChatModel, ChainedApprovalModel())
 
 
 def _write_counting_tool(base_dir: Path, tool_id: str, counter: Path) -> None:
@@ -142,8 +175,24 @@ def _spec(tool_id: str, *, auto_mode: bool = False) -> SystemSpec:
         description="writer agent",
         model=_MODEL,
         prompts=BasePromptSet(),
-        tools=(ToolSpec(tool_id, f"{tool_id} description"),),
+        tools=(ToolSpec(tool_id, "Send an email to the selected recipient."),),
         auto_mode=auto_mode,
+    )
+    return SystemSpec(meta=SystemMeta(name="hitl"), defaults=None, graph=GraphNode(node=agent))
+
+
+def _chained_spec() -> SystemSpec:
+    agent = AgentSpec(
+        id="writer",
+        name="writer",
+        description="writer agent",
+        model=_MODEL,
+        prompts=BasePromptSet(),
+        tools=(
+            ToolSpec("send_email", "Send an email to the selected recipient."),
+            ToolSpec("archive_email", "Archive the email after sending it."),
+        ),
+        auto_mode=False,
     )
     return SystemSpec(meta=SystemMeta(name="hitl"), defaults=None, graph=GraphNode(node=agent))
 
@@ -171,7 +220,10 @@ async def test_tool_requires_approval_and_does_not_execute(tmp_path: Path) -> No
     assert result.pending_approval is not None
     assert result.pending_approval.tool_name == "send_email"
     assert result.pending_approval.agent_id == "writer"
-    assert result.pending_approval.description  # human-readable, "not executed yet"
+    assert result.pending_approval.description == (
+        "Send an email to the selected recipient. This action has not been executed."
+    )
+    assert "writer" not in result.pending_approval.description
     # The provider must NOT have been invoked before approval.
     assert _executions(counter) == 0
 
@@ -195,6 +247,35 @@ async def test_allow_once_resumes_same_run_and_executes_once(tmp_path: Path) -> 
     assert resumed.visited == ["writer"]  # same run, agent not re-selected as a new route
     assert (resumed.input_tokens, resumed.output_tokens) == (6, 3)
     assert recovered == resumed
+
+
+async def test_retrying_first_decision_recovers_second_pending_approval(tmp_path: Path) -> None:
+    first_counter = tmp_path / "first.log"
+    second_counter = tmp_path / "second.log"
+    _write_counting_tool(tmp_path, "send_email", first_counter)
+    _write_counting_tool(tmp_path, "archive_email", second_counter)
+
+    async with LangGraphEngine(tmp_path, model_factory=_chained_factory) as engine:
+        await engine.build(_chained_spec())
+        first = await engine.run("hi", context=RunContext(run_id="run-chained"))
+        assert first.pending_approval is not None
+
+        second = await engine.resume(
+            "run-chained",
+            first.pending_approval.approval_id,
+            "allow once",
+        )
+        assert second.pending_approval is not None
+        recovered = await engine.get_processed_result(
+            "run-chained",
+            first.pending_approval.approval_id,
+        )
+
+    assert second.status == "pending_approval"
+    assert second.pending_approval.tool_name == "archive_email"
+    assert recovered == second
+    assert _executions(first_counter) == 1
+    assert _executions(second_counter) == 0
 
 
 async def test_resume_is_stable_when_provider_changes_tool_call_id(tmp_path: Path) -> None:

--- a/tests/approvals/test_manager.py
+++ b/tests/approvals/test_manager.py
@@ -67,7 +67,12 @@ def _approval_manager() -> ApprovalManager:
     )
 
 
-async def _pending(mgr: ApprovalManager, *, user: str | None = None):
+async def _pending(
+    mgr: ApprovalManager,
+    *,
+    user: str | None = None,
+    auth_ref: str | None = None,
+):
     return await mgr.create_pending(
         run_id="r1",
         thread_id="r1",
@@ -78,6 +83,7 @@ async def _pending(mgr: ApprovalManager, *, user: str | None = None):
         provider="local",
         description="agent 'a' wants to call 'send_email'",
         arguments={"to": "x@y.com", "api_key": "secret"},
+        auth_ref=auth_ref,
         authorized_user_id=user,
     )
 
@@ -165,6 +171,47 @@ async def test_authorized_approver_allowed() -> None:
     mgr = _approval_manager()
     await _pending(mgr, user="owner")
     claimed = await mgr.claim(run_id="r1", approval_id="ap1", caller_user_id="owner")
+    assert claimed.status == ApprovalStatus.RESUMING
+
+
+async def test_claim_rejects_a_different_session_before_claiming() -> None:
+    mgr = _approval_manager()
+    await _pending(mgr, user="owner", auth_ref="session-1")
+
+    with pytest.raises(UnauthorizedApprover):
+        await mgr.claim(
+            run_id="r1",
+            approval_id="ap1",
+            caller_user_id="owner",
+            caller_auth_ref="session-2",
+        )
+
+    claimed = await mgr.claim(
+        run_id="r1",
+        approval_id="ap1",
+        caller_user_id="owner",
+        caller_auth_ref="session-1",
+    )
+    assert claimed.status == ApprovalStatus.RESUMING
+
+
+async def test_claim_rejects_an_omitted_session_before_claiming() -> None:
+    mgr = _approval_manager()
+    await _pending(mgr, user="owner", auth_ref="session-1")
+
+    with pytest.raises(UnauthorizedApprover):
+        await mgr.claim(
+            run_id="r1",
+            approval_id="ap1",
+            caller_user_id="owner",
+        )
+
+    claimed = await mgr.claim(
+        run_id="r1",
+        approval_id="ap1",
+        caller_user_id="owner",
+        caller_auth_ref="session-1",
+    )
     assert claimed.status == ApprovalStatus.RESUMING
 
 

--- a/tests/cli/test_chat_command.py
+++ b/tests/cli/test_chat_command.py
@@ -136,6 +136,17 @@ class ApprovalFakeEngine(FakeEngine):
         assert run_id == self.stream_pending.run_id
         return self.stream_pending
 
+    async def get_processed_result(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> RunResult | None:
+        del run_id, approval_id, caller_user_id, caller_session_id
+        return None
+
     async def resume(
         self,
         run_id: str,
@@ -143,7 +154,9 @@ class ApprovalFakeEngine(FakeEngine):
         decision: ApprovalDecision | str,
         *,
         caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
     ) -> RunResult:
+        del caller_session_id
         assert isinstance(decision, ApprovalDecision)
         self.resume_calls.append((run_id, approval_id, decision, caller_user_id))
         return next(self.results)

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -127,7 +127,10 @@ async function mockConversationApi(
   return calls;
 }
 
-async function mockApprovalApi(page: Page, options: { failDecision?: boolean } = {}) {
+async function mockApprovalApi(
+  page: Page,
+  options: { decisionStatus?: number; decisionDetail?: string } = {},
+) {
   const decisions: string[] = [];
   let streamCount = 0;
   let sessionApproved = false;
@@ -166,7 +169,7 @@ async function mockApprovalApi(page: Page, options: { failDecision?: boolean } =
           approval_id: `approval-${streamCount}`,
           agent_id: "writer",
           tool_name: "send_email",
-          description: "Writer wants to send an email. It has not been executed yet.",
+          description: "Send an email to the selected recipient. This action has not been executed.",
           provider: "local",
           used_tools: [],
         })}`,
@@ -181,11 +184,11 @@ async function mockApprovalApi(page: Page, options: { failDecision?: boolean } =
     decisions.push(body.decision || "");
     sessionApproved ||= body.decision === "allow_for_session";
     await new Promise((resolve) => setTimeout(resolve, 25));
-    if (options.failDecision) {
+    if (options.decisionStatus) {
       await route.fulfill({
-        status: 500,
+        status: options.decisionStatus,
         contentType: "application/json",
-        body: JSON.stringify({ detail: "private approval failure" }),
+        body: JSON.stringify({ detail: options.decisionDetail ?? "private approval failure" }),
       });
       return;
     }
@@ -573,6 +576,13 @@ for (const action of [
     await shadowClick(page, ".send");
 
     await expect.poll(() => shadowText(page, ".approval-card")).toContain("Approval required");
+    await expect
+      .poll(() => shadowText(page, ".approval-description"))
+      .toBe("Send an email to the selected recipient. This action has not been executed.");
+    await expect.poll(() => shadowText(page, ".approval-tool")).toBe("Tool: send_email");
+    expect(await shadowText(page, ".approval-card")).not.toContain("writer");
+    expect(await shadowText(page, ".approval-card")).not.toContain("mail-prod");
+    expect(await shadowText(page, ".approval-card")).not.toContain("provider");
     await expect.poll(() => shadowText(page, ".approval-actions")).toContain("Approve");
     await expect.poll(() => shadowText(page, ".approval-actions")).toContain("Deny");
     await expect
@@ -612,7 +622,7 @@ test("session approval prevents another prompt for the same session tool", async
 });
 
 test("a failed approval decision restores the controls without leaking details", async ({ page }) => {
-  const approval = await mockApprovalApi(page, { failDecision: true });
+  const approval = await mockApprovalApi(page, { decisionStatus: 500 });
   await page.goto("/widget-demo.html");
   await shadowClick(page, ".launcher");
   await shadowFill(page, ".input", "send the email");
@@ -628,7 +638,33 @@ test("a failed approval decision restores the controls without leaking details",
   );
   await expect.poll(() => shadowExists(page, ".approval-status")).toBe(false);
   await expect.poll(() => shadowExists(page, ".approval-button:disabled")).toBe(false);
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(true);
   expect(await shadowText(page, ".approval-card")).not.toContain("private approval failure");
+});
+
+test("a terminal approval failure releases the composer and leaves a safe error", async ({
+  page,
+}) => {
+  const approval = await mockApprovalApi(page, {
+    decisionStatus: 404,
+    decisionDetail: "approval not found",
+  });
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "send the email");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+
+  await shadowClickText(page, ".approval-button", "Approve");
+
+  await expect.poll(() => approval.decisions).toEqual(["allow_once"]);
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+  await expect
+    .poll(() => shadowText(page, ".msg-error"))
+    .toBe("This approval is no longer available. You can continue chatting.");
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+  await shadowFill(page, ".input", "continue chatting");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("continue chatting");
 });
 
 test("Shift+Enter inserts a newline and Enter sends", async ({ page }) => {

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -127,6 +127,98 @@ async function mockConversationApi(
   return calls;
 }
 
+async function mockApprovalApi(page: Page, options: { failDecision?: boolean } = {}) {
+  const decisions: string[] = [];
+  let streamCount = 0;
+  let sessionApproved = false;
+
+  await page.route("**/conversations", async (route) => {
+    const body =
+      route.request().method() === "GET"
+        ? []
+        : { conversation_id: "conv-approval", session_id: "conv-approval" };
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+
+  await page.route("**/conversations/*/messages/stream", async (route: Route) => {
+    streamCount += 1;
+    if (sessionApproved) {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: [
+          `event: final\ndata: ${JSON.stringify({ type: "final", content: "Session approval reused", route: ["writer"], used_tools: [] })}`,
+          "event: done\ndata: [DONE]",
+          "",
+        ].join("\n\n"),
+      });
+      return;
+    }
+    const runId = `run-${streamCount}`;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: pending_approval\ndata: ${JSON.stringify({
+          type: "pending_approval",
+          route: ["writer"],
+          run_id: runId,
+          approval_id: `approval-${streamCount}`,
+          agent_id: "writer",
+          tool_name: "send_email",
+          description: "Writer wants to send an email. It has not been executed yet.",
+          provider: "local",
+          used_tools: [],
+        })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await page.route(/\/conversations\/[^/]+\/runs\/[^/]+\/approvals\/[^/]+\/decision$/, async (route) => {
+    const body = JSON.parse(route.request().postData() || "{}") as { decision?: string };
+    decisions.push(body.decision || "");
+    sessionApproved ||= body.decision === "allow_for_session";
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    if (options.failDecision) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "private approval failure" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        answer:
+          body.decision === "deny" ? "The tool request was denied." : "The tool completed.",
+        visited: ["writer"],
+        used_tools: [],
+        status: "completed",
+        run_id: null,
+        pending_approval: null,
+      }),
+    });
+  });
+
+  await page.route("**/conversations/*/messages", async (route: Route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.route("**/conversations/*/usage", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ used_tokens: 0, max_tokens: null, percent: 0, severity: "normal" }),
+    });
+  });
+
+  return { decisions, getStreamCount: () => streamCount };
+}
+
 async function mockConversationApiWithStaleConversation(page: Page, staleStatus = 404) {
   await pinVisitorPass(page);
   const calls: string[] = [];
@@ -462,6 +554,81 @@ test("tool activity shows the tool name without its internal provider", async ({
   await expect.poll(() => shadowText(page, ".messages")).toContain("Echo: find the docs");
   await expect.poll(() => shadowText(page, ".tool-title")).toBe("search_docs");
   await expect.poll(() => shadowText(page, ".tool-title")).not.toContain("mcp");
+});
+
+for (const action of [
+  { label: "Approve", decision: "allow_once", answer: "The tool completed." },
+  { label: "Deny", decision: "deny", answer: "The tool request was denied." },
+  {
+    label: "Approve for this session",
+    decision: "allow_for_session",
+    answer: "The tool completed.",
+  },
+]) {
+  test(`${action.label} resolves a pending tool request exactly once`, async ({ page }) => {
+    const approval = await mockApprovalApi(page);
+    await page.goto("/widget-demo.html");
+    await shadowClick(page, ".launcher");
+    await shadowFill(page, ".input", "send the email");
+    await shadowClick(page, ".send");
+
+    await expect.poll(() => shadowText(page, ".approval-card")).toContain("Approval required");
+    await expect.poll(() => shadowText(page, ".approval-actions")).toContain("Approve");
+    await expect.poll(() => shadowText(page, ".approval-actions")).toContain("Deny");
+    await expect
+      .poll(() => shadowText(page, ".approval-actions"))
+      .toContain("Approve for this session");
+    await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(true);
+
+    await shadowClickText(page, ".approval-button", action.label);
+    await shadowClickText(page, ".approval-button", action.label);
+
+    await expect.poll(() => approval.decisions).toEqual([action.decision]);
+    await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+    await expect.poll(() => shadowText(page, ".messages")).toContain(action.answer);
+    await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+    await expect.poll(() => shadowExists(page, ".approval-status")).toBe(false);
+  });
+}
+
+test("session approval prevents another prompt for the same session tool", async ({ page }) => {
+  const approval = await mockApprovalApi(page);
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "first email");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+
+  await shadowClickText(page, ".approval-button", "Approve for this session");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+
+  await shadowFill(page, ".input", "second email");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Session approval reused");
+  await expect.poll(() => approval.getStreamCount()).toBe(2);
+  expect(approval.decisions).toEqual(["allow_for_session"]);
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+});
+
+test("a failed approval decision restores the controls without leaking details", async ({ page }) => {
+  const approval = await mockApprovalApi(page, { failDecision: true });
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "send the email");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+
+  await shadowClickText(page, ".approval-button", "Approve");
+
+  await expect.poll(() => approval.decisions).toEqual(["allow_once"]);
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+  await expect.poll(() => shadowText(page, ".approval-error")).toBe(
+    "Something went wrong. Please try again.",
+  );
+  await expect.poll(() => shadowExists(page, ".approval-status")).toBe(false);
+  await expect.poll(() => shadowExists(page, ".approval-button:disabled")).toBe(false);
+  expect(await shadowText(page, ".approval-card")).not.toContain("private approval failure");
 });
 
 test("Shift+Enter inserts a newline and Enter sends", async ({ page }) => {

--- a/tests/engine/test_run_lifecycle.py
+++ b/tests/engine/test_run_lifecycle.py
@@ -34,6 +34,16 @@ class RegistrationSpy(RunRepository):
         self.transitions.append((run_id, target))
         return True
 
+    async def add_token_usage(
+        self,
+        run_id: str,
+        *,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> RunRecord | None:
+        del run_id, input_tokens, output_tokens
+        raise AssertionError("RunLifecycle must not record engine-owned usage")
+
 
 async def test_begin_delegates_registration_as_one_repository_operation() -> None:
     repository = RegistrationSpy()

--- a/tests/runs/test_repository.py
+++ b/tests/runs/test_repository.py
@@ -57,6 +57,27 @@ async def test_run_repository_registers_new_run(run_repository: RunRepository) -
     assert await run_repository.get("r1") == record
 
 
+async def test_run_repository_accumulates_reported_token_usage(
+    run_repository: RunRepository,
+) -> None:
+    record = _run("r1")
+    await run_repository.create_if_absent(record)
+
+    first = await run_repository.add_token_usage("r1", input_tokens=10, output_tokens=None)
+    second = await run_repository.add_token_usage("r1", input_tokens=5, output_tokens=3)
+
+    assert first is record
+    assert second is record
+    assert record.input_tokens == 15
+    assert record.output_tokens == 3
+
+
+async def test_run_repository_token_usage_does_not_create_an_unknown_run(
+    run_repository: RunRepository,
+) -> None:
+    assert await run_repository.add_token_usage("missing", input_tokens=1, output_tokens=1) is None
+
+
 async def test_run_repository_does_not_overwrite_existing_run(
     run_repository: RunRepository,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds complete end-to-end Human-in-the-Loop approval support to the agent manager and web widget.

Previously, the engine could pause for approval, but the manager and widget could not reliably submit a decision, resume the same run, persist its result, or support session-level approval.

## What changed

### Engine

- Added a resumable approval capability through the `ApprovalEngine` protocol.
- Added safe approval authorization using the caller’s user and session identity.
- Added recovery for already-processed approval decisions.
- Preserved cumulative token usage across approval/resume execution legs.
- Added support for session-scoped approval grants.

### Agent Manager

- Added an approval decision endpoint:

  `POST /conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision`

- Exposed pending approval metadata to API and SSE clients.
- Resumed suspended runs after approval decisions.
- Persisted final assistant responses idempotently after resumed execution.
- Handled repeated decision requests safely.
- Sanitized internal approval and engine errors before returning them to clients.

### Web Widget

Added three approval actions:

| Action | Behavior |
| --- | --- |
| Approve | Allows this specific tool execution |
| Deny | Rejects this specific tool execution |
| Approve for this session | Allows the execution and remembers the relevant approval scope for the current session |

Additional UI behavior:

- Displays an approval card when execution is paused.
- Prevents duplicate approval requests.
- Disables the composer while approval is pending.
- Restores controls when a decision fails.
- Supports chained approval requests.
- Prevents repeated prompts after session-level approval.
- Keeps internal backend errors hidden from users.

### Documentation

Updated the HITL and widget documentation to describe:

- approval lifecycle and resume behavior;
- approval decision semantics;
- session-level approval scope;
- manager API integration;
- widget behavior and failure handling.

## Validation

- `make check` — passed
  - Ruff formatting and lint passed
  - Mypy passed
  - 681 Python tests passed
- `npm run typecheck:widget` — passed
- `npm run test:widget` — passed
- `npm run test:widget:e2e` — 29 tests passed

<img width="968" height="468" alt="image" src="https://github.com/user-attachments/assets/19c18cf6-3968-439c-b8af-59eb3eaeddf2" />

