### PR TITLE
Feat/shared tool usage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,7 +166,7 @@ Responsibilities:
 - **Security / context gate**: filter `protected` nodes via the access plugin so
   an orchestrator never exposes a child the caller may not reach.
 - **Execute the root node as a supervisor agent**: the orchestrator's children
-  (agents or nested orchestrators) are exposed to it as callable tools; it
+  (agents or nested orchestrators) are exposed to it as callable delegations; it
   decides which child tool(s) to call, collects their answers, and synthesises a
   final response. The whole tree runs inside the root invocation.
 - **Resolve dynamic prompt values** by calling each node's declared resolvers.
@@ -175,8 +175,12 @@ Responsibilities:
 - **Enforce tool/data policy**: expose only the agent's declared tools; pass
   trusted, runtime-controlled context to tools (see §11).
 - **Call tools / MCP servers** through runtime-managed adapters.
+- **Record** every tool call in the tool-usage repository — the source of truth
+  for execution metadata, keyed by run and conversation, and the seam through
+  which a later agent or turn learns what has already been run.
 - **Return** the response plus a structured trace (`visited` = call-chain;
-  `used_tools` = real tool/MCP calls, merged up from nested agents).
+  `used_tools` = real tool/MCP calls, projected from the usage repository and so
+  including nested agents).
 
 ---
 
@@ -580,6 +584,18 @@ trusted code truncate/redact/normalize a tool result before it reaches the
 model) — for auth, policy, audit, and context enrichment, distinct from
 LLM-invoked tools. Per-tool `input_policy` (trusted parameter injection) is
 still not implemented — see §11.
+
+**Shared tool usage (✅ done, not in the original task list):**
+`agent_engine/tool_usage/` owns execution metadata: a `ToolUsageRepository` port
+(process-local adapter shipped, distributed adapters injected at the composition
+root), a `ToolUsageTracker` that records outcomes on the single tool-execution
+path, and a `ToolUsageContextProvider` that projects a conversation's usage into a private
+system-role block for the model, refreshed before every model turn, plus a
+read-only `list_executed_tools` tool so an orchestrator can answer questions about
+past execution from data rather than from its own tool bindings. `GraphState` carries no tool usage: the
+repository is the source of truth, and both the model context and
+`RunResult.used_tools` are projections of it. See
+[`MCP_AND_TOOLS.md`](MCP_AND_TOOLS.md).
 
 **Model providers (✅ done, not in the original task list):**
 `agent_engine/models/factory.py` builds chat models via `init_chat_model` for

--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -44,7 +44,7 @@ DENY                do not run it; store nothing
 Agent / LangGraph node
         │  requests a concrete tool call
         ▼
-AgentNode._invoke_tool           (the single choke point for local + MCP tools)
+ToolInvoker.invoke               (the single choke point for local + MCP tools)
         │
         ▼
 ApprovalCoordinator.resolve()    (centralized; no tool-specific logic)
@@ -54,12 +54,22 @@ ApprovalCoordinator.resolve()    (centralized; no tool-specific logic)
         ▼
    execute=True  ──► idempotency guard ─► provider (LocalTool / MCP tools/call)
    execute=False ──► structured "[denied]" tool result (no execution)
+        │
+        ▼
+ToolUsageTracker                 (records the outcome; never decides anything)
 ```
 
 There is **no** path that reaches a provider without passing through
 `ApprovalCoordinator.resolve()`. The engine uses a custom tool loop
 (`run_tool_loop`), not a bypassing LangGraph `ToolNode`, and both local and MCP
-tools are invoked from the same `_invoke_tool`.
+tools are invoked from the same `ToolInvoker.invoke`.
+
+Approval and tool-usage tracking are separate subsystems that share identifiers
+(`run_id`, `tool_call_id`, agent, tool) but no responsibilities: approval decides
+*whether* an invocation may run, tracking records *what happened to it*. See
+[MCP_AND_TOOLS.md](MCP_AND_TOOLS.md) for the tracking side; a suspended
+invocation is recorded only once it is decided, and a resumed one keeps the
+approval's `tool_call_id`, so approve/resume never produces a second record.
 
 Components (all small, single-responsibility):
 
@@ -74,6 +84,7 @@ Components (all small, single-responsibility):
 | `RunRepository` | Abstract run-persistence contract; owns idempotent registration semantics |
 | `ApprovalManager` | Pending-approval lifecycle + atomic resume claim |
 | `ToolExecutionManager` | Execution idempotency ledger |
+| `ToolInvoker` | Coordinates one tool call: identity, limits, gate, execution, recording |
 | `CheckpointProviderFactory` | Selects the checkpointer once at startup |
 
 The policy, session repository, and provider are all injected behind interfaces

--- a/docs/MCP_AND_TOOLS.md
+++ b/docs/MCP_AND_TOOLS.md
@@ -151,9 +151,9 @@ agent's tools at **build time** (`_build_agent_tools`):
   the `MultiServerMCPClient.get_tools()` results discovered during `build()`.
 
 Both are bound to the agent's model; the tool-call loop runs until the model
-stops requesting tools. Each call is recorded in the run's `used_tools` with its
-`provider` (`"local"` or `"mcp"`), so the origin is tracked for tracing even
-though it is hidden from the model.
+stops requesting tools. Each call is recorded in the run's tool-usage repository
+with its `provider` (`"local"` or `"mcp"`), so the origin is tracked for tracing
+even though it is hidden from the model.
 
 The engine is driven as an async context manager: `build()` connects MCP servers
 and discovers tools; `close()` (on context exit) releases them. `run()` does not
@@ -165,12 +165,173 @@ async with LangGraphEngine(base_dir) as engine:
     result = await engine.run(message)
 ```
 
-## Runtime Tool Usage Summary
+## Shared Tool Usage
 
-Every run collects deterministic tool-usage records (`RunResult.used_tools`) on
-the runtime tool-execution path — in call order, not inferred from the final
-answer or requested from the model. Records from tools called by nested agents
-are merged up into the top-level result.
+Every run collects deterministic tool-usage records on the runtime
+tool-execution path — in call order, not inferred from the final answer or
+requested from the model. The **source of truth is a repository**, not the
+LangGraph state:
+
+```text
+ToolInvoker            (coordinates one tool call)
+      │
+      ▼
+ToolUsageTracker       (execution event → domain record)
+      │
+      ▼
+ToolUsageRepository    (source of truth: run → agent → tool call)
+      │
+      ├──────────────► ToolUsageContextProvider ──► private model context
+      │
+      └──────────────► run trace (RunResult.used_tools)
+```
+
+Because every agent shares one repository instance, an agent that starts later
+sees what earlier agents did — including agents nested under an orchestrator —
+without any of it being threaded through `GraphState`. Orchestrators receive the
+same context, so a supervisor can answer a user asking what has already been
+done.
+
+### Persistence model
+
+The domain relationship is `conversation → run → agent → tool call`. One record
+per **logical invocation**, identified by `(run_id, tool_call_id)`:
+
+| Field | Meaning |
+| --- | --- |
+| `conversation_id` | The conversation the run belongs to (absent outside one) |
+| `run_id` | The exact run the invocation happened in |
+| `agent_id` | The agent that invoked it — the id the approval subsystem also records, and the name the model is shown |
+| `agent_path` | That agent's position in the graph (`openwebui/admin_management/user_management`) |
+| `tool_call_id` | Stable id of the logical invocation, unchanged across suspend/resume |
+| `tool_name` / `provider` / `server_id` | What was called, and where it came from |
+| `kind` | `tool` for a real tool/MCP call, `agent` when an orchestrator delegated to a child |
+| `status` | `succeeded`, `failed`, or `denied` |
+| `error` | Bounded error text for a failed call |
+
+Conversation scope gives continuity across the user's turns; run scope keeps
+execution-level traceability. Neither replaces the other, and both are queryable.
+
+Delegating to a child agent is an action too, so an orchestrator records it —
+that is how a later turn can reconstruct the routing that already happened.
+Those records are `kind = agent`; the caller-facing run trace reports
+`kind = tool` only, and so does the model context by default (see below).
+
+`record` is an upsert on that identity, so a graph re-entry after an approval
+resume updates the existing record instead of adding a second one. Arguments and
+results are never stored: they may carry sensitive or oversized data, and no
+consumer of tool usage needs them.
+
+`ToolUsageRepository` is a `Protocol` with three operations (`record`,
+`list_for_run`, `list_for_conversation`). The engine ships a process-local adapter
+(`InMemoryToolUsageRepository`); a distributed deployment supplies a Redis- or
+PostgreSQL-backed adapter with the same contract and injects it at the
+composition root (`build_tool_usage_repository` in `agent_manager/composition.py`,
+or the `tool_usage_repository=` argument of `LangGraphEngine`). No agent, node,
+tool-loop, or model-context code changes when the backend changes.
+
+Recording is observability, not part of the tool's contract: a repository write
+failure is logged at WARNING with the invocation's identity and swallowed, so a
+metadata problem can never turn a completed tool call into a failed one. The
+visible cost is a trace that may be missing an entry the log names explicitly.
+
+### Model context is a projection, not the record
+
+`ToolUsageContextProvider` reads the records for a `ToolUsageScope` and projects
+them into a small, private block supplied to the model as a **system-role
+message** next to the system prompt:
+
+```text
+## Execution record for this conversation
+Internal execution metadata, not chat history. Some of the tools bound to you are
+other agents: calling one delegates the work, it does not perform it. ...
+
+### Tools executed
+...
+user_management:
+- create_user [succeeded]
+
+### Agents delegated to
+...
+- openwebui -> admin_management
+```
+
+An orchestrator's children are bound to it as callable tools, so their
+descriptions name them as delegations (`Delegate this request to the 'x' agent`)
+and its instruction contract states that calling one hands the work over rather
+than performing it. The record's two sections exist for the same reason. Asked which tools it had run, one answered `admin_management` — the child
+it had merely routed to — and defended it, because from its own binding that is
+a tool. Naming only the executed tools did not help either: the model trusted its
+tool list over an unexplained record. So the record names both levels and states
+the difference, and successful routing carries no `[succeeded]` marker that could
+read as a tool result. Pass `include_delegations=False` to report executed tools
+only.
+
+Only agent, tool name, and status cross that boundary — no timestamps, ids,
+arguments, results, or error text. The block is never a user or assistant turn,
+so it does not enter the conversation history the caller persists and never
+reaches the user; a conversation with no tool usage adds nothing at all.
+
+Two policies live in the provider, and changing them touches nothing else:
+
+* **Scope** — the conversation is preferred when the caller has one, so a
+  follow-up turn (a new `run_id`) still knows what earlier turns did; a run
+  outside any conversation falls back to its own run.
+* **Size** — the most recent 50 invocations, bounding prompt growth on a long
+  conversation. A trimmed record says so, rather than passing itself off as
+  complete.
+* **Non-duplication** — an invocation the asking agent made in the run it is
+  currently executing is skipped while its own `AIMessage` + `ToolMessage` pair
+  is still in the turn. The model already has that call in full through the
+  normal tool protocol; the block would only repeat it in less detail. The same
+  agent's calls from an earlier run or an earlier node entry *are* shown, since
+  nothing in the current turn carries them.
+
+The block is re-read **before every model turn** (`ModelContext` keeps one slot
+for it next to the system prompt), so a model invocation always reflects tools
+that finished since the previous one — including during the same turn. Every
+participant receives it: leaf agents, intermediate orchestrators, and the root.
+
+This supplements the standard tool protocol; it does not replace it. An agent's
+own active call still reaches its model as `AIMessage(tool_calls)` →
+`ToolMessage(result)` → model, unchanged. The shared context solves the other
+problem: awareness across agents, across runs, and across the conversation.
+
+### Answering "which tools have run?"
+
+Reporting is a separate problem from reasoning, and it needed a separate
+mechanism. An orchestrator's children are bound to it as tools, so asked which
+tools had run it named the child agent it had delegated to — and kept doing so
+through four rounds of instruction and record wording, because from its own tool
+list that answer is true.
+
+Orchestrators are therefore given a read-only engine tool,
+`list_executed_tools`, which returns the conversation's executed tools from the
+repository:
+
+```text
+Tools executed in this conversation, oldest first:
+- user_management: add_new_user [succeeded]
+```
+
+The answer now comes from a tool result the model cannot contradict from its
+bindings, rather than from an instruction it can ignore. The two read paths
+degrade differently on purpose: the passive block falls back to empty context
+when the repository cannot be read, while the report says the record is
+unavailable — claiming "nothing has run" would invite an agent to repeat an
+action that already took effect. The tool performs no
+side effect, is not counted against child-agent call limits, and is not itself
+recorded as usage. It changes nothing about Human-in-the-Loop: orchestrator-level
+tools have never passed the approval gate — that gate belongs to the real tools
+an agent executes, which still all pass through it. A configured child named
+`list_executed_tools` wins, and the engine's tool is not bound.
+
+### Run trace
+
+`RunResult.used_tools` is a second projection of the same records — the
+caller-facing trace returned by the API and rendered by the widget, including
+tools called by nested agents, and scoped to the run. It reports real tool/MCP
+calls only; the route an orchestrator took is reported separately as `visited`.
 
 Rendering these records in `agentctl run` is ⏳ **planned** (not yet wired into
 the CLI output). The intended format:
@@ -203,8 +364,7 @@ arguments:
 * ask_question [mcp: deepwiki] failed: request timed out
 ```
 
-Every actual tool call is printed in call order. Repeated calls to the same
-tool are printed repeatedly rather than collapsed into a count.
+Every logical tool call is printed in call order.
 
 ---
 
@@ -236,7 +396,7 @@ For the MVP:
 - create remote MCP clients from `mcps.<id>.url` via `langchain-mcp-adapters` (✅ implemented);
 - discover MCP tool metadata during `build()` (✅ implemented);
 - hide local-vs-MCP origin by presenting both as LangChain tools, while tracking
-  the origin in `used_tools.provider` (✅ implemented);
+  the origin in the tool-usage records (✅ implemented);
 - bind discovered MCP tools into LangGraph/LangChain tool-calling (✅ implemented);
 - pass trusted request context through `ctx` into tool calls (⏳ planned —
   resolvers receive `ctx`, tools do not yet);

--- a/docs/MCP_AND_TOOLS.md
+++ b/docs/MCP_AND_TOOLS.md
@@ -215,7 +215,8 @@ execution-level traceability. Neither replaces the other, and both are queryable
 Delegating to a child agent is an action too, so an orchestrator records it —
 that is how a later turn can reconstruct the routing that already happened.
 Those records are `kind = agent`; the caller-facing run trace reports
-`kind = tool` only, and so does the model context by default (see below).
+`kind = tool` only, while private model context renders tools and delegations in
+separate labelled sections (see below).
 
 `record` is an upsert on that identity, so a graph re-entry after an approval
 resume updates the existing record instead of adding a second one. Arguments and
@@ -229,6 +230,12 @@ PostgreSQL-backed adapter with the same contract and injects it at the
 composition root (`build_tool_usage_repository` in `agent_manager/composition.py`,
 or the `tool_usage_repository=` argument of `LangGraphEngine`). No agent, node,
 tool-loop, or model-context code changes when the backend changes.
+
+Both list operations accept an optional invocation-kind filter and positive
+`limit`. A bounded read returns the newest matching records in chronological
+order. Context projections request `limit + 1`, using the extra row only to mark
+the output as truncated; filtering before limiting prevents delegation-heavy
+histories from under-filling tool-only reports.
 
 Recording is observability, not part of the tool's contract: a repository write
 failure is logged at WARNING with the invocation's identity and swallowed, so a
@@ -279,13 +286,13 @@ Two policies live in the provider, and changing them touches nothing else:
   outside any conversation falls back to its own run.
 * **Size** — the most recent 50 invocations, bounding prompt growth on a long
   conversation. A trimmed record says so, rather than passing itself off as
-  complete.
-* **Non-duplication** — an invocation the asking agent made in the run it is
-  currently executing is skipped while its own `AIMessage` + `ToolMessage` pair
-  is still in the turn. The model already has that call in full through the
-  normal tool protocol; the block would only repeat it in less detail. The same
-  agent's calls from an earlier run or an earlier node entry *are* shown, since
-  nothing in the current turn carries them.
+  complete. The provider requests only `limit + 1` matching records, so one
+  extra row detects truncation without loading the full history.
+
+The repository remains the source of truth even when a tool result is also
+present in the current model turn. Records are never hidden by tool name: two
+calls to the same tool can be different logical invocations, and an orchestrator
+can legitimately delegate to the same child more than once.
 
 The block is re-read **before every model turn** (`ModelContext` keeps one slot
 for it next to the system prompt), so a model invocation always reflects tools
@@ -314,8 +321,13 @@ Tools executed in this conversation, oldest first:
 - user_management: add_new_user [succeeded]
 ```
 
-The answer now comes from a tool result the model cannot contradict from its
-bindings, rather than from an instruction it can ignore. The two read paths
+The passive context remains useful for reasoning, but it is not enough for an
+explicit reporting question: the model can still classify a bound child agent
+as a tool despite the labelled record. Keeping this reporting tool trades one
+reserved engine-tool name and an extra model tool call for a deterministic
+repository lookup with a clear result boundary. The answer now comes from a
+tool result the model cannot contradict from its bindings, rather than from an
+instruction it can ignore. The two read paths
 degrade differently on purpose: the passive block falls back to empty context
 when the repository cannot be read, while the report says the record is
 unavailable — claiming "nothing has run" would invite an agent to repeat an

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ implemented, so protected-node access control is not actually enforced today.
 11. [CLAUDE_CODE_WORKFLOW.md](CLAUDE_CODE_WORKFLOW.md) — using Claude Code in this repo.
 12. [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) — how to work in this repo.
 13. [ROADMAP.md](ROADMAP.md) — phased plan.
+14. [adr/](adr/) — architecture decision records for contract-level changes.
 
 ## Relationship to other directories
 

--- a/docs/adr/0001-tool-usage-as-execution-metadata.md
+++ b/docs/adr/0001-tool-usage-as-execution-metadata.md
@@ -1,0 +1,65 @@
+# ADR 0001 — Tool usage is execution metadata, not graph state
+
+- **Status:** Accepted
+- **Date:** 2026-08-15
+
+## Context
+
+Tool usage was collected in a Python list seeded from `GraphState["used_tools"]`,
+merged upward by `OrchestratorNode` after each child returned, and handed back as
+a state delta. Three problems followed from that ownership model:
+
+- an agent could not see what another agent had already run, because the merge
+  happened only after the child finished;
+- nothing survived the run, so a later turn of the same conversation started
+  blind;
+- the node owned persistence, approval, execution, hooks, and tracking at once,
+  and a distributed backend had nowhere to plug in.
+
+## Decision
+
+Execution metadata is owned by a dedicated subsystem, `agent_engine/tool_usage/`,
+with the repository as its source of truth.
+
+- `ToolUsageRepository` (Protocol) persists one record per logical invocation,
+  identified by `(run_id, tool_call_id)` and carrying
+  `conversation → run → agent → tool call`. `record` is an upsert on that
+  identity, so an approval resume updates rather than duplicates.
+- `ToolUsageTracker` writes execution outcomes; it decides nothing else.
+- `ToolUsageContextProvider` projects persisted records into a private
+  system-role block for the model, refreshed before every model turn.
+- `as_usage_records` projects the same records into the caller-facing
+  `RunResult.used_tools` trace.
+- `ToolInvoker` owns the single tool-execution path (identity, limits, the
+  approval gate, idempotency, provider execution, hooks, recording), leaving
+  nodes with prompt building and the model loop.
+
+Approval and tool usage stay separate subsystems that share identifiers
+(`run_id`, `tool_call_id`, agent, tool) and no responsibilities.
+
+## Contract changes
+
+- `GraphState["used_tools"]` is **removed**. `RunResult.used_tools` is unchanged
+  for callers, but is now projected from the repository rather than carried
+  through graph state.
+- `ToolUsageStatus` gains `"denied"`. The HTTP and widget field is a free string,
+  so no client breaks.
+- `LangGraphEngine.__init__` gains `tool_usage_repository`, defaulting to the
+  process-local adapter.
+- Orchestrators are bound one engine-provided read-only tool,
+  `list_executed_tools`. A configured child of the same name wins.
+- Child agents are described to their parent as delegations rather than actions.
+
+## Consequences
+
+- Replacing the in-memory adapter with Redis or PostgreSQL is a new adapter plus
+  one line in the composition root; agents, nodes, the tool loop, and the model
+  context are untouched.
+- Two identical calls by one agent in one run now collapse to a single record,
+  because they are one logical invocation. The previous list appended twice.
+- Recording is observability: a repository write failure is logged and swallowed
+  so a metadata problem cannot fail a completed tool call. A *read* failure on
+  the explicit report is not swallowed — reporting "nothing ran" when the record
+  is unreadable would invite repeating an action that already took effect.
+- Delegations are recorded as `kind = agent`. They are excluded from the run
+  trace, which has always meant real tool/MCP calls.

--- a/docs/adr/0001-tool-usage-as-execution-metadata.md
+++ b/docs/adr/0001-tool-usage-as-execution-metadata.md
@@ -24,7 +24,9 @@ with the repository as its source of truth.
 - `ToolUsageRepository` (Protocol) persists one record per logical invocation,
   identified by `(run_id, tool_call_id)` and carrying
   `conversation → run → agent → tool call`. `record` is an upsert on that
-  identity, so an approval resume updates rather than duplicates.
+  identity, so an approval resume updates rather than duplicates. Its read
+  operations accept an optional invocation-kind filter and a positive limit;
+  bounded reads return the newest matching records in chronological order.
 - `ToolUsageTracker` writes execution outcomes; it decides nothing else.
 - `ToolUsageContextProvider` projects persisted records into a private
   system-role block for the model, refreshed before every model turn.
@@ -49,6 +51,9 @@ Approval and tool usage stay separate subsystems that share identifiers
 - Orchestrators are bound one engine-provided read-only tool,
   `list_executed_tools`. A configured child of the same name wins.
 - Child agents are described to their parent as delegations rather than actions.
+- Duplicate-tool protection is scoped to one node activation. A graph/HITL
+  replay is a new activation, so it can reach the existing idempotency cache;
+  an identical retry within one activation remains blocked.
 
 ## Consequences
 
@@ -63,3 +68,12 @@ Approval and tool usage stay separate subsystems that share identifiers
   is unreadable would invite repeating an action that already took effect.
 - Delegations are recorded as `kind = agent`. They are excluded from the run
   trace, which has always meant real tool/MCP calls.
+- The repository remains authoritative even when a call is also visible through
+  the model's normal tool protocol. Records are never hidden by tool name because
+  repeated names can represent distinct invocations or delegations.
+- Keeping `list_executed_tools` trades one reserved engine-tool name and an extra
+  model tool call for deterministic answers to explicit usage questions. Passive
+  context alone did not reliably stop models from reporting child agents as
+  tools. The reporting tool is read-only, unrecorded, outside tool/child-call
+  limits, uses the provider's shared vocabulary, and yields to a configured
+  child with the same name.

--- a/docs/mcp-and-tools.mdx
+++ b/docs/mcp-and-tools.mdx
@@ -183,3 +183,26 @@ tools used:
   * get_order_status [local] succeeded (42ms)
   * crm_lookup [mcp: crm_mcp] succeeded (118ms)
 ```
+
+## Shared tool usage across agents
+
+Tool usage is stored in a repository, not carried in graph state, so every agent and orchestrator working on the same conversation shares it. Each one is privately told what has already been run — including in earlier turns of the same conversation, so an agent can answer "which tools have you used?":
+
+```
+## Execution record for this conversation
+
+### Tools executed
+user_management:
+- create_user [succeeded]
+
+### Agents delegated to
+- openwebui -> admin_management
+```
+
+Tools and agents are listed apart on purpose: an orchestrator's children are bound to it as tools, so a flat list made it answer "the tool I ran is admin_management" when it had only routed there.
+
+For direct questions ("which tools have you run?"), orchestrators also get a read-only `list_executed_tools` tool that returns the executed tools straight from the repository — so the answer comes from data rather than from what the model believes about its own tool list.
+
+That block is internal execution context: it is given to the model as a system message, never as a conversation turn, and never persisted as chat history. Only agent, tool name, and status are included — never arguments, results, or errors. It is refreshed before every model turn, so a supervisor's final answer reflects what the agents it just called actually ran.
+
+The store behind it is a repository port. The in-memory adapter ships with the engine; a shared backend (Redis, PostgreSQL) is an adapter swap in the composition layer, with no change to agents or tools.

--- a/docs/mcp-and-tools.mdx
+++ b/docs/mcp-and-tools.mdx
@@ -201,8 +201,8 @@ user_management:
 
 Tools and agents are listed apart on purpose: an orchestrator's children are bound to it as tools, so a flat list made it answer "the tool I ran is admin_management" when it had only routed there.
 
-For direct questions ("which tools have you run?"), orchestrators also get a read-only `list_executed_tools` tool that returns the executed tools straight from the repository — so the answer comes from data rather than from what the model believes about its own tool list.
+For direct questions ("which tools have you run?"), orchestrators also get a read-only `list_executed_tools` tool that returns the executed tools straight from the repository. The passive context is useful for reasoning but a model can still mistake a bound child agent for a tool when explicitly reporting. This deterministic lookup trades one reserved engine-tool name and an extra model tool call for an answer grounded in repository data. It is not recorded, does not consume tool/child-call limits, and a configured child with the same name wins.
 
 That block is internal execution context: it is given to the model as a system message, never as a conversation turn, and never persisted as chat history. Only agent, tool name, and status are included — never arguments, results, or errors. It is refreshed before every model turn, so a supervisor's final answer reflects what the agents it just called actually ran.
 
-The store behind it is a repository port. The in-memory adapter ships with the engine; a shared backend (Redis, PostgreSQL) is an adapter swap in the composition layer, with no change to agents or tools.
+The store behind it is a repository port. The in-memory adapter ships with the engine; a shared backend (Redis, PostgreSQL) is an adapter swap in the composition layer, with no change to agents or tools. Bounded reads return the newest matching records in chronological order, and context requests one extra record only to detect truncation.

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -56,6 +56,7 @@ from agent_engine.engine.langgraph.helpers import (
 from agent_engine.engine.langgraph.nodes import AgentNode, ChildEntry, OrchestratorNode
 from agent_engine.engine.langgraph.run_lifecycle import RunLifecycle
 from agent_engine.engine.langgraph.stream_channel import StreamChannel
+from agent_engine.engine.langgraph.tool_invoker import AgentToolBinding, ToolInvoker
 from agent_engine.engine.types import ChatMessage, PendingApproval, RunResult
 from agent_engine.loaders.import_roots import register_import_roots
 from agent_engine.loaders.resolver_loader import ResolverLoader
@@ -79,6 +80,12 @@ from agent_engine.runtime.streaming import (
     TokenUsage,
     current_streams,
 )
+from agent_engine.runtime.tool_models import ToolUsageRecord
+from agent_engine.tool_usage.context import ToolUsageContextProvider
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.repository import ToolUsageRepository
+from agent_engine.tool_usage.trace import as_usage_records
+from agent_engine.tool_usage.tracker import ToolUsageTracker
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +123,6 @@ def _initial_state(
             {"role": history_message.role.value, "content": history_message.content}
             for history_message in history
         ],
-        "used_tools": [],
     }
     if expose_run_context:
         state["run_context"] = _state_run_context(ctx)
@@ -246,6 +252,7 @@ class LangGraphEngine(Engine):
         run_repository: RunRepository | None = None,
         session_approval_repository: SessionApprovalRepository | None = None,
         session_approval_store: SessionApprovalStore | None = None,
+        tool_usage_repository: ToolUsageRepository | None = None,
     ) -> None:
         if session_approval_repository is not None and session_approval_store is not None:
             raise ValueError("pass session_approval_repository or session_approval_store, not both")
@@ -291,6 +298,12 @@ class LangGraphEngine(Engine):
             session_repository=self._session_approval_repository,
             session_store=session_approval_store,
         )
+        # One usage repository per engine, so every agent of every run reads and
+        # writes the same store; the writer and the reader are separate roles on
+        # top of it.
+        self._tool_usage_repository = tool_usage_repository or InMemoryToolUsageRepository()
+        self._tool_usage_tracker = ToolUsageTracker(self._tool_usage_repository)
+        self._tool_usage_context = ToolUsageContextProvider(self._tool_usage_repository)
 
     async def build(self, spec: SystemSpec) -> None:
         self._system_name = spec.meta.name
@@ -396,8 +409,9 @@ class LangGraphEngine(Engine):
         """
         return cast(dict[str, Any], await app.ainvoke(graph_input, self._thread_config(ctx)))
 
-    def _completed_result(
+    async def _completed_result(
         self,
+        ctx: RunContext,
         result: dict[str, Any],
         *,
         token_usage: tuple[int | None, int | None] = (None, None),
@@ -408,10 +422,20 @@ class LangGraphEngine(Engine):
             system_name=self._system_name,
             visited=result.get("visited", []),
             answer=result.get("answer", ""),
-            used_tools=tuple(result.get("used_tools", [])),
+            used_tools=await self._used_tools(ctx),
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+
+    async def _used_tools(self, ctx: RunContext) -> tuple[ToolUsageRecord, ...]:
+        """The run's tool trace, read from the usage repository.
+
+        The trace is a projection of persisted usage — including tools called by
+        nested agents — rather than something the graph state carried up.
+        """
+        if ctx.run_id is None:
+            return ()
+        return as_usage_records(await self._tool_usage_repository.list_for_run(ctx.run_id))
 
     async def _record_token_usage(
         self,
@@ -450,7 +474,7 @@ class LangGraphEngine(Engine):
                 pending = await self._pending_result(ctx, result, token_usage=token_usage)
                 if pending is not None:
                     return pending
-                run_result = self._completed_result(result, token_usage=token_usage)
+                run_result = await self._completed_result(ctx, result, token_usage=token_usage)
                 await lifecycle.succeed(ctx, run_result)
                 return run_result
             except Exception as exc:
@@ -499,7 +523,7 @@ class LangGraphEngine(Engine):
             system_name=self._system_name,
             visited=result.get("visited", []),
             answer="",
-            used_tools=tuple(result.get("used_tools", [])),
+            used_tools=await self._used_tools(ctx),
             input_tokens=token_usage[0],
             output_tokens=token_usage[1],
             status="pending_approval",
@@ -553,13 +577,13 @@ class LangGraphEngine(Engine):
                 system_name=self._system_name,
                 visited=values.get("visited", []),
                 answer="",
-                used_tools=tuple(values.get("used_tools", [])),
+                used_tools=await self._used_tools(ctx),
                 input_tokens=token_usage[0],
                 output_tokens=token_usage[1],
                 status="pending_approval",
                 pending_approval=approval,
             )
-        return self._completed_result(values, token_usage=token_usage)
+        return await self._completed_result(ctx, values, token_usage=token_usage)
 
     async def resume(
         self,
@@ -613,7 +637,7 @@ class LangGraphEngine(Engine):
                 pending = await self._pending_result(ctx, result, token_usage=token_usage)
                 if pending is not None:
                     return pending
-                run_result = self._completed_result(result, token_usage=token_usage)
+                run_result = await self._completed_result(ctx, result, token_usage=token_usage)
                 await lifecycle.succeed(ctx, run_result)
                 log(
                     logger,
@@ -692,7 +716,7 @@ class LangGraphEngine(Engine):
             if pending is not None:
                 channel.emit(_pending_approval_event(self._system_name, pending))
                 return
-            run_result = self._completed_result(result, token_usage=token_usage)
+            run_result = await self._completed_result(ctx, result, token_usage=token_usage)
             await lifecycle.succeed(
                 ctx,
                 run_result,
@@ -818,6 +842,7 @@ class LangGraphEngine(Engine):
                     name=child.node.name or child.node.id,
                     protected=child.node.protected,
                     callable=callable_node,
+                    description=child.node.description,
                 )
             )
 
@@ -828,6 +853,8 @@ class LangGraphEngine(Engine):
             children=children,
             filters=self._filters,
             base_dir=self._base_dir,
+            usage_context=self._tool_usage_context,
+            usage_tracker=self._tool_usage_tracker,
             fallback_model=fallback_model,
         )
 
@@ -841,14 +868,37 @@ class LangGraphEngine(Engine):
             spec=spec,
             node_path=node_path,
             bound_model=bound_model,
-            tool_map={t.name: t for t in tools},
-            mcp_tool_names=mcp_names,
-            mcp_server_by_tool=server_by_tool,
             resolver_loader=self._resolver_loader,
-            hook_manager=self._hook_manager,
             base_dir=self._base_dir,
+            tool_invoker=self._build_tool_invoker(
+                spec,
+                node_path,
+                AgentToolBinding(
+                    tools={t.name: t for t in tools},
+                    mcp_tool_names=frozenset(mcp_names),
+                    mcp_server_by_tool=server_by_tool,
+                ),
+            ),
+            usage_context=self._tool_usage_context,
+        )
+
+    def _build_tool_invoker(
+        self, spec: AgentSpec, node_path: str, binding: AgentToolBinding
+    ) -> ToolInvoker:
+        """Give the agent the one collaborator that runs its tool calls.
+
+        Every invoker shares the engine's approval, idempotency, and usage
+        collaborators, so agents of the same run agree on what already happened.
+        """
+        assert self._hook_manager is not None
+        return ToolInvoker(
+            spec=spec,
+            node_path=node_path,
+            binding=binding,
+            hook_manager=self._hook_manager,
             execution_manager=self._execution_manager,
             approval_coordinator=self._approval_coordinator,
+            usage_tracker=self._tool_usage_tracker,
             system_namespace=self._system_name,
         )
 

--- a/src/agent_engine/engine/langgraph/executed_tools_tool.py
+++ b/src/agent_engine/engine/langgraph/executed_tools_tool.py
@@ -1,0 +1,66 @@
+"""The engine's own read-only tool for reporting what has already executed.
+
+An orchestrator's children are bound to it as tools, so asked "which tools have
+run?" a model answers from that list and names a child agent — a claim no system
+instruction reliably corrected. Giving it a tool turns the question into a tool
+call whose result comes from the usage repository, which the model cannot
+contradict from its own bindings.
+
+The tool performs no side effect: it reads execution metadata and returns text.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+from agent_engine.engine.langgraph.helpers import current_usage_scope
+from agent_engine.logging_config import log
+from agent_engine.tool_usage.context import (
+    EXECUTION_RECORD_UNAVAILABLE,
+    ToolUsageContextProvider,
+    format_executed_tools,
+)
+
+logger = logging.getLogger(__name__)
+
+EXECUTED_TOOLS_TOOL_NAME = "list_executed_tools"
+
+_DESCRIPTION = (
+    "List the tools that have actually been executed so far in this conversation, "
+    "with the agent that ran each one and its outcome. Call this whenever the user "
+    "asks which tools have run, what has been done, or whether an action already "
+    "happened. The result is authoritative execution metadata: answer from it, not "
+    "from the agents in your own tool list."
+)
+
+
+def build_executed_tools_tool(provider: ToolUsageContextProvider, agent_id: str) -> BaseTool:
+    """Bind the usage provider into a no-argument reporting tool."""
+
+    async def list_executed_tools() -> str:
+        scope = current_usage_scope(agent_id)
+        try:
+            context = await provider.get_executed_tools(scope)
+        except Exception as exc:
+            # Never raise out of a tool the model called, and never let a read
+            # failure be reported as "nothing has run" — that would invite a
+            # repeat of an action that already took effect.
+            log(
+                logger,
+                logging.WARNING,
+                "execution record unavailable",
+                agent=agent_id,
+                run_id=scope.run_id,
+                conversation_id=scope.conversation_id,
+                error=type(exc).__name__,
+            )
+            return EXECUTION_RECORD_UNAVAILABLE
+        return format_executed_tools(context)
+
+    return StructuredTool.from_function(
+        coroutine=list_executed_tools,
+        name=EXECUTED_TOOLS_TOOL_NAME,
+        description=_DESCRIPTION,
+    )

--- a/src/agent_engine/engine/langgraph/helpers.py
+++ b/src/agent_engine/engine/langgraph/helpers.py
@@ -26,7 +26,7 @@ def current_usage_scope(agent_id: str | None = None) -> ToolUsageScope:
     return ToolUsageScope(run_id=ctx.run_id, conversation_id=ctx.conversation_id, agent_id=agent_id)
 
 
-ExecutionContextRefresher = Callable[[frozenset[str]], Awaitable[str | None]]
+ExecutionContextRefresher = Callable[[], Awaitable[str | None]]
 
 
 def execution_context_refresher(
@@ -35,11 +35,11 @@ def execution_context_refresher(
     """Bind a usage provider to one agent's ambient scope, ready to re-read.
 
     Nodes hold the result and know nothing about scopes, records, or wording;
-    they only report which tools their current turn already shows the model.
+    they only ask for the latest execution context.
     """
 
-    async def refresh(already_visible: frozenset[str]) -> str | None:
-        context = await provider.get(current_usage_scope(agent_id), already_visible=already_visible)
+    async def refresh() -> str | None:
+        context = await provider.get(current_usage_scope(agent_id))
         return context.render()
 
     return refresh
@@ -81,19 +81,6 @@ class ModelContext:
     def messages(self) -> list[Any]:
         """The live message list handed to the model."""
         return self._messages
-
-    def requested_tool_names(self) -> frozenset[str]:
-        """Tools this turn has already asked for, and whose results it carries.
-
-        What the model can see for itself through the normal tool protocol, so
-        the execution context does not have to repeat it.
-        """
-        return frozenset(
-            name
-            for message in self._messages
-            for call in getattr(message, "tool_calls", None) or ()
-            if isinstance(call, dict) and isinstance(name := call.get("name"), str)
-        )
 
     def append(self, message: Any) -> None:
         """Add one model response or tool result to the running turn."""
@@ -186,7 +173,7 @@ async def run_tool_loop(
             logger.debug("[%s] ← tool_call: %s(%s)", node_path, tc["name"], tc["args"])
             content = await invoke_tool(tc)
             logger.debug("[%s] → tool_result[%s]: %s", node_path, tc["name"], content[:300])
-            context.append(ToolMessage(content=content, tool_call_id=tc["id"]))
+            context.append(ToolMessage(content=content, tool_call_id=tc["id"], name=tc["name"]))
         await _refresh(context, refresh_execution_context)
         response = await invoke_model(model, context.messages, state)
     return response
@@ -197,9 +184,7 @@ async def _refresh(
     refresh_execution_context: ExecutionContextRefresher | None,
 ) -> None:
     if refresh_execution_context is not None:
-        context.set_execution_context(
-            await refresh_execution_context(context.requested_tool_names())
-        )
+        context.set_execution_context(await refresh_execution_context())
 
 
 def emit_route(state: GraphState, route: tuple[str, ...]) -> None:

--- a/src/agent_engine/engine/langgraph/helpers.py
+++ b/src/agent_engine/engine/langgraph/helpers.py
@@ -10,30 +10,107 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 
 from agent_engine.core.spec import AgentSpec, GraphNode, OrchestratorSpec
 from agent_engine.runtime.execution import ExecutionLimitExceeded, current_execution, log_limit
+from agent_engine.runtime.hooks import current_run_context
 from agent_engine.runtime.state import GraphState
 from agent_engine.runtime.streaming import current_streams
+from agent_engine.tool_usage.context import ToolUsageContextProvider, ToolUsageScope
 
 logger = logging.getLogger(__name__)
 
 
-def model_context(
-    system_prompt: str,
-    history: list[dict[str, str]],
-    user_message: str,
-) -> list[Any]:
-    """Build ordered provider-native messages from structured prior turns."""
-    messages: list[Any] = [SystemMessage(content=system_prompt)]
-    for message in history:
-        role = message.get("role")
-        content = message.get("content", "")
-        if role == "user":
-            messages.append(HumanMessage(content=content))
-        elif role == "assistant":
-            messages.append(AIMessage(content=content))
-        else:
-            raise ValueError(f"Unsupported conversation history role: {role!r}")
-    messages.append(HumanMessage(content=user_message))
-    return messages
+def current_usage_scope(agent_id: str | None = None) -> ToolUsageScope:
+    """The ambient scope to report tool usage for: this conversation, this run."""
+    ctx = current_run_context.get()
+    if ctx is None:
+        return ToolUsageScope(agent_id=agent_id)
+    return ToolUsageScope(run_id=ctx.run_id, conversation_id=ctx.conversation_id, agent_id=agent_id)
+
+
+ExecutionContextRefresher = Callable[[frozenset[str]], Awaitable[str | None]]
+
+
+def execution_context_refresher(
+    provider: ToolUsageContextProvider, agent_id: str
+) -> ExecutionContextRefresher:
+    """Bind a usage provider to one agent's ambient scope, ready to re-read.
+
+    Nodes hold the result and know nothing about scopes, records, or wording;
+    they only report which tools their current turn already shows the model.
+    """
+
+    async def refresh(already_visible: frozenset[str]) -> str | None:
+        context = await provider.get(current_usage_scope(agent_id), already_visible=already_visible)
+        return context.render()
+
+    return refresh
+
+
+class ModelContext:
+    """The ordered messages for one node's model turns.
+
+    Layout: system instructions, an optional private execution-context system
+    message, prior conversation turns, then the current user message. Keeping the
+    execution slot beside the system prompt — never as a user or assistant turn —
+    is what stops runtime metadata from entering the conversation history the
+    caller persists or reaching the user. The slot can be refreshed between model
+    turns, so a node learns what its children ran while it was waiting.
+    """
+
+    _EXECUTION_SLOT = 1
+
+    def __init__(
+        self,
+        system_prompt: str,
+        history: list[dict[str, str]],
+        user_message: str,
+    ) -> None:
+        self._messages: list[Any] = [SystemMessage(content=system_prompt)]
+        self._has_execution_context = False
+        for message in history:
+            role = message.get("role")
+            content = message.get("content", "")
+            if role == "user":
+                self._messages.append(HumanMessage(content=content))
+            elif role == "assistant":
+                self._messages.append(AIMessage(content=content))
+            else:
+                raise ValueError(f"Unsupported conversation history role: {role!r}")
+        self._messages.append(HumanMessage(content=user_message))
+
+    @property
+    def messages(self) -> list[Any]:
+        """The live message list handed to the model."""
+        return self._messages
+
+    def requested_tool_names(self) -> frozenset[str]:
+        """Tools this turn has already asked for, and whose results it carries.
+
+        What the model can see for itself through the normal tool protocol, so
+        the execution context does not have to repeat it.
+        """
+        return frozenset(
+            name
+            for message in self._messages
+            for call in getattr(message, "tool_calls", None) or ()
+            if isinstance(call, dict) and isinstance(name := call.get("name"), str)
+        )
+
+    def append(self, message: Any) -> None:
+        """Add one model response or tool result to the running turn."""
+        self._messages.append(message)
+
+    def set_execution_context(self, text: str | None) -> None:
+        """Install, replace, or drop the private execution-context message.
+
+        It stays adjacent to the system prompt, so providers that require a
+        single leading system block still see consecutive system messages.
+        """
+        if self._has_execution_context:
+            self._messages.pop(self._EXECUTION_SLOT)
+            self._has_execution_context = False
+        if text:
+            self._messages.insert(self._EXECUTION_SLOT, SystemMessage(content=text))
+            self._has_execution_context = True
 
 
 def node_id(node: GraphNode, parent_path: str | None) -> str:
@@ -76,10 +153,12 @@ async def invoke_model(model: Any, messages: list[Any], state: GraphState) -> An
 
 async def run_tool_loop(
     model: Any,
-    messages: list[Any],
+    context: ModelContext,
     state: GraphState,
     node_path: str,
     invoke_tool: Callable[[dict[str, Any]], Awaitable[str]],
+    *,
+    refresh_execution_context: ExecutionContextRefresher | None = None,
 ) -> Any:
     """Drive the model → tools → model loop until the model stops calling tools.
 
@@ -87,9 +166,14 @@ async def run_tool_loop(
     caller supplies its own: an agent runs real/MCP tools, an orchestrator runs
     child agents exposed as tools. The final (tool-call-free) model response is
     returned.
+
+    ``refresh_execution_context`` is re-read before every model turn, so the turn
+    that synthesises an answer reflects what the tools (or child agents) called in
+    this same turn actually did.
     """
     limiter = current_execution.get()
-    response = await invoke_model(model, messages, state)
+    await _refresh(context, refresh_execution_context)
+    response = await invoke_model(model, context.messages, state)
     while getattr(response, "tool_calls", None):
         if limiter is not None:
             try:
@@ -97,14 +181,25 @@ async def run_tool_loop(
             except ExecutionLimitExceeded as exc:
                 log_limit(exc)
                 break
-        messages.append(response)
+        context.append(response)
         for tc in response.tool_calls:
             logger.debug("[%s] ← tool_call: %s(%s)", node_path, tc["name"], tc["args"])
             content = await invoke_tool(tc)
             logger.debug("[%s] → tool_result[%s]: %s", node_path, tc["name"], content[:300])
-            messages.append(ToolMessage(content=content, tool_call_id=tc["id"]))
-        response = await invoke_model(model, messages, state)
+            context.append(ToolMessage(content=content, tool_call_id=tc["id"]))
+        await _refresh(context, refresh_execution_context)
+        response = await invoke_model(model, context.messages, state)
     return response
+
+
+async def _refresh(
+    context: ModelContext,
+    refresh_execution_context: ExecutionContextRefresher | None,
+) -> None:
+    if refresh_execution_context is not None:
+        context.set_execution_context(
+            await refresh_execution_context(context.requested_tool_names())
+        )
 
 
 def emit_route(state: GraphState, route: tuple[str, ...]) -> None:

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -2,14 +2,15 @@
 
 ``AgentNode``        — runs a single agent: resolve context → build prompt → tool loop.
 ``OrchestratorNode`` — supervisor agent that calls child agents as tools and synthesizes.
+
+Neither node owns tool-execution or tool-usage state: a node asks its
+:class:`ToolInvoker` to run a call, and asks its
+:class:`ToolUsageContextProvider` what the run has already done.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
-import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
@@ -19,38 +20,39 @@ from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.errors import GraphInterrupt
 from pydantic import BaseModel
 
-from agent_engine.approvals.coordinator import ApprovalCoordinator
-from agent_engine.approvals.invocation import ToolInvocation
-from agent_engine.approvals.manager import ToolExecutionManager, execution_id_for
 from agent_engine.core.spec import AgentSpec, OrchestratorSpec
+from agent_engine.engine.langgraph.executed_tools_tool import (
+    EXECUTED_TOOLS_TOOL_NAME,
+    build_executed_tools_tool,
+)
 from agent_engine.engine.langgraph.filters import RouteFilter
 from agent_engine.engine.langgraph.helpers import (
+    ModelContext,
     as_text,
+    current_usage_scope,
     emit_route,
+    execution_context_refresher,
     load_file,
-    model_context,
     render_prompt,
     run_tool_loop,
 )
+from agent_engine.engine.langgraph.tool_invoker import ToolInvoker
 from agent_engine.loaders.resolver_loader import ResolverLoader
-from agent_engine.logging_config import log
 from agent_engine.runtime.execution import (
     ExecutionLimitExceeded,
     blocked_message,
     current_execution,
     log_limit,
 )
-from agent_engine.runtime.hooks import (
-    HookManager,
-    ToolCallContext,
-    ToolRequestContext,
-    ToolResultContext,
-    current_run_context,
-)
-from agent_engine.runtime.hooks.models import ToolStatus
 from agent_engine.runtime.state import GraphState
 from agent_engine.runtime.streaming import current_streams
-from agent_engine.runtime.tool_models import ToolProviderName, ToolUsageRecord
+from agent_engine.tool_usage.context import ToolUsageContextProvider
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationKind,
+    stable_tool_call_id,
+)
+from agent_engine.tool_usage.tracker import ToolUsageTracker
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +64,11 @@ _ORCHESTRATOR_CONTRACT = """
   Do NOT call a tool for something outside its stated scope.
 - If no appropriate tool exists for part of the request, say: "I'm not able to help with that."
 - You may call multiple tools if the request covers several topics.
+- The tools available to you are other AGENTS, not actions. Calling one hands the request
+  to that agent; the agent, not you, performs the work with its own tools. Never describe an
+  agent you called as a tool that ran.
+- When the user asks which tools have run or what has already been done, call
+  `list_executed_tools` and answer from its result — never from your own tool list.
 """
 
 
@@ -84,50 +91,18 @@ class ChildEntry:
     name: str
     protected: bool
     callable: AgentNode | OrchestratorNode
+    description: str = ""
 
+    @property
+    def tool_description(self) -> str:
+        """How this child is described to the parent's model.
 
-@dataclass(frozen=True)
-class ExecuteTool:
-    """Approval-gate result: the gate is open — the caller may run the tool."""
-
-
-@dataclass(frozen=True)
-class DenyTool:
-    """Approval-gate result: the gate is closed — do not run the tool.
-
-    ``message`` is the structured, model-facing result to return in place of
-    execution (a normal denial, not a system error).
-    """
-
-    message: str
-
-
-ToolGate = ExecuteTool | DenyTool
-
-
-@dataclass(frozen=True)
-class _ToolCall:
-    """One resolved, about-to-run tool call: the tool plus its stable identity.
-
-    Bundling these fields once removes the repeated ``agent/tool/provider/server``
-    argument lists that the limit, gate, logging, hook, and execution steps would
-    each otherwise rebuild from the raw ``tc`` dict.
-    """
-
-    tool: BaseTool
-    name: str
-    args: dict[str, Any]
-    provider: ToolProviderName
-    server_id: str | None
-    tool_call_id: str
-    run_id: str
-    exec_id: str
-    description: str
-
-
-def _elapsed_ms(start: float) -> int:
-    """Whole milliseconds elapsed since a ``time.perf_counter()`` reading."""
-    return int((time.perf_counter() - start) * 1000)
+        Named as a delegation rather than an action, because a child bound as a
+        plain tool reads to the model as something it performs itself — which is
+        how an orchestrator comes to report a child agent as a tool it ran.
+        """
+        summary = self.description or self.name
+        return f"Delegate this request to the '{self.name}' agent. {summary}"
 
 
 class AgentNode:
@@ -142,28 +117,18 @@ class AgentNode:
         spec: AgentSpec,
         node_path: str,
         bound_model: Any,
-        tool_map: dict[str, BaseTool],
-        mcp_tool_names: set[str],
         resolver_loader: ResolverLoader,
-        hook_manager: HookManager,
         base_dir: Path,
-        execution_manager: ToolExecutionManager,
-        approval_coordinator: ApprovalCoordinator,
-        system_namespace: str = "",
-        mcp_server_by_tool: dict[str, str] | None = None,
+        tool_invoker: ToolInvoker,
+        usage_context: ToolUsageContextProvider,
     ) -> None:
         self._spec = spec
         self._node_path = node_path
         self._bound_model = bound_model
-        self._tool_map = tool_map
-        self._mcp_tool_names = mcp_tool_names
-        self._mcp_server_by_tool = mcp_server_by_tool or {}
         self._resolver_loader = resolver_loader
-        self._hook_manager = hook_manager
         self._base_dir = base_dir
-        self._execution_manager = execution_manager
-        self._approval_coordinator = approval_coordinator
-        self._system_namespace = system_namespace
+        self._tool_invoker = tool_invoker
+        self._refresh_execution_context = execution_context_refresher(usage_context, spec.id)
 
     async def __call__(self, state: GraphState) -> GraphState:
         ctx = self._resolve_context()
@@ -187,320 +152,32 @@ class AgentNode:
         return render_prompt(template, ctx)
 
     async def _run(self, system_prompt: str, state: GraphState) -> GraphState:
-        """Drive the model + tool loop until the model stops requesting tools."""
+        """Drive the model + tool loop until the model stops requesting tools.
+
+        The execution context is re-read from the usage repository before every
+        model turn, so an agent knows what other agents did without any of it
+        travelling through the graph state.
+        """
         user_msg: str = state.get("message", "")
-        messages = model_context(system_prompt, state.get("history", []), user_msg)
+        context = ModelContext(system_prompt, state.get("history", []), user_msg)
         logger.debug("[%s] system:\n%s", self._node_path, system_prompt)
         logger.debug("[%s] → user: %s", self._node_path, user_msg)
 
         visited: list[str] = [*state.get("visited", []), self._node_path]
         emit_route(state, tuple(visited))
 
-        used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
-
-        async def invoke_tool(tc: dict[str, Any]) -> str:
-            return await self._invoke_tool(tc, used_tools)
-
         response = await run_tool_loop(
-            self._bound_model, messages, state, self._node_path, invoke_tool
+            self._bound_model,
+            context,
+            state,
+            self._node_path,
+            self._tool_invoker.invoke,
+            refresh_execution_context=self._refresh_execution_context,
         )
         answer = as_text(response.content)
         logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
 
-        return {"visited": visited, "answer": answer, "used_tools": used_tools}
-
-    async def _invoke_tool(self, tc: dict[str, Any], used_tools: list[ToolUsageRecord]) -> str:
-        """Resolve, gate, and execute one tool call for both local and MCP tools.
-
-        The pipeline short-circuits at the first step that stops the call, each
-        returning a model-facing string:
-
-        1. resolve the tool (unknown name → error);
-        2. enforce execution limits (blocked → controlled message);
-        3. the Human-in-the-Loop gate (denied → ``[denied]``; when approval is
-           required and not yet granted the graph suspends and this method does
-           not return normally);
-        4. idempotency (a replayed call returns its recorded result);
-        5. execute with the ``before/after/on_error`` lifecycle hooks.
-        """
-        tool = self._tool_map.get(tc["name"])
-        if tool is None:
-            return f"Unknown tool: {tc['name']}"
-        call = self._describe_call(tool, tc)
-
-        blocked = self._enforce_limits(call)
-        if blocked is not None:
-            return blocked
-
-        gate = await self._gate_tool_call(call)
-        if isinstance(gate, DenyTool):
-            return gate.message
-
-        cached = await self._cached_result(call, used_tools)
-        if cached is not None:
-            return cached
-
-        return await self._execute(call, used_tools)
-
-    def _describe_call(self, tool: BaseTool, tc: dict[str, Any]) -> _ToolCall:
-        """Freeze the tool's runtime identity: provider, ids, and idempotency key."""
-        name: str = tc["name"]
-        args = tc.get("args") or {}
-        run_context = current_run_context.get()
-        run_id = run_context.run_id if run_context and run_context.run_id else tc["id"]
-        provider: ToolProviderName = "mcp" if name in self._mcp_tool_names else "local"
-        server_id = self._mcp_server_by_tool.get(name)
-        stable_payload = json.dumps(
-            [run_id, self._node_path, provider, server_id, name, args],
-            sort_keys=True,
-            separators=(",", ":"),
-            default=str,
-        )
-        tool_call_id = f"call_{hashlib.sha256(stable_payload.encode()).hexdigest()[:24]}"
-        return _ToolCall(
-            tool=tool,
-            name=name,
-            args=args,
-            provider=provider,
-            server_id=server_id,
-            tool_call_id=tool_call_id,
-            run_id=run_id,
-            exec_id=execution_id_for(tool_call_id),
-            description=tool.description,
-        )
-
-    def _enforce_limits(self, call: _ToolCall) -> str | None:
-        """Register the call against execution limits (total/per-agent counts,
-        duplicate detection). Returns a controlled message when a limit blocks the
-        call — which is then never executed — or ``None`` when it may proceed.
-        """
-        limiter = current_execution.get()
-        if limiter is None:
-            return None
-        try:
-            limiter.register_tool_call(self._spec.id, call.name, call.args)
-        except ExecutionLimitExceeded as exc:
-            log_limit(exc)
-            return blocked_message(exc)
-        return None
-
-    async def _cached_result(
-        self, call: _ToolCall, used_tools: list[ToolUsageRecord]
-    ) -> str | None:
-        """Return a prior successful result for this exact call, if any.
-
-        Guards against a second side effect when a graph re-entry after resume
-        replays the node with the same ``tool_call_id`` (the primary
-        duplicate-execution protection).
-        """
-        cached = await self._execution_manager.already_executed(call.exec_id)
-        if cached is None or cached.result is None:
-            return None
-        log(
-            logger,
-            logging.INFO,
-            "duplicate tool execution prevented",
-            agent=self._spec.id,
-            tool=call.name,
-            tool_call_id=call.tool_call_id,
-            execution_id=call.exec_id,
-        )
-        used_tools.append(self._usage(call, "succeeded"))
-        return cached.result
-
-    async def _execute(self, call: _ToolCall, used_tools: list[ToolUsageRecord]) -> str:
-        """Run the provider exactly once, wrapped in the idempotency ledger and the
-        ``before_tool_call`` hook, dispatching to the success or error recorder.
-        """
-        await self._execution_manager.begin_execution(
-            call.exec_id,
-            tool_call_id=call.tool_call_id,
-            run_id=call.run_id,
-            tool_name=call.name,
-        )
-        self._log_call(logging.INFO, "tool call started", call)
-        await self._hook_manager.run_before_tool_call(
-            current_run_context.get(),
-            ToolRequestContext(
-                agent_id=self._spec.id,
-                tool_name=call.name,
-                provider=call.provider,
-                server_id=call.server_id,
-            ),
-        )
-
-        start = time.perf_counter()
-        try:
-            result = await call.tool.ainvoke(call.args)
-        except Exception as exc:
-            return await self._record_error(call, used_tools, exc, _elapsed_ms(start))
-        return await self._record_success(call, used_tools, result, _elapsed_ms(start))
-
-    async def _record_error(
-        self,
-        call: _ToolCall,
-        used_tools: list[ToolUsageRecord],
-        exc: Exception,
-        latency_ms: int,
-    ) -> str:
-        """Record a failed call, fire ``on_tool_error``, and return the error text.
-
-        The failure is returned (not raised) so the model can read it and recover.
-        """
-        error = str(exc)[:200]
-        used_tools.append(self._usage(call, "failed", error=error))
-        self._log_call(logging.WARNING, "tool call failed", call, ms=latency_ms, error=error)
-
-        await self._hook_manager.run_on_tool_error(
-            current_run_context.get(),
-            self._call_context(call, "failed", latency_ms, error=error),
-        )
-        await self._execution_manager.finish_execution(
-            call.exec_id, status="failed", result=f"Tool error: {exc}"
-        )
-        return f"Tool error: {exc}"
-
-    async def _record_success(
-        self,
-        call: _ToolCall,
-        used_tools: list[ToolUsageRecord],
-        result: object,
-        latency_ms: int,
-    ) -> str:
-        """Record a successful call, fire ``after_tool_call`` and result-transform
-        hooks, persist the result to the idempotency ledger, and return it.
-        """
-        used_tools.append(self._usage(call, "succeeded"))
-        self._log_call(logging.INFO, "tool call ended", call, ms=latency_ms)
-        await self._hook_manager.run_after_tool_call(
-            current_run_context.get(),
-            self._call_context(call, "succeeded", latency_ms),
-        )
-        result_text = await self._transform_result(call, str(result), latency_ms)
-        await self._execution_manager.finish_execution(
-            call.exec_id, status="succeeded", result=result_text
-        )
-        return result_text
-
-    async def _transform_result(self, call: _ToolCall, result_text: str, latency_ms: int) -> str:
-        """Let ``transform_tool_result`` hooks reshape the result (e.g. truncate
-        oversized MCP output). The context is only built when such a hook exists.
-        """
-        if not self._hook_manager.has("transform_tool_result"):
-            return result_text
-        transformed = await self._hook_manager.run_transform_tool_result(
-            current_run_context.get(),
-            ToolResultContext(
-                agent_id=self._spec.id,
-                tool_name=call.name,
-                provider=call.provider,
-                result=result_text,
-                server_id=call.server_id,
-                latency_ms=latency_ms,
-            ),
-        )
-        return transformed.result
-
-    def _usage(
-        self, call: _ToolCall, status: ToolStatus, *, error: str | None = None
-    ) -> ToolUsageRecord:
-        """Build the per-call trace record with this node's identity filled in."""
-        return ToolUsageRecord(
-            name=call.name,
-            provider=call.provider,
-            status=status,
-            agent_id=self._spec.id,
-            server_id=call.server_id,
-            error=error,
-        )
-
-    def _call_context(
-        self,
-        call: _ToolCall,
-        status: ToolStatus,
-        latency_ms: int,
-        *,
-        error: str | None = None,
-    ) -> ToolCallContext:
-        """Build the hook context for a completed call (success or failure)."""
-        return ToolCallContext(
-            agent_id=self._spec.id,
-            tool_name=call.name,
-            provider=call.provider,
-            server_id=call.server_id,
-            status=status,
-            latency_ms=latency_ms,
-            error=error,
-        )
-
-    def _log_call(self, level: int, event: str, call: _ToolCall, **fields: Any) -> None:
-        """Structured log line carrying the call's identity (never its arguments)."""
-        log(
-            logger,
-            level,
-            event,
-            agent=self._spec.id,
-            tool=call.name,
-            provider=call.provider,
-            server=call.server_id,
-            **fields,
-        )
-
-    async def _gate_tool_call(self, call: _ToolCall) -> ToolGate:
-        """Run the call through the approval coordinator.
-
-        Returns :class:`ExecuteTool` when the tool may run (auto mode, an existing
-        session permission, or a human ``ALLOW_ONCE`` / ``ALLOW_FOR_SESSION``), or
-        :class:`DenyTool` carrying a model-facing message when the user denied the
-        call — a normal denial, not a system failure. When approval is required and
-        not yet granted the coordinator suspends the run via the interrupt provider
-        (``resolve`` does not return here), so no side effect happens before consent.
-        """
-        run_context = current_run_context.get()
-        session_id = run_context.conversation_id if run_context else None
-        auth_context = run_context.auth_context if run_context else None
-        user_id = (
-            auth_context.user_id
-            if auth_context and auth_context.user_id is not None
-            else run_context.user_id
-            if run_context
-            else None
-        )
-        organization_id = (
-            auth_context.organization_id
-            if auth_context and auth_context.organization_id is not None
-            else run_context.organization_id
-            if run_context
-            else None
-        )
-        approval_id_value = run_context.metadata.get("approval_id") if run_context else None
-        invocation = ToolInvocation(
-            tool_call_id=call.tool_call_id,
-            agent_id=self._spec.id,
-            tool_name=call.name,
-            session_id=session_id,
-            provider=call.provider,
-            server_id=call.server_id,
-            arguments=call.args,
-            system_namespace=self._system_namespace,
-            user_id=user_id or "",
-            organization_id=organization_id or "",
-            run_id=run_context.run_id if run_context else None,
-            approval_id=(approval_id_value if isinstance(approval_id_value, str) else None),
-            human_description=call.description,
-        )
-        outcome = await self._approval_coordinator.resolve(
-            invocation, auto_mode=self._spec.auto_mode
-        )
-        if outcome.execute:
-            return ExecuteTool()
-        self._log_call(logging.WARNING, "tool denied", call, tool_call_id=call.tool_call_id)
-        return DenyTool(
-            message=(
-                f"[denied] status=denied toolCallId={call.tool_call_id} tool={call.name} "
-                "reason=the user denied the action. The tool was not executed."
-            )
-        )
+        return {"visited": visited, "answer": answer}
 
 
 class OrchestratorNode:
@@ -513,6 +190,11 @@ class OrchestratorNode:
     Access filters control which child tools are made available — if a child is
     filtered out the LLM simply does not have that tool and responds naturally
     (e.g. "I can't help with domestic flights").
+
+    Like an agent, it receives the conversation's tool usage as private context,
+    refreshed before each model turn — so its synthesis knows what the children
+    it just called actually ran, and it can answer a user asking what has been
+    done so far.
     """
 
     def __init__(
@@ -523,6 +205,8 @@ class OrchestratorNode:
         children: list[ChildEntry],
         filters: list[RouteFilter],
         base_dir: Path,
+        usage_context: ToolUsageContextProvider,
+        usage_tracker: ToolUsageTracker,
         fallback_model: BaseChatModel | None = None,
     ) -> None:
         self._spec = spec
@@ -532,6 +216,9 @@ class OrchestratorNode:
         self._children = children
         self._filters = filters
         self._base_dir = base_dir
+        self._usage = usage_tracker
+        self._usage_context = usage_context
+        self._refresh_execution_context = execution_context_refresher(usage_context, spec.id)
 
     async def __call__(self, state: GraphState) -> GraphState:
         candidates = self._filter_children(state)
@@ -554,18 +241,22 @@ class OrchestratorNode:
         entry: ChildEntry,
         parent_state: GraphState,
         visited_acc: list[str],
-        used_tools_acc: list[ToolUsageRecord],
     ) -> StructuredTool:
         """Wrap a child node as a StructuredTool the orchestrator LLM can call.
 
-        ``visited_acc`` and ``used_tools_acc`` are the parent's live trace lists.
-        When the child returns we merge its new path segments and the tools it
-        used back into them, so the final route and tool trace reflect the whole
-        call-chain — not just the orchestrator's own step.
+        ``visited_acc`` is the parent's live route list: when the child returns we
+        merge its new path segments back into it, so the final route reflects the
+        whole call-chain. The child's tool usage needs no merging — it is already
+        recorded against the same run in the usage repository.
+
+        Delegating to a child is itself an action this orchestrator took, so it
+        is recorded too — that is how a later turn knows the routing that already
+        happened. Execution still goes through the child node, unchanged.
         """
 
         async def invoke(message: str) -> str:
             snapshot = list(visited_acc)
+            identity = self._child_identity(entry, message)
             # Children never stream their answer to the user — only the root
             # orchestrator's final synthesis does. The stream sinks are ambient
             # (current_streams); clear the answer sink for the child while keeping
@@ -573,7 +264,6 @@ class OrchestratorNode:
             sub_state: GraphState = {
                 "message": message,
                 "visited": snapshot,
-                "used_tools": [],
                 "run_context": parent_state.get("run_context", {}),
             }
             child_sinks = replace(current_streams.get(), answer=None)
@@ -583,23 +273,56 @@ class OrchestratorNode:
             except GraphInterrupt:
                 # An approval interrupt raised inside a nested child must bubble up
                 # to the LangGraph runtime so the checkpoint is taken — it is
-                # control flow, not a child failure. Never swallow it.
+                # control flow, not a child failure. Never swallow it, and record
+                # nothing: the invocation has not reached an outcome yet.
                 raise
             except Exception as exc:
+                await self._usage.record_failure(identity, error=str(exc))
                 return f"Agent error: {exc}"
             finally:
                 current_streams.reset(sink_token)
 
             for path in result.get("visited", [])[len(snapshot) :]:
                 visited_acc.append(path)
-            used_tools_acc.extend(result.get("used_tools", []))
+            await self._usage.record_success(identity)
             return result.get("answer", "")
 
         return StructuredTool.from_function(
             coroutine=invoke,
             name=entry.id,
-            description=entry.name,
+            description=entry.tool_description,
             args_schema=_AgentCall,
+        )
+
+    def _reporting_tools(self, child_names: set[str]) -> list[BaseTool]:
+        """The engine's own read-only tools, added unless a child claims the name.
+
+        A configured child always wins: the system's own graph outranks a
+        convenience the engine provides. Callers add these only when the
+        orchestrator has children to expose, so an orchestrator whose children
+        were all filtered out still faces the model with no tools at all.
+        """
+        if EXECUTED_TOOLS_TOOL_NAME in child_names:
+            return []
+        return [build_executed_tools_tool(self._usage_context, self._spec.id)]
+
+    def _child_identity(self, entry: ChildEntry, message: str) -> ToolCallIdentity:
+        """Name one delegation the same way a tool call is named.
+
+        Derived from the run, this orchestrator's position, the child, and the
+        message, so a replay after resume reaches the same identity instead of
+        recording a second delegation.
+        """
+        scope = current_usage_scope(self._spec.id)
+        run_id = scope.run_id or self._node_path
+        return ToolCallIdentity(
+            run_id=run_id,
+            agent_id=self._spec.id,
+            agent_path=self._node_path,
+            tool_call_id=stable_tool_call_id(run_id, self._node_path, "agent", entry.id, message),
+            tool_name=entry.id,
+            conversation_id=scope.conversation_id,
+            kind=ToolInvocationKind.AGENT,
         )
 
     async def _run(
@@ -610,10 +333,11 @@ class OrchestratorNode:
     ) -> GraphState:
         """Drive the orchestrator LLM tool loop and return the synthesised answer."""
         visited: list[str] = [*state.get("visited", []), self._node_path]
-        used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
 
-        # Build tools here so they share the live `visited` / `used_tools` lists.
-        tools = [self._make_tool(e, state, visited, used_tools) for e in candidates]
+        # Build tools here so they share the live `visited` list.
+        child_tools = [self._make_tool(e, state, visited) for e in candidates]
+        child_names = {tool.name for tool in child_tools}
+        tools = [*child_tools, *self._reporting_tools(child_names)] if child_tools else []
         bound_model = self._model.bind_tools(tools) if tools else self._model
         if self._fallback_model is not None:
             bound_fallback = (
@@ -625,7 +349,7 @@ class OrchestratorNode:
         tool_by_name = {t.name: t for t in tools}
 
         user_msg: str = state.get("message", "")
-        messages = model_context(system_prompt, state.get("history", []), user_msg)
+        context = ModelContext(system_prompt, state.get("history", []), user_msg)
         logger.debug(
             "[%s] system:\n%s\ntools: %s", self._node_path, system_prompt, list(tool_by_name)
         )
@@ -638,9 +362,10 @@ class OrchestratorNode:
             if tool is None:
                 return f"Unknown agent: {tc['name']}"
             # Limit orchestrator→child-agent invocations. A blocked call returns a
-            # controlled message instead of running the child.
+            # controlled message instead of running the child. Reporting on past
+            # execution is not a delegation, so it is not counted or recorded.
             limiter = current_execution.get()
-            if limiter is not None:
+            if limiter is not None and tc["name"] in child_names:
                 try:
                     limiter.register_child_call(self._node_path, tc["name"])
                 except ExecutionLimitExceeded as exc:
@@ -648,8 +373,15 @@ class OrchestratorNode:
                     return blocked_message(exc)
             return cast(str, await tool.ainvoke(tc["args"]))
 
-        response = await run_tool_loop(bound_model, messages, state, self._node_path, invoke_tool)
+        response = await run_tool_loop(
+            bound_model,
+            context,
+            state,
+            self._node_path,
+            invoke_tool,
+            refresh_execution_context=self._refresh_execution_context,
+        )
         answer = as_text(response.content)
         logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
 
-        return {"visited": visited, "answer": answer, "used_tools": used_tools}
+        return {"visited": visited, "answer": answer}

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -11,6 +11,7 @@ Neither node owns tool-execution or tool-usage state: a node asks its
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
@@ -42,6 +43,7 @@ from agent_engine.runtime.execution import (
     ExecutionLimitExceeded,
     blocked_message,
     current_execution,
+    current_invocation,
     log_limit,
 )
 from agent_engine.runtime.state import GraphState
@@ -131,9 +133,13 @@ class AgentNode:
         self._refresh_execution_context = execution_context_refresher(usage_context, spec.id)
 
     async def __call__(self, state: GraphState) -> GraphState:
-        ctx = self._resolve_context()
-        system_prompt = self._build_prompt(ctx)
-        return await self._run(system_prompt, state)
+        token = current_invocation.set(uuid.uuid4().hex)
+        try:
+            ctx = self._resolve_context()
+            system_prompt = self._build_prompt(ctx)
+            return await self._run(system_prompt, state)
+        finally:
+            current_invocation.reset(token)
 
     def _resolve_context(self) -> dict[str, str]:
         """Run every declared resolver and return the accumulated key→value map.
@@ -221,12 +227,18 @@ class OrchestratorNode:
         self._refresh_execution_context = execution_context_refresher(usage_context, spec.id)
 
     async def __call__(self, state: GraphState) -> GraphState:
-        candidates = self._filter_children(state)
-        base_prompt = load_file(self._base_dir, self._spec.prompts.system) or self._spec.description
-        orchestrator_content = load_file(self._base_dir, self._spec.prompts.orchestrator)
-        base_prompt = f"{base_prompt}\n\n{orchestrator_content}"
-        system_prompt = f"{base_prompt}\n{_ORCHESTRATOR_CONTRACT}"
-        return await self._run(system_prompt, candidates, state)
+        token = current_invocation.set(uuid.uuid4().hex)
+        try:
+            candidates = self._filter_children(state)
+            base_prompt = (
+                load_file(self._base_dir, self._spec.prompts.system) or self._spec.description
+            )
+            orchestrator_content = load_file(self._base_dir, self._spec.prompts.orchestrator)
+            base_prompt = f"{base_prompt}\n\n{orchestrator_content}"
+            system_prompt = f"{base_prompt}\n{_ORCHESTRATOR_CONTRACT}"
+            return await self._run(system_prompt, candidates, state)
+        finally:
+            current_invocation.reset(token)
 
     def _filter_children(self, state: GraphState) -> list[ChildEntry]:
         """Apply every RouteFilter to narrow down which child tools are available."""

--- a/src/agent_engine/engine/langgraph/tool_invoker.py
+++ b/src/agent_engine/engine/langgraph/tool_invoker.py
@@ -1,0 +1,431 @@
+"""Coordination of a single tool invocation for one agent.
+
+``ToolInvoker`` owns the path from "the model asked for this tool" to "here is
+the text the model gets back": identity, execution limits, the Human-in-the-Loop
+gate, idempotency, provider execution with lifecycle hooks, and handing the
+outcome to the usage tracker. There is exactly one such path — the approval flow
+and the tracking flow are steps in it, never a second pipeline.
+
+Keeping it out of the node leaves ``AgentNode`` with prompt building and the
+model loop, and lets the invoker be constructed and tested on its own.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.tools import BaseTool
+
+from agent_engine.approvals.coordinator import ApprovalCoordinator
+from agent_engine.approvals.invocation import ToolInvocation
+from agent_engine.approvals.manager import ToolExecutionManager, execution_id_for
+from agent_engine.core.spec import AgentSpec
+from agent_engine.logging_config import log
+from agent_engine.runtime.execution import (
+    ExecutionLimitExceeded,
+    blocked_message,
+    current_execution,
+    log_limit,
+)
+from agent_engine.runtime.hooks import (
+    HookManager,
+    ToolCallContext,
+    ToolRequestContext,
+    ToolResultContext,
+    current_run_context,
+)
+from agent_engine.runtime.hooks.models import ToolStatus
+from agent_engine.runtime.tool_models import ToolProviderName
+from agent_engine.tool_usage.models import ToolCallIdentity, stable_tool_call_id
+from agent_engine.tool_usage.tracker import ToolUsageTracker
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExecuteTool:
+    """Approval-gate result: the gate is open — the caller may run the tool."""
+
+
+@dataclass(frozen=True)
+class DenyTool:
+    """Approval-gate result: the gate is closed — do not run the tool.
+
+    ``message`` is the structured, model-facing result to return in place of
+    execution (a normal denial, not a system error).
+    """
+
+    message: str
+
+
+ToolGate = ExecuteTool | DenyTool
+
+
+@dataclass(frozen=True)
+class AgentToolBinding:
+    """The tools one agent may call, plus where each of them came from."""
+
+    tools: dict[str, BaseTool] = field(default_factory=dict)
+    mcp_tool_names: frozenset[str] = frozenset()
+    mcp_server_by_tool: Mapping[str, str] = field(default_factory=dict)
+
+    def get(self, name: str) -> BaseTool | None:
+        return self.tools.get(name)
+
+    def provider_of(self, name: str) -> ToolProviderName:
+        return "mcp" if name in self.mcp_tool_names else "local"
+
+    def server_of(self, name: str) -> str | None:
+        return self.mcp_server_by_tool.get(name)
+
+
+@dataclass(frozen=True)
+class _ToolCall:
+    """One resolved, about-to-run tool call: the tool plus its stable identity.
+
+    Bundling these fields once removes the repeated ``agent/tool/provider/server``
+    argument lists that the limit, gate, logging, hook, tracking, and execution
+    steps would each otherwise rebuild from the raw ``tc`` dict.
+    """
+
+    tool: BaseTool
+    identity: ToolCallIdentity
+    args: dict[str, Any]
+    exec_id: str
+
+    @property
+    def name(self) -> str:
+        return self.identity.tool_name
+
+    @property
+    def provider(self) -> ToolProviderName:
+        return self.identity.provider
+
+    @property
+    def server_id(self) -> str | None:
+        return self.identity.server_id
+
+    @property
+    def tool_call_id(self) -> str:
+        return self.identity.tool_call_id
+
+    @property
+    def run_id(self) -> str:
+        return self.identity.run_id
+
+    @property
+    def description(self) -> str:
+        return self.tool.description
+
+
+def _elapsed_ms(start: float) -> int:
+    """Whole milliseconds elapsed since a ``time.perf_counter()`` reading."""
+    return int((time.perf_counter() - start) * 1000)
+
+
+class ToolInvoker:
+    """Runs one agent's tool calls: gate, execute, record.
+
+    All collaborators are injected, and none of them is per-run state, so one
+    invoker serves every run of its agent concurrently.
+    """
+
+    def __init__(
+        self,
+        *,
+        spec: AgentSpec,
+        node_path: str,
+        binding: AgentToolBinding,
+        hook_manager: HookManager,
+        execution_manager: ToolExecutionManager,
+        approval_coordinator: ApprovalCoordinator,
+        usage_tracker: ToolUsageTracker,
+        system_namespace: str = "",
+    ) -> None:
+        self._spec = spec
+        self._node_path = node_path
+        self._binding = binding
+        self._hook_manager = hook_manager
+        self._execution_manager = execution_manager
+        self._approval_coordinator = approval_coordinator
+        self._usage = usage_tracker
+        self._system_namespace = system_namespace
+
+    async def invoke(self, tc: dict[str, Any]) -> str:
+        """Resolve, gate, and execute one tool call for both local and MCP tools.
+
+        The pipeline short-circuits at the first step that stops the call, each
+        returning a model-facing string:
+
+        1. resolve the tool (unknown name → error);
+        2. enforce execution limits (blocked → controlled message);
+        3. the Human-in-the-Loop gate (denied → ``[denied]``; when approval is
+           required and not yet granted the graph suspends and this method does
+           not return normally);
+        4. idempotency (a replayed call returns its recorded result);
+        5. execute with the ``before/after/on_error`` lifecycle hooks.
+
+        Every outcome that reached a decision — executed, failed, or denied — is
+        recorded against the run before the text is returned.
+        """
+        tool = self._binding.get(tc["name"])
+        if tool is None:
+            return f"Unknown tool: {tc['name']}"
+        call = self._describe_call(tool, tc)
+
+        blocked = self._enforce_limits(call)
+        if blocked is not None:
+            return blocked
+
+        gate = await self._gate_tool_call(call)
+        if isinstance(gate, DenyTool):
+            await self._usage.record_denied(call.identity)
+            return gate.message
+
+        cached = await self._cached_result(call)
+        if cached is not None:
+            return cached
+
+        return await self._execute(call)
+
+    def _describe_call(self, tool: BaseTool, tc: dict[str, Any]) -> _ToolCall:
+        """Freeze the tool's runtime identity: provider, ids, and idempotency key.
+
+        ``tool_call_id`` is derived from the call itself rather than the
+        provider's message id, so the same logical invocation keeps one identity
+        across a suspension and its resumed replay. The conversation is recorded
+        alongside it so a later turn can ask what earlier turns already did.
+        """
+        name: str = tc["name"]
+        args = tc.get("args") or {}
+        run_context = current_run_context.get()
+        run_id = run_context.run_id if run_context and run_context.run_id else tc["id"]
+        provider = self._binding.provider_of(name)
+        server_id = self._binding.server_of(name)
+        tool_call_id = stable_tool_call_id(run_id, self._node_path, provider, server_id, name, args)
+        return _ToolCall(
+            tool=tool,
+            identity=ToolCallIdentity(
+                run_id=run_id,
+                agent_id=self._spec.id,
+                agent_path=self._node_path,
+                tool_call_id=tool_call_id,
+                tool_name=name,
+                provider=provider,
+                server_id=server_id,
+                conversation_id=run_context.conversation_id if run_context else None,
+            ),
+            args=args,
+            exec_id=execution_id_for(tool_call_id),
+        )
+
+    def _enforce_limits(self, call: _ToolCall) -> str | None:
+        """Register the call against execution limits (total/per-agent counts,
+        duplicate detection). Returns a controlled message when a limit blocks the
+        call — which is then never executed — or ``None`` when it may proceed.
+        """
+        limiter = current_execution.get()
+        if limiter is None:
+            return None
+        try:
+            limiter.register_tool_call(self._spec.id, call.name, call.args)
+        except ExecutionLimitExceeded as exc:
+            log_limit(exc)
+            return blocked_message(exc)
+        return None
+
+    async def _cached_result(self, call: _ToolCall) -> str | None:
+        """Return a prior successful result for this exact call, if any.
+
+        Guards against a second side effect when a graph re-entry after resume
+        replays the node with the same ``tool_call_id`` (the primary
+        duplicate-execution protection). Re-recording the same identity is an
+        upsert, so the replay does not add a second usage record either.
+        """
+        cached = await self._execution_manager.already_executed(call.exec_id)
+        if cached is None or cached.result is None:
+            return None
+        log(
+            logger,
+            logging.INFO,
+            "duplicate tool execution prevented",
+            agent=self._spec.id,
+            tool=call.name,
+            tool_call_id=call.tool_call_id,
+            execution_id=call.exec_id,
+        )
+        await self._usage.record_success(call.identity)
+        return cached.result
+
+    async def _execute(self, call: _ToolCall) -> str:
+        """Run the provider exactly once, wrapped in the idempotency ledger and the
+        ``before_tool_call`` hook, dispatching to the success or error recorder.
+        """
+        await self._execution_manager.begin_execution(
+            call.exec_id,
+            tool_call_id=call.tool_call_id,
+            run_id=call.run_id,
+            tool_name=call.name,
+        )
+        self._log_call(logging.INFO, "tool call started", call)
+        await self._hook_manager.run_before_tool_call(
+            current_run_context.get(),
+            ToolRequestContext(
+                agent_id=self._spec.id,
+                tool_name=call.name,
+                provider=call.provider,
+                server_id=call.server_id,
+            ),
+        )
+
+        start = time.perf_counter()
+        try:
+            result = await call.tool.ainvoke(call.args)
+        except Exception as exc:
+            return await self._record_error(call, exc, _elapsed_ms(start))
+        return await self._record_success(call, result, _elapsed_ms(start))
+
+    async def _record_error(self, call: _ToolCall, exc: Exception, latency_ms: int) -> str:
+        """Record a failed call, fire ``on_tool_error``, and return the error text.
+
+        The failure is returned (not raised) so the model can read it and recover.
+        """
+        error = str(exc)[:200]
+        await self._usage.record_failure(call.identity, error=error)
+        self._log_call(logging.WARNING, "tool call failed", call, ms=latency_ms, error=error)
+
+        await self._hook_manager.run_on_tool_error(
+            current_run_context.get(),
+            self._call_context(call, "failed", latency_ms, error=error),
+        )
+        await self._execution_manager.finish_execution(
+            call.exec_id, status="failed", result=f"Tool error: {exc}"
+        )
+        return f"Tool error: {exc}"
+
+    async def _record_success(self, call: _ToolCall, result: object, latency_ms: int) -> str:
+        """Record a successful call, fire ``after_tool_call`` and result-transform
+        hooks, persist the result to the idempotency ledger, and return it.
+        """
+        await self._usage.record_success(call.identity)
+        self._log_call(logging.INFO, "tool call ended", call, ms=latency_ms)
+        await self._hook_manager.run_after_tool_call(
+            current_run_context.get(),
+            self._call_context(call, "succeeded", latency_ms),
+        )
+        result_text = await self._transform_result(call, str(result), latency_ms)
+        await self._execution_manager.finish_execution(
+            call.exec_id, status="succeeded", result=result_text
+        )
+        return result_text
+
+    async def _transform_result(self, call: _ToolCall, result_text: str, latency_ms: int) -> str:
+        """Let ``transform_tool_result`` hooks reshape the result (e.g. truncate
+        oversized MCP output). The context is only built when such a hook exists.
+        """
+        if not self._hook_manager.has("transform_tool_result"):
+            return result_text
+        transformed = await self._hook_manager.run_transform_tool_result(
+            current_run_context.get(),
+            ToolResultContext(
+                agent_id=self._spec.id,
+                tool_name=call.name,
+                provider=call.provider,
+                result=result_text,
+                server_id=call.server_id,
+                latency_ms=latency_ms,
+            ),
+        )
+        return transformed.result
+
+    def _call_context(
+        self,
+        call: _ToolCall,
+        status: ToolStatus,
+        latency_ms: int,
+        *,
+        error: str | None = None,
+    ) -> ToolCallContext:
+        """Build the hook context for a completed call (success or failure)."""
+        return ToolCallContext(
+            agent_id=self._spec.id,
+            tool_name=call.name,
+            provider=call.provider,
+            server_id=call.server_id,
+            status=status,
+            latency_ms=latency_ms,
+            error=error,
+        )
+
+    def _log_call(self, level: int, event: str, call: _ToolCall, **fields: Any) -> None:
+        """Structured log line carrying the call's identity (never its arguments)."""
+        log(
+            logger,
+            level,
+            event,
+            agent=self._spec.id,
+            tool=call.name,
+            provider=call.provider,
+            server=call.server_id,
+            **fields,
+        )
+
+    async def _gate_tool_call(self, call: _ToolCall) -> ToolGate:
+        """Run the call through the approval coordinator.
+
+        Returns :class:`ExecuteTool` when the tool may run (auto mode, an existing
+        session permission, or a human ``ALLOW_ONCE`` / ``ALLOW_FOR_SESSION``), or
+        :class:`DenyTool` carrying a model-facing message when the user denied the
+        call — a normal denial, not a system failure. When approval is required and
+        not yet granted the coordinator suspends the run via the interrupt provider
+        (``resolve`` does not return here), so no side effect happens before consent.
+        """
+        run_context = current_run_context.get()
+        session_id = run_context.conversation_id if run_context else None
+        auth_context = run_context.auth_context if run_context else None
+        user_id = (
+            auth_context.user_id
+            if auth_context and auth_context.user_id is not None
+            else run_context.user_id
+            if run_context
+            else None
+        )
+        organization_id = (
+            auth_context.organization_id
+            if auth_context and auth_context.organization_id is not None
+            else run_context.organization_id
+            if run_context
+            else None
+        )
+        approval_id_value = run_context.metadata.get("approval_id") if run_context else None
+        invocation = ToolInvocation(
+            tool_call_id=call.tool_call_id,
+            agent_id=self._spec.id,
+            tool_name=call.name,
+            session_id=session_id,
+            provider=call.provider,
+            server_id=call.server_id,
+            arguments=call.args,
+            system_namespace=self._system_namespace,
+            user_id=user_id or "",
+            organization_id=organization_id or "",
+            run_id=run_context.run_id if run_context else None,
+            approval_id=(approval_id_value if isinstance(approval_id_value, str) else None),
+            human_description=call.description,
+        )
+        outcome = await self._approval_coordinator.resolve(
+            invocation, auto_mode=self._spec.auto_mode
+        )
+        if outcome.execute:
+            return ExecuteTool()
+        self._log_call(logging.WARNING, "tool denied", call, tool_call_id=call.tool_call_id)
+        return DenyTool(
+            message=(
+                f"[denied] status=denied toolCallId={call.tool_call_id} tool={call.name} "
+                "reason=the user denied the action. The tool was not executed."
+            )
+        )

--- a/src/agent_engine/runtime/execution.py
+++ b/src/agent_engine/runtime/execution.py
@@ -137,6 +137,10 @@ current_execution: ContextVar[ExecutionLimiter | None] = ContextVar(
     "current_execution", default=None
 )
 
+#: Opaque id for one node activation. Graph replay creates a fresh activation,
+#: while all model/tool iterations inside that activation share the same id.
+current_invocation: ContextVar[str | None] = ContextVar("current_invocation", default=None)
+
 
 def _signature(agent_id: str, tool_name: str, args: object) -> str:
     """Opaque, stable signature for duplicate detection: agent + tool + args.
@@ -147,7 +151,7 @@ def _signature(agent_id: str, tool_name: str, args: object) -> str:
         serialized = json.dumps(args, sort_keys=True, default=str)
     except (TypeError, ValueError):
         serialized = repr(args)
-    return f"{agent_id}\x1f{tool_name}\x1f{serialized}"
+    return f"{current_invocation.get()}\x1f{agent_id}\x1f{tool_name}\x1f{serialized}"
 
 
 def log_limit(exc: ExecutionLimitExceeded) -> None:

--- a/src/agent_engine/runtime/state.py
+++ b/src/agent_engine/runtime/state.py
@@ -8,15 +8,15 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
-from agent_engine.runtime.tool_models import ToolUsageRecord
-
 
 class GraphState(TypedDict, total=False):
     """Mutable state carried through one run of the compiled LangGraph.
 
     Kept fully serializable so it can be checkpointed: request-scoped callbacks
     (answer/route/token streaming) live on the ``current_streams`` contextvar,
-    not here (see ``agent_engine.runtime.streaming``).
+    not here (see ``agent_engine.runtime.streaming``). Execution metadata such as
+    tool usage is not carried here either — its source of truth is the
+    ``ToolUsageRepository``, keyed by run, not graph-state propagation.
     """
 
     message: str
@@ -30,9 +30,6 @@ class GraphState(TypedDict, total=False):
 
     answer: str
     """The final answer produced by the agent (leaf) node that handled it."""
-
-    used_tools: list[ToolUsageRecord]
-    """Runtime-observed tool calls, in call order."""
 
     run_context: dict[str, Any]
     """Generic request/run context supplied by the host application, CLI, or API.

--- a/src/agent_engine/runtime/tool_models.py
+++ b/src/agent_engine/runtime/tool_models.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 ToolProviderName = Literal["local", "mcp", "unknown"]
-ToolUsageStatus = Literal["started", "succeeded", "failed"]
+ToolUsageStatus = Literal["started", "succeeded", "failed", "denied"]
 
 
 @dataclass(frozen=True)

--- a/src/agent_engine/tool_usage/__init__.py
+++ b/src/agent_engine/tool_usage/__init__.py
@@ -1,0 +1,52 @@
+"""Shared tool-usage tracking: what happened to every tool call in a run.
+
+The subsystem answers one question — *which agent invoked which tool during
+which run, and with what outcome* — and keeps its two audiences apart:
+
+* :mod:`models` — the domain record and the ``run → agent → tool call`` identity.
+* :mod:`repository` — the persistence port; the source of truth.
+* :mod:`in_memory` — the process-local adapter for development and tests.
+* :mod:`tracker` — writes execution outcomes through the port.
+* :mod:`context` — projects persisted usage into private model context.
+* :mod:`trace` — projects persisted usage into the public run trace.
+
+It makes no authorization decisions; whether a call may run belongs to
+:mod:`agent_engine.approvals`. The two subsystems share identifiers (``run_id``,
+``tool_call_id``, agent, tool) without sharing responsibilities.
+"""
+
+from __future__ import annotations
+
+from agent_engine.tool_usage.context import (
+    ToolUsageContext,
+    ToolUsageContextProvider,
+    ToolUsageEntry,
+    ToolUsageScope,
+)
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationKind,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+    stable_tool_call_id,
+)
+from agent_engine.tool_usage.repository import ToolUsageRepository
+from agent_engine.tool_usage.trace import as_usage_records
+from agent_engine.tool_usage.tracker import ToolUsageTracker
+
+__all__ = [
+    "InMemoryToolUsageRepository",
+    "ToolCallIdentity",
+    "ToolInvocationKind",
+    "ToolInvocationRecord",
+    "ToolInvocationStatus",
+    "ToolUsageContext",
+    "ToolUsageContextProvider",
+    "ToolUsageEntry",
+    "ToolUsageRepository",
+    "ToolUsageScope",
+    "ToolUsageTracker",
+    "as_usage_records",
+    "stable_tool_call_id",
+]

--- a/src/agent_engine/tool_usage/context.py
+++ b/src/agent_engine/tool_usage/context.py
@@ -200,12 +200,7 @@ class ToolUsageContextProvider:
         self._report_max_entries = report_max_entries
         self._include_delegations = include_delegations
 
-    async def get(
-        self,
-        scope: ToolUsageScope,
-        *,
-        already_visible: frozenset[str] = frozenset(),
-    ) -> ToolUsageContext:
+    async def get(self, scope: ToolUsageScope) -> ToolUsageContext:
         """Return the usage context for ``scope``.
 
         The conversation is preferred when the caller has one, so a later turn
@@ -213,13 +208,12 @@ class ToolUsageContextProvider:
         falls back to its own run. A scope with neither id — a caller running
         outside any registered run — yields empty context rather than an error.
 
-        ``already_visible`` names the tools the caller has itself invoked in the
-        turn it is about to send. Those invocations reach the model in full
-        through the normal tool protocol (``AIMessage`` + ``ToolMessage``), so
-        repeating them here would spend tokens saying less.
+        The repository is always read with ``max_entries + 1``. The extra row is
+        used only to tell whether the rendered context is truncated.
         """
         try:
-            records = await self._load(scope)
+            kind = None if self._include_delegations else ToolInvocationKind.TOOL
+            records = await self._load(scope, limit=self._max_entries + 1, kind=kind)
         except Exception as exc:
             log(
                 logger,
@@ -230,7 +224,7 @@ class ToolUsageContextProvider:
                 error=type(exc).__name__,
             )
             return EMPTY_CONTEXT
-        return self._project(records, scope, already_visible)
+        return self._bounded(records, self._max_entries)
 
     async def get_executed_tools(self, scope: ToolUsageScope) -> ToolUsageContext:
         """Every tool executed in ``scope``, for an explicit question about them.
@@ -244,28 +238,27 @@ class ToolUsageContextProvider:
         record cannot be read would invite an agent to repeat an action that
         already took effect.
         """
-        records = [r for r in await self._load(scope) if r.call.kind is ToolInvocationKind.TOOL]
+        records = await self._load(
+            scope,
+            limit=self._report_max_entries + 1,
+            kind=ToolInvocationKind.TOOL,
+        )
         return self._bounded(records, self._report_max_entries)
 
-    async def _load(self, scope: ToolUsageScope) -> Sequence[ToolInvocationRecord]:
-        if scope.conversation_id:
-            return await self._repository.list_for_conversation(scope.conversation_id)
-        if scope.run_id:
-            return await self._repository.list_for_run(scope.run_id)
-        return ()
-
-    def _project(
+    async def _load(
         self,
-        records: Sequence[ToolInvocationRecord],
         scope: ToolUsageScope,
-        already_visible: frozenset[str],
-    ) -> ToolUsageContext:
-        wanted = [
-            r
-            for r in records
-            if self._is_included(r) and not self._is_visible(r, scope, already_visible)
-        ]
-        return self._bounded(wanted, self._max_entries)
+        *,
+        limit: int,
+        kind: ToolInvocationKind | None,
+    ) -> Sequence[ToolInvocationRecord]:
+        if scope.conversation_id:
+            return await self._repository.list_for_conversation(
+                scope.conversation_id, limit=limit, kind=kind
+            )
+        if scope.run_id:
+            return await self._repository.list_for_run(scope.run_id, limit=limit, kind=kind)
+        return ()
 
     @staticmethod
     def _bounded(records: Sequence[ToolInvocationRecord], limit: int) -> ToolUsageContext:
@@ -282,26 +275,4 @@ class ToolUsageContextProvider:
                 for record in records[-limit:]
             ),
             truncated=len(records) > limit,
-        )
-
-    def _is_included(self, record: ToolInvocationRecord) -> bool:
-        return self._include_delegations or record.call.kind is ToolInvocationKind.TOOL
-
-    @staticmethod
-    def _is_visible(
-        record: ToolInvocationRecord,
-        scope: ToolUsageScope,
-        already_visible: frozenset[str],
-    ) -> bool:
-        """Whether the caller's own turn already shows the model this invocation.
-
-        Only the asker's own calls, in the run it is currently executing, can be
-        in its message list — another agent's call, or the same agent's call in
-        an earlier run or an earlier node entry, is not.
-        """
-        call = record.call
-        return (
-            call.tool_name in already_visible
-            and call.agent_id == scope.agent_id
-            and call.run_id == scope.run_id
         )

--- a/src/agent_engine/tool_usage/context.py
+++ b/src/agent_engine/tool_usage/context.py
@@ -1,0 +1,307 @@
+"""Projection of persisted tool usage into private model context.
+
+The LLM needs to know which tools have already run and how they ended; it does
+not need the persistence record. This module owns that translation — scope,
+selection, projection, and wording — so agents never format stored records
+themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from agent_engine.logging_config import log
+from agent_engine.tool_usage.models import (
+    ToolInvocationKind,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from agent_engine.tool_usage.repository import ToolUsageRepository
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ENTRIES = 50
+DEFAULT_REPORT_MAX_ENTRIES = 200
+
+_HEADER = (
+    "## Execution record for this conversation\n"
+    "Internal execution metadata, not chat history. Some of the tools bound to "
+    "you are other agents: calling one delegates the work, it does not perform "
+    "it. This record separates the two. Reason with it, do not redo work it "
+    "shows as done, and do not restate it unless it is relevant."
+)
+
+_TOOLS_HEADING = (
+    "### Tools executed\n"
+    "The real actions that ran, as `agent: tool`. These — and only these — are "
+    "the tools that have run in this conversation; answer with these names when "
+    "the user asks which tools ran, even if the tool is not one of your own."
+)
+
+_DELEGATIONS_HEADING = (
+    "### Agents delegated to\n"
+    "Routing only, as `agent -> agent`. An agent is not a tool: never name one "
+    "of these when asked which tools ran."
+)
+
+_TRUNCATED = "(Older entries are not shown; this record is not complete.)"
+
+
+@dataclass(frozen=True)
+class ToolUsageScope:
+    """Who is asking, and about which conversation and run.
+
+    The ids come from the ambient run context; ``agent_id`` names the caller, so
+    the projection can tell the asker's own invocations from everyone else's.
+    """
+
+    run_id: str | None = None
+    conversation_id: str | None = None
+    agent_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolUsageEntry:
+    """The few facts the model is given about one prior invocation."""
+
+    agent_id: str
+    tool_name: str
+    status: str
+    kind: ToolInvocationKind = ToolInvocationKind.TOOL
+
+
+@dataclass(frozen=True)
+class ToolUsageContext:
+    """What the model may know about tool usage so far, grouped when rendered.
+
+    A value object distinct from the persistence record: no timestamps, ids,
+    arguments, results, or error text cross this boundary.
+    """
+
+    entries: tuple[ToolUsageEntry, ...] = ()
+    truncated: bool = False
+    """Older invocations were dropped to bound the size, and are not shown."""
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.entries
+
+    def render(self) -> str | None:
+        """Render the internal context block, or ``None`` when there is nothing
+        to say — so an unused conversation costs no tokens at all.
+
+        Tools and delegations are rendered as separate, labelled sections. They
+        are different kinds of action, and a model asked "which tools did you
+        run?" must not answer with the name of a child agent.
+        """
+        if self.is_empty:
+            return None
+        sections = [
+            section
+            for section in (self._tool_section(), self._delegation_section())
+            if section is not None
+        ]
+        if self.truncated:
+            sections.append(_TRUNCATED)
+        return "\n\n".join([_HEADER, *sections])
+
+    def _tool_section(self) -> str | None:
+        tools = [e for e in self.entries if e.kind is ToolInvocationKind.TOOL]
+        if not tools:
+            return None
+        by_agent: dict[str, list[ToolUsageEntry]] = {}
+        for entry in tools:
+            by_agent.setdefault(entry.agent_id, []).append(entry)
+        blocks = [
+            "\n".join([f"{agent}:", *(f"- {e.tool_name} [{e.status}]" for e in entries)])
+            for agent, entries in by_agent.items()
+        ]
+        return "\n\n".join([_TOOLS_HEADING, *blocks])
+
+    def _delegation_section(self) -> str | None:
+        delegations = [e for e in self.entries if e.kind is ToolInvocationKind.AGENT]
+        if not delegations:
+            return None
+        lines = [f"- {e.agent_id} -> {e.tool_name}{self._failure(e)}" for e in delegations]
+        return "\n".join([_DELEGATIONS_HEADING, *lines])
+
+    @staticmethod
+    def _failure(entry: ToolUsageEntry) -> str:
+        """Routing that worked is just a path; routing that did not is news."""
+        return "" if entry.status == ToolInvocationStatus.SUCCEEDED.value else f" [{entry.status}]"
+
+
+EMPTY_CONTEXT = ToolUsageContext()
+
+_NOTHING_EXECUTED = "No tools have been executed in this conversation yet."
+
+EXECUTION_RECORD_UNAVAILABLE = (
+    "The execution record could not be read right now, so what has already run is "
+    "unknown. Do not assume nothing has run, and do not repeat an action that may "
+    "already have taken effect; say the record is unavailable."
+)
+
+
+def format_executed_tools(context: ToolUsageContext) -> str:
+    """Render executed tools as an answerable list, for a tool result.
+
+    A second model-facing wording, kept beside the first so the vocabulary of
+    execution metadata lives in one module rather than in whatever calls it.
+    """
+    if context.is_empty:
+        return _NOTHING_EXECUTED
+    lines = [f"- {e.agent_id}: {e.tool_name} [{e.status}]" for e in context.entries]
+    body = ["Tools executed in this conversation, oldest first:", *lines]
+    if context.truncated:
+        body.append(_TRUNCATED)
+    return "\n".join(body)
+
+
+class ToolUsageContextProvider:
+    """Reads persisted usage for a scope and projects it for the model.
+
+    The single seam where context policy lives: which scope is consulted, which
+    invocations are shown, how many, and in what shape. Changing that policy
+    touches this class only — agents ask for a scope's context and pass the
+    result on. It never executes tools and never writes.
+
+    ``max_entries`` and ``report_max_entries`` bound prompt growth on a long
+    conversation by keeping the most recent invocations; a trimmed context says
+    so rather than passing itself off as complete.
+
+    The two read paths degrade differently on purpose. :meth:`get` supplements a
+    turn, so a read failure degrades to empty context (logged) rather than
+    failing the run — an empty block is what an early conversation looks like
+    anyway. :meth:`get_executed_tools` answers a direct question, where "empty"
+    would be a false statement that nothing ran, so it propagates the failure
+    and lets its caller say the record is unavailable.
+
+    ``include_delegations`` reports routing in its own labelled section. It is on
+    by default so an orchestrator sees the whole picture — its own children are
+    bound to it as tools, so a record that mentioned neither would leave it
+    reasoning from its tool binding alone. Turn it off for a deployment that
+    wants the model to see executed tools only.
+    """
+
+    def __init__(
+        self,
+        repository: ToolUsageRepository,
+        *,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        report_max_entries: int = DEFAULT_REPORT_MAX_ENTRIES,
+        include_delegations: bool = True,
+    ) -> None:
+        if max_entries <= 0 or report_max_entries <= 0:
+            raise ValueError("entry limits must be positive")
+        self._repository = repository
+        self._max_entries = max_entries
+        self._report_max_entries = report_max_entries
+        self._include_delegations = include_delegations
+
+    async def get(
+        self,
+        scope: ToolUsageScope,
+        *,
+        already_visible: frozenset[str] = frozenset(),
+    ) -> ToolUsageContext:
+        """Return the usage context for ``scope``.
+
+        The conversation is preferred when the caller has one, so a later turn
+        still knows what earlier turns did; a run started outside a conversation
+        falls back to its own run. A scope with neither id — a caller running
+        outside any registered run — yields empty context rather than an error.
+
+        ``already_visible`` names the tools the caller has itself invoked in the
+        turn it is about to send. Those invocations reach the model in full
+        through the normal tool protocol (``AIMessage`` + ``ToolMessage``), so
+        repeating them here would spend tokens saying less.
+        """
+        try:
+            records = await self._load(scope)
+        except Exception as exc:
+            log(
+                logger,
+                logging.WARNING,
+                "tool usage context unavailable",
+                run_id=scope.run_id,
+                conversation_id=scope.conversation_id,
+                error=type(exc).__name__,
+            )
+            return EMPTY_CONTEXT
+        return self._project(records, scope, already_visible)
+
+    async def get_executed_tools(self, scope: ToolUsageScope) -> ToolUsageContext:
+        """Every tool executed in ``scope``, for an explicit question about them.
+
+        Unlike :meth:`get`, the turn's own visible calls are not filtered out —
+        this answers "what has run?", not "what does this turn still need to be
+        told?". Delegations are never included: they are routing, and the
+        question is about tools.
+
+        A repository failure propagates. Reporting "nothing has run" when the
+        record cannot be read would invite an agent to repeat an action that
+        already took effect.
+        """
+        records = [r for r in await self._load(scope) if r.call.kind is ToolInvocationKind.TOOL]
+        return self._bounded(records, self._report_max_entries)
+
+    async def _load(self, scope: ToolUsageScope) -> Sequence[ToolInvocationRecord]:
+        if scope.conversation_id:
+            return await self._repository.list_for_conversation(scope.conversation_id)
+        if scope.run_id:
+            return await self._repository.list_for_run(scope.run_id)
+        return ()
+
+    def _project(
+        self,
+        records: Sequence[ToolInvocationRecord],
+        scope: ToolUsageScope,
+        already_visible: frozenset[str],
+    ) -> ToolUsageContext:
+        wanted = [
+            r
+            for r in records
+            if self._is_included(r) and not self._is_visible(r, scope, already_visible)
+        ]
+        return self._bounded(wanted, self._max_entries)
+
+    @staticmethod
+    def _bounded(records: Sequence[ToolInvocationRecord], limit: int) -> ToolUsageContext:
+        """Project the most recent ``limit`` records, saying so when older ones
+        were dropped — a partial record must not read as a complete one."""
+        return ToolUsageContext(
+            entries=tuple(
+                ToolUsageEntry(
+                    agent_id=record.call.agent_id,
+                    tool_name=record.call.tool_name,
+                    status=record.status.value,
+                    kind=record.call.kind,
+                )
+                for record in records[-limit:]
+            ),
+            truncated=len(records) > limit,
+        )
+
+    def _is_included(self, record: ToolInvocationRecord) -> bool:
+        return self._include_delegations or record.call.kind is ToolInvocationKind.TOOL
+
+    @staticmethod
+    def _is_visible(
+        record: ToolInvocationRecord,
+        scope: ToolUsageScope,
+        already_visible: frozenset[str],
+    ) -> bool:
+        """Whether the caller's own turn already shows the model this invocation.
+
+        Only the asker's own calls, in the run it is currently executing, can be
+        in its message list — another agent's call, or the same agent's call in
+        an earlier run or an earlier node entry, is not.
+        """
+        call = record.call
+        return (
+            call.tool_name in already_visible
+            and call.agent_id == scope.agent_id
+            and call.run_id == scope.run_id
+        )

--- a/src/agent_engine/tool_usage/in_memory.py
+++ b/src/agent_engine/tool_usage/in_memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-from agent_engine.tool_usage.models import ToolInvocationRecord
+from agent_engine.tool_usage.models import ToolInvocationKind, ToolInvocationRecord
 
 _Key = tuple[str, str]
 
@@ -36,14 +36,38 @@ class InMemoryToolUsageRepository:
                     self._by_conversation.setdefault(conversation_id, []).append(key)
             self._records[key] = record
 
-    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
-        return await self._snapshot(self._by_run, run_id)
+    async def list_for_run(
+        self,
+        run_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
+        return await self._snapshot(self._by_run, run_id, limit=limit, kind=kind)
 
-    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
-        return await self._snapshot(self._by_conversation, conversation_id)
+    async def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
+        return await self._snapshot(self._by_conversation, conversation_id, limit=limit, kind=kind)
 
     async def _snapshot(
-        self, index: dict[str, list[_Key]], scope_id: str
+        self,
+        index: dict[str, list[_Key]],
+        scope_id: str,
+        *,
+        limit: int | None,
+        kind: ToolInvocationKind | None,
     ) -> tuple[ToolInvocationRecord, ...]:
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be positive")
         async with self._lock:
-            return tuple(self._records[key] for key in index.get(scope_id, ()))
+            records = [
+                self._records[key]
+                for key in index.get(scope_id, ())
+                if kind is None or self._records[key].call.kind is kind
+            ]
+            return tuple(records[-limit:] if limit is not None else records)

--- a/src/agent_engine/tool_usage/in_memory.py
+++ b/src/agent_engine/tool_usage/in_memory.py
@@ -1,0 +1,49 @@
+"""Process-local tool-usage repository for development and tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_engine.tool_usage.models import ToolInvocationRecord
+
+_Key = tuple[str, str]
+
+
+class InMemoryToolUsageRepository:
+    """Process-local implementation of :class:`ToolUsageRepository`.
+
+    An ``asyncio.Lock`` guards the store, matching the approval repositories, so
+    concurrent agents in one run cannot lose a write. Records live once, keyed by
+    ``(run_id, tool_call_id)``; the run and conversation indexes hold keys in
+    first-seen order, which gives the upsert-on-identity and call-order
+    guarantees the contract requires. Callers receive tuples of frozen records,
+    never the internal mapping.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[_Key, ToolInvocationRecord] = {}
+        self._by_run: dict[str, list[_Key]] = {}
+        self._by_conversation: dict[str, list[_Key]] = {}
+        self._lock = asyncio.Lock()
+
+    async def record(self, record: ToolInvocationRecord) -> None:
+        key = record.key
+        async with self._lock:
+            if key not in self._records:
+                self._by_run.setdefault(key[0], []).append(key)
+                conversation_id = record.call.conversation_id
+                if conversation_id:
+                    self._by_conversation.setdefault(conversation_id, []).append(key)
+            self._records[key] = record
+
+    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
+        return await self._snapshot(self._by_run, run_id)
+
+    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
+        return await self._snapshot(self._by_conversation, conversation_id)
+
+    async def _snapshot(
+        self, index: dict[str, list[_Key]], scope_id: str
+    ) -> tuple[ToolInvocationRecord, ...]:
+        async with self._lock:
+            return tuple(self._records[key] for key in index.get(scope_id, ()))

--- a/src/agent_engine/tool_usage/models.py
+++ b/src/agent_engine/tool_usage/models.py
@@ -1,0 +1,93 @@
+"""Domain model for observed tool usage.
+
+Persistence-facing types only: what happened to a logical invocation, and the
+identity that names it. No LangGraph, LangChain, or prompt concerns.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from agent_engine.runtime.tool_models import ToolProviderName
+
+
+class ToolInvocationStatus(StrEnum):
+    """Terminal outcome of one logical invocation.
+
+    Only outcomes the runtime actually observes are modelled. Intermediate
+    approval states belong to the approval subsystem, which owns them.
+    """
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    DENIED = "denied"
+
+
+class ToolInvocationKind(StrEnum):
+    """What was invoked: a real tool, or a child agent exposed as one.
+
+    Both are actions an orchestrator or agent took, so both belong to the
+    execution history. They are distinguished because the caller-facing run
+    trace reports real tool/MCP calls only.
+    """
+
+    TOOL = "tool"
+    AGENT = "agent"
+
+
+def stable_tool_call_id(*parts: Any) -> str:
+    """Derive a deterministic call id from the call's own identifying parts.
+
+    Deriving it from the call — rather than the provider's message id — is what
+    lets one logical invocation keep a single identity across a suspension and
+    its resumed replay.
+    """
+    payload = json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str)
+    return f"call_{hashlib.sha256(payload.encode()).hexdigest()[:24]}"
+
+
+@dataclass(frozen=True)
+class ToolCallIdentity:
+    """Names one logical invocation: ``conversation → run → agent → tool call``.
+
+    ``conversation_id`` gives continuity across the user's turns; ``run_id``
+    preserves the exact execution it happened in. ``agent_id`` is the agent's
+    own id — the one the approval subsystem also records, and the name the model
+    is shown — while ``agent_path`` locates that agent in the graph, so a record
+    stays traceable when the same agent id appears under different parents.
+    """
+
+    run_id: str
+    agent_id: str
+    agent_path: str
+    tool_call_id: str
+    tool_name: str
+    provider: ToolProviderName = "local"
+    server_id: str | None = None
+    conversation_id: str | None = None
+    kind: ToolInvocationKind = ToolInvocationKind.TOOL
+
+
+@dataclass(frozen=True)
+class ToolInvocationRecord:
+    """The persisted outcome of one logical invocation.
+
+    Immutable, so a repository can hand out records without exposing internals.
+    Arguments and results are deliberately absent: they may carry sensitive or
+    oversized data and no consumer of tool usage needs them.
+    """
+
+    call: ToolCallIdentity
+    status: ToolInvocationStatus
+    error: str | None = None
+    recorded_at: float = field(default_factory=time.time)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """The ``(run_id, tool_call_id)`` pair that identifies the invocation."""
+        return self.call.run_id, self.call.tool_call_id

--- a/src/agent_engine/tool_usage/repository.py
+++ b/src/agent_engine/tool_usage/repository.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
-from agent_engine.tool_usage.models import ToolInvocationRecord
+from agent_engine.tool_usage.models import ToolInvocationKind, ToolInvocationRecord
 
 
 @runtime_checkable
@@ -23,7 +23,9 @@ class ToolUsageRepository(Protocol):
       replayed invocation updates its record instead of adding a second one;
     * keep first-seen order, which is chronological call order, within both
       scopes;
-    * return snapshots that no later write mutates.
+    * return snapshots that no later write mutates;
+    * when ``limit`` is supplied, return the latest records in chronological
+      order (not reverse order), after applying the optional ``kind`` filter.
 
     Scopes are isolated: a listing never returns a record from another run or
     another conversation, and an unknown id yields no records. A record whose
@@ -34,10 +36,22 @@ class ToolUsageRepository(Protocol):
         """Store the outcome of one logical tool invocation."""
         ...
 
-    async def list_for_run(self, run_id: str) -> Sequence[ToolInvocationRecord]:
+    async def list_for_run(
+        self,
+        run_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> Sequence[ToolInvocationRecord]:
         """Return this run's records in call order (empty when unknown)."""
         ...
 
-    async def list_for_conversation(self, conversation_id: str) -> Sequence[ToolInvocationRecord]:
+    async def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> Sequence[ToolInvocationRecord]:
         """Return every run's records for this conversation, in call order."""
         ...

--- a/src/agent_engine/tool_usage/repository.py
+++ b/src/agent_engine/tool_usage/repository.py
@@ -1,0 +1,43 @@
+"""Abstract persistence contract for tool usage.
+
+The engine depends only on this ``Protocol`` (Dependency Inversion). A shared
+deployment supplies a distributed adapter with the same contract; nothing in the
+agents, nodes, or tool-execution path changes when it does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from agent_engine.tool_usage.models import ToolInvocationRecord
+
+
+@runtime_checkable
+class ToolUsageRepository(Protocol):
+    """Persistence contract for observed tool usage, the source of truth.
+
+    A record is identified by ``(run_id, tool_call_id)``. Implementations must:
+
+    * treat ``record`` as an idempotent upsert on that identity, so a resumed or
+      replayed invocation updates its record instead of adding a second one;
+    * keep first-seen order, which is chronological call order, within both
+      scopes;
+    * return snapshots that no later write mutates.
+
+    Scopes are isolated: a listing never returns a record from another run or
+    another conversation, and an unknown id yields no records. A record whose
+    identity carries no ``conversation_id`` is reachable by run only.
+    """
+
+    async def record(self, record: ToolInvocationRecord) -> None:
+        """Store the outcome of one logical tool invocation."""
+        ...
+
+    async def list_for_run(self, run_id: str) -> Sequence[ToolInvocationRecord]:
+        """Return this run's records in call order (empty when unknown)."""
+        ...
+
+    async def list_for_conversation(self, conversation_id: str) -> Sequence[ToolInvocationRecord]:
+        """Return every run's records for this conversation, in call order."""
+        ...

--- a/src/agent_engine/tool_usage/trace.py
+++ b/src/agent_engine/tool_usage/trace.py
@@ -1,0 +1,36 @@
+"""Projection of persisted tool usage into the public run trace.
+
+The API/UI trace (``RunResult.used_tools``) is a second, separate projection of
+the same records — deliberately not the persistence model and not the model
+context.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from agent_engine.runtime.tool_models import ToolUsageRecord
+from agent_engine.tool_usage.models import ToolInvocationKind, ToolInvocationRecord
+
+
+def as_usage_records(
+    records: Sequence[ToolInvocationRecord],
+) -> tuple[ToolUsageRecord, ...]:
+    """Map stored invocations onto the caller-facing trace, in call order.
+
+    Child-agent invocations are left out: this trace has always meant *real
+    tool/MCP calls*, and the route an orchestrator took is reported separately as
+    ``visited``. They remain in the repository, where the model context uses them.
+    """
+    return tuple(
+        ToolUsageRecord(
+            name=record.call.tool_name,
+            provider=record.call.provider,
+            status=record.status.value,
+            agent_id=record.call.agent_id,
+            server_id=record.call.server_id,
+            error=record.error,
+        )
+        for record in records
+        if record.call.kind is ToolInvocationKind.TOOL
+    )

--- a/src/agent_engine/tool_usage/tracker.py
+++ b/src/agent_engine/tool_usage/tracker.py
@@ -1,0 +1,67 @@
+"""Turns tool-execution events into persisted usage records."""
+
+from __future__ import annotations
+
+import logging
+
+from agent_engine.logging_config import log
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from agent_engine.tool_usage.repository import ToolUsageRepository
+
+logger = logging.getLogger(__name__)
+
+_ERROR_MAX_CHARS = 200
+
+
+class ToolUsageTracker:
+    """Records what happened to a tool invocation, and nothing else.
+
+    It does not decide whether a tool may run, execute anything, build prompts,
+    or choose a backend: it maps one execution event onto one domain record and
+    hands it to the injected repository. Holding no per-run state, a single
+    instance is shared by every agent in the engine.
+
+    Failure policy: recording is observability, not the tool's contract, so a
+    repository error is logged at WARNING with the invocation's identity and
+    swallowed. A metadata write must never turn a completed tool call into a
+    failed one, nor mask the tool's own error. The cost is a trace that may be
+    missing an entry the log names explicitly.
+    """
+
+    def __init__(self, repository: ToolUsageRepository) -> None:
+        self._repository = repository
+
+    async def record_success(self, call: ToolCallIdentity) -> None:
+        await self._record(ToolInvocationRecord(call=call, status=ToolInvocationStatus.SUCCEEDED))
+
+    async def record_failure(self, call: ToolCallIdentity, *, error: str) -> None:
+        await self._record(
+            ToolInvocationRecord(
+                call=call,
+                status=ToolInvocationStatus.FAILED,
+                error=error[:_ERROR_MAX_CHARS],
+            )
+        )
+
+    async def record_denied(self, call: ToolCallIdentity) -> None:
+        await self._record(ToolInvocationRecord(call=call, status=ToolInvocationStatus.DENIED))
+
+    async def _record(self, record: ToolInvocationRecord) -> None:
+        try:
+            await self._repository.record(record)
+        except Exception as exc:
+            log(
+                logger,
+                logging.WARNING,
+                "tool usage not recorded",
+                run_id=record.call.run_id,
+                agent=record.call.agent_id,
+                tool=record.call.tool_name,
+                tool_call_id=record.call.tool_call_id,
+                status=record.status.value,
+                error=type(exc).__name__,
+            )

--- a/src/agent_manager/api/app.py
+++ b/src/agent_manager/api/app.py
@@ -46,6 +46,7 @@ def create_app(config_path: str, settings: Settings | None = None) -> FastAPI:
             LangGraphEngine(
                 base_dir,
                 session_approval_repository=repositories.session_approvals,
+                tool_usage_repository=repositories.tool_usage,
             ) as engine,
         ):
             await engine.build(spec)

--- a/src/agent_manager/composition.py
+++ b/src/agent_manager/composition.py
@@ -14,6 +14,8 @@ from agent_engine.approvals.session_store import (
     InMemorySessionApprovalRepository,
     SessionApprovalRepository,
 )
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.repository import ToolUsageRepository
 from agent_manager.config import AuthMode, Settings
 from agent_manager.domain import Repository
 from agent_manager.infrastructure.auth.keys import StaticSecretKeySource
@@ -38,11 +40,22 @@ EPHEMERAL_SECRET_BYTES = 32
 class ApplicationRepositories:
     conversations: Repository
     session_approvals: SessionApprovalRepository
+    tool_usage: ToolUsageRepository
 
 
 def build_session_approval_repository() -> SessionApprovalRepository:
     """Create the process-lifetime adapter used by the current application."""
     return InMemorySessionApprovalRepository()
+
+
+def build_tool_usage_repository() -> ToolUsageRepository:
+    """Select the tool-usage backend for this deployment.
+
+    The only place the concrete adapter is named: a distributed deployment
+    swaps the implementation here, and no agent, node, or tool-execution code
+    changes with it.
+    """
+    return InMemoryToolUsageRepository()
 
 
 def build_identity_resolver(settings: Settings) -> IdentityResolver:
@@ -113,6 +126,7 @@ async def application_repositories(
         yield ApplicationRepositories(
             conversations=SqlRepository(sessions),
             session_approvals=build_session_approval_repository(),
+            tool_usage=build_tool_usage_repository(),
         )
     finally:
         await db_engine.dispose()

--- a/tests/approvals/test_hitl_tool_usage.py
+++ b/tests/approvals/test_hitl_tool_usage.py
@@ -1,0 +1,202 @@
+"""Tool usage tracking across the Human-in-the-Loop lifecycle.
+
+Approval decides *whether* an invocation runs; tracking records *what happened
+to it*. One logical invocation — requested, suspended, approved, executed —
+must leave exactly one record, under the same run, agent, and tool call id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from langchain_core.language_models import BaseChatModel
+
+from agent_engine.approvals.manager import ApprovalManager
+from agent_engine.approvals.repository import InMemoryApprovalRepository
+from agent_engine.core.spec import (
+    AgentSpec,
+    BasePromptSet,
+    GraphNode,
+    ModelConfig,
+    SystemMeta,
+    SystemSpec,
+    ToolSpec,
+)
+from agent_engine.engine.langgraph.engine import LangGraphEngine
+from agent_engine.runs.in_memory import InMemoryRunRepository
+from agent_engine.runtime.hooks import RunContext
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from tests.approvals.test_engine_hitl import FakeChatModel
+
+_MODEL = ModelConfig(provider="fake", name="fake", temperature=None)
+
+
+def _factory(provider: str, name: str, temperature: float | None, **_: Any) -> BaseChatModel:
+    return cast(BaseChatModel, FakeChatModel())
+
+
+def write_counting_tool(base_dir: Path, tool_id: str, counter: Path) -> None:
+    tools_dir = base_dir / "plugins" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / f"{tool_id}.py").write_text(
+        f"def {tool_id}(message: str) -> str:\n"
+        f"    with open({str(counter)!r}, 'a') as f:\n"
+        "        f.write('x')\n"
+        "    return 'sent: ' + message\n",
+        encoding="utf-8",
+    )
+
+
+def spec(tool_id: str) -> SystemSpec:
+    return SystemSpec(
+        meta=SystemMeta(name="hitl-usage"),
+        defaults=None,
+        graph=GraphNode(
+            node=AgentSpec(
+                id="writer",
+                name="writer",
+                description="writer agent",
+                model=_MODEL,
+                prompts=BasePromptSet(),
+                tools=(ToolSpec(tool_id, f"{tool_id} description"),),
+                auto_mode=False,
+            )
+        ),
+    )
+
+
+class Harness:
+    """An engine whose approval and usage stores the test can inspect."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self.approvals = InMemoryApprovalRepository()
+        self.usage = InMemoryToolUsageRepository()
+        self.engine = LangGraphEngine(
+            base_dir,
+            model_factory=_factory,
+            approval_manager=ApprovalManager(
+                run_repository=InMemoryRunRepository(),
+                approval_repository=self.approvals,
+            ),
+            tool_usage_repository=self.usage,
+        )
+
+    async def __aenter__(self) -> Harness:
+        await self.engine.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.engine.__aexit__(*args)
+
+
+async def test_a_suspended_invocation_records_nothing_until_it_is_decided(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    write_counting_tool(tmp_path, "send_email", counter)
+    async with Harness(tmp_path) as harness:
+        await harness.engine.build(spec("send_email"))
+        pending = await harness.engine.run("hi", context=RunContext(run_id="run-1"))
+
+        assert pending.status == "pending_approval"
+        assert list(await harness.usage.list_for_run("run-1")) == []
+        assert not counter.exists()
+
+
+async def test_approval_records_one_invocation_with_the_approved_identity(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    write_counting_tool(tmp_path, "send_email", counter)
+    async with Harness(tmp_path) as harness:
+        await harness.engine.build(spec("send_email"))
+        pending = await harness.engine.run("hi", context=RunContext(run_id="run-1"))
+        assert pending.pending_approval is not None
+        approval_id = pending.pending_approval.approval_id
+
+        resumed = await harness.engine.resume("run-1", approval_id, "allow once")
+
+        approval = await harness.approvals.get(approval_id)
+        stored = await harness.usage.list_for_run("run-1")
+
+    assert resumed.status == "completed"
+    assert len(counter.read_text()) == 1
+    assert len(stored) == 1  # one logical invocation, not request + resume
+    assert approval is not None
+    assert stored[0].call.tool_call_id == approval.tool_call_id
+    assert stored[0].call.agent_id == approval.agent_id == "writer"
+    assert stored[0].status.value == "succeeded"
+
+
+async def test_a_denied_invocation_is_recorded_as_denied(tmp_path: Path) -> None:
+    counter = tmp_path / "calls.log"
+    write_counting_tool(tmp_path, "send_email", counter)
+    async with Harness(tmp_path) as harness:
+        await harness.engine.build(spec("send_email"))
+        pending = await harness.engine.run("hi", context=RunContext(run_id="run-1"))
+        assert pending.pending_approval is not None
+
+        resumed = await harness.engine.resume("run-1", pending.pending_approval.approval_id, "deny")
+        stored = await harness.usage.list_for_run("run-1")
+
+    assert resumed.status == "completed"
+    assert not counter.exists()
+    assert [r.status.value for r in stored] == ["denied"]
+    assert stored[0].call.agent_id == "writer"
+
+
+async def test_a_session_approval_records_each_run_under_its_own_run_id(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    write_counting_tool(tmp_path, "send_email", counter)
+
+    async with Harness(tmp_path) as harness:
+        await harness.engine.build(spec("send_email"))
+        pending = await harness.engine.run(
+            "hi", context=RunContext(run_id="run-a", conversation_id="conv-1", user_id="user-1")
+        )
+        assert pending.pending_approval is not None
+        await harness.engine.resume(
+            "run-a",
+            pending.pending_approval.approval_id,
+            "allow for this session",
+            caller_user_id="user-1",
+            caller_session_id="conv-1",
+        )
+
+        # The session permission suppresses the prompt; usage is still tracked.
+        second = await harness.engine.run(
+            "again", context=RunContext(run_id="run-b", conversation_id="conv-1", user_id="user-1")
+        )
+
+        first_records = await harness.usage.list_for_run("run-a")
+        second_records = await harness.usage.list_for_run("run-b")
+
+    assert second.status == "completed"
+    assert len(counter.read_text()) == 2
+    assert [r.status.value for r in first_records] == ["succeeded"]
+    assert [r.status.value for r in second_records] == ["succeeded"]
+    assert first_records[0].call.tool_call_id != second_records[0].call.tool_call_id
+
+
+async def test_a_replayed_node_after_resume_does_not_add_a_second_record(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    write_counting_tool(tmp_path, "send_email", counter)
+    async with Harness(tmp_path) as harness:
+        await harness.engine.build(spec("send_email"))
+        pending = await harness.engine.run("hi", context=RunContext(run_id="run-1"))
+        assert pending.pending_approval is not None
+        approval_id = pending.pending_approval.approval_id
+
+        await harness.engine.resume("run-1", approval_id, "allow once")
+        recovered = await harness.engine.get_processed_result("run-1", approval_id)
+        stored = await harness.usage.list_for_run("run-1")
+
+    assert recovered is not None
+    assert len(stored) == 1
+    assert len(counter.read_text()) == 1
+    assert [t.name for t in recovered.used_tools] == ["send_email"]

--- a/tests/approvals/test_hitl_tool_usage.py
+++ b/tests/approvals/test_hitl_tool_usage.py
@@ -27,13 +27,19 @@ from agent_engine.engine.langgraph.engine import LangGraphEngine
 from agent_engine.runs.in_memory import InMemoryRunRepository
 from agent_engine.runtime.hooks import RunContext
 from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
-from tests.approvals.test_engine_hitl import FakeChatModel
+from tests.approvals.test_engine_hitl import ChainedApprovalModel, FakeChatModel
 
 _MODEL = ModelConfig(provider="fake", name="fake", temperature=None)
 
 
 def _factory(provider: str, name: str, temperature: float | None, **_: Any) -> BaseChatModel:
     return cast(BaseChatModel, FakeChatModel())
+
+
+def _chained_factory(
+    provider: str, name: str, temperature: float | None, **_: Any
+) -> BaseChatModel:
+    return cast(BaseChatModel, ChainedApprovalModel())
 
 
 def write_counting_tool(base_dir: Path, tool_id: str, counter: Path) -> None:
@@ -66,15 +72,36 @@ def spec(tool_id: str) -> SystemSpec:
     )
 
 
+def chained_spec() -> SystemSpec:
+    return SystemSpec(
+        meta=SystemMeta(name="hitl-usage"),
+        defaults=None,
+        graph=GraphNode(
+            node=AgentSpec(
+                id="writer",
+                name="writer",
+                description="writer agent",
+                model=_MODEL,
+                prompts=BasePromptSet(),
+                tools=(
+                    ToolSpec("send_email", "Send the email."),
+                    ToolSpec("archive_email", "Archive the email."),
+                ),
+                auto_mode=False,
+            )
+        ),
+    )
+
+
 class Harness:
     """An engine whose approval and usage stores the test can inspect."""
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(self, base_dir: Path, *, model_factory: Any = _factory) -> None:
         self.approvals = InMemoryApprovalRepository()
         self.usage = InMemoryToolUsageRepository()
         self.engine = LangGraphEngine(
             base_dir,
-            model_factory=_factory,
+            model_factory=model_factory,
             approval_manager=ApprovalManager(
                 run_repository=InMemoryRunRepository(),
                 approval_repository=self.approvals,
@@ -200,3 +227,36 @@ async def test_a_replayed_node_after_resume_does_not_add_a_second_record(
     assert len(stored) == 1
     assert len(counter.read_text()) == 1
     assert [t.name for t in recovered.used_tools] == ["send_email"]
+
+
+async def test_second_approval_replay_reuses_the_first_tools_cached_result(
+    tmp_path: Path,
+) -> None:
+    first_counter = tmp_path / "send.log"
+    second_counter = tmp_path / "archive.log"
+    write_counting_tool(tmp_path, "send_email", first_counter)
+    write_counting_tool(tmp_path, "archive_email", second_counter)
+
+    async with Harness(tmp_path, model_factory=_chained_factory) as harness:
+        await harness.engine.build(chained_spec())
+        first = await harness.engine.run("hi", context=RunContext(run_id="run-chained"))
+        assert first.pending_approval is not None
+
+        second = await harness.engine.resume(
+            "run-chained", first.pending_approval.approval_id, "allow once"
+        )
+        assert second.pending_approval is not None
+        assert second.pending_approval.tool_name == "archive_email"
+
+        completed = await harness.engine.resume(
+            "run-chained", second.pending_approval.approval_id, "allow once"
+        )
+        stored = await harness.usage.list_for_run("run-chained")
+
+    assert completed.status == "completed"
+    assert first_counter.read_text() == "x"
+    assert second_counter.read_text() == "x"
+    assert [(record.call.tool_name, record.status.value) for record in stored] == [
+        ("send_email", "succeeded"),
+        ("archive_email", "succeeded"),
+    ]

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -1,0 +1,17 @@
+"""Fixtures shared by the engine tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.engine.usage_models import AllToolsThenAnswerModel
+
+
+@pytest.fixture
+def models() -> dict[str, AllToolsThenAnswerModel]:
+    """One deterministic model per node of the two-agent supervisor fixture."""
+    return {
+        "root-model": AllToolsThenAnswerModel("synthesized"),
+        "planner-model": AllToolsThenAnswerModel("planned"),
+        "developer-model": AllToolsThenAnswerModel("developed"),
+    }

--- a/tests/engine/test_engine_flow.py
+++ b/tests/engine/test_engine_flow.py
@@ -38,6 +38,9 @@ from agent_engine.engine.langgraph.filters import AccessFilter
 from agent_engine.engine.types import RunResult
 from agent_engine.runtime.hooks import AuthContext, RunContext
 from agent_engine.runtime.state import GraphState
+from agent_engine.tool_usage.context import ToolUsageContextProvider
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.tracker import ToolUsageTracker
 from tests.fixtures.utils import fake_model_factory
 
 # ---------------------------------------------------------------------------
@@ -94,6 +97,10 @@ def orchestrator(node_id: str, children: list[GraphNode]) -> GraphNode:
 
 def system(graph: GraphNode) -> SystemSpec:
     return SystemSpec(meta=SystemMeta(name="test-system"), defaults=None, graph=graph)
+
+
+def usage_context() -> ToolUsageContextProvider:
+    return ToolUsageContextProvider(InMemoryToolUsageRepository())
 
 
 def write_tool(base_dir: Path, tool_id: str) -> None:
@@ -341,7 +348,6 @@ def test_access_filter_keeps_protected_when_allowed(tmp_path: Path) -> None:
 def test_graph_state_accepts_generic_run_context() -> None:
     state: GraphState = {
         "message": "hello",
-        "used_tools": [],
         "run_context": {"metadata": {"allowed_nodes": ("admin",)}},
     }
 
@@ -474,8 +480,10 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         children=[],
         filters=[],
         base_dir=tmp_path,
+        usage_context=usage_context(),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
     )
-    await node_both({"message": "hi", "visited": [], "used_tools": []})
+    await node_both({"message": "hi", "visited": []})
     expected_both = (
         f"System persona content\n\nOrchestrator routing content\n{_ORCHESTRATOR_CONTRACT}"
     )
@@ -499,8 +507,10 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         children=[],
         filters=[],
         base_dir=tmp_path,
+        usage_context=usage_context(),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
     )
-    await node_sys({"message": "hi", "visited": [], "used_tools": []})
+    await node_sys({"message": "hi", "visited": []})
     expected_sys = f"System persona content\n\n\n{_ORCHESTRATOR_CONTRACT}"
     assert model_sys.captured_prompt == expected_sys
 
@@ -523,8 +533,10 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         children=[],
         filters=[],
         base_dir=tmp_path,
+        usage_context=usage_context(),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
     )
-    await node_orch({"message": "hi", "visited": [], "used_tools": []})
+    await node_orch({"message": "hi", "visited": []})
     expected_orch = f"orch desc\n\nOrchestrator routing content\n{_ORCHESTRATOR_CONTRACT}"
     assert model_orch.captured_prompt == expected_orch
 
@@ -544,7 +556,9 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         children=[],
         filters=[],
         base_dir=tmp_path,
+        usage_context=usage_context(),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
     )
-    await node_desc({"message": "hi", "visited": [], "used_tools": []})
+    await node_desc({"message": "hi", "visited": []})
     expected_desc = f"orch desc\n\n\n{_ORCHESTRATOR_CONTRACT}"
     assert model_desc.captured_prompt == expected_desc

--- a/tests/engine/test_executed_tools_tool.py
+++ b/tests/engine/test_executed_tools_tool.py
@@ -1,0 +1,206 @@
+"""The orchestrator's read-only report of what has actually executed.
+
+Asked which tools had run, an orchestrator kept naming the child agent it had
+delegated to — that name is in its own tool list, and no system instruction
+reliably overrode it. These tests cover the tool that makes the answer come from
+the repository instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from agent_engine.core.spec import ModelConfig, OrchestratorPromptSet, OrchestratorSpec
+from agent_engine.engine.langgraph.executed_tools_tool import (
+    EXECUTED_TOOLS_TOOL_NAME,
+    build_executed_tools_tool,
+)
+from agent_engine.engine.langgraph.nodes import OrchestratorNode
+from agent_engine.runtime.hooks import RunContext, current_run_context
+from agent_engine.tool_usage.context import ToolUsageContextProvider
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationKind,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from agent_engine.tool_usage.tracker import ToolUsageTracker
+from tests.engine.test_shared_tool_usage import run_system
+from tests.engine.usage_models import AllToolsThenAnswerModel
+
+
+def usage(
+    agent_id: str,
+    tool_name: str,
+    *,
+    run_id: str = "run-1",
+    kind: ToolInvocationKind = ToolInvocationKind.TOOL,
+    status: ToolInvocationStatus = ToolInvocationStatus.SUCCEEDED,
+) -> ToolInvocationRecord:
+    return ToolInvocationRecord(
+        call=ToolCallIdentity(
+            run_id=run_id,
+            agent_id=agent_id,
+            agent_path=f"openwebui/{agent_id}",
+            tool_call_id=f"call-{agent_id}-{tool_name}-{run_id}",
+            tool_name=tool_name,
+            conversation_id="conv-1",
+            kind=kind,
+        ),
+        status=status,
+    )
+
+
+@pytest.fixture
+def run_scope() -> Iterator[None]:
+    """Run the tool inside a run context, as the engine always does."""
+    token = current_run_context.set(RunContext(run_id="run-2", conversation_id="conv-1"))
+    yield
+    current_run_context.reset(token)
+
+
+async def report(repository: InMemoryToolUsageRepository) -> str:
+    tool = build_executed_tools_tool(ToolUsageContextProvider(repository), "openwebui")
+    return str(await tool.ainvoke({}))
+
+
+async def test_it_reports_the_tools_executed_across_the_conversation(run_scope: None) -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("user_management", "add_new_user"))
+    await repository.record(usage("group_management", "create_group", run_id="run-2"))
+
+    answer = await report(repository)
+
+    assert "user_management: add_new_user [succeeded]" in answer
+    assert "group_management: create_group [succeeded]" in answer
+
+
+async def test_it_never_reports_a_delegation_as_an_executed_tool(run_scope: None) -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("user_management", "add_new_user"))
+    await repository.record(usage("openwebui", "admin_management", kind=ToolInvocationKind.AGENT))
+
+    answer = await report(repository)
+
+    assert "add_new_user" in answer
+    assert "admin_management" not in answer
+
+
+async def test_it_reports_a_failed_tool_with_its_outcome(run_scope: None) -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(
+        usage("user_management", "add_new_user", status=ToolInvocationStatus.FAILED)
+    )
+
+    assert "add_new_user [failed]" in await report(repository)
+
+
+async def test_it_says_so_when_nothing_has_executed(run_scope: None) -> None:
+    assert "No tools have been executed" in await report(InMemoryToolUsageRepository())
+
+
+async def test_another_conversation_is_never_reported(run_scope: None) -> None:
+    repository = InMemoryToolUsageRepository()
+    other = ToolInvocationRecord(
+        call=ToolCallIdentity(
+            run_id="other-run",
+            agent_id="user_management",
+            agent_path="other/user_management",
+            tool_call_id="other-call",
+            tool_name="delete_user",
+            conversation_id="conv-other",
+        ),
+        status=ToolInvocationStatus.SUCCEEDED,
+    )
+    await repository.record(other)
+
+    assert "delete_user" not in await report(repository)
+
+
+async def test_an_unreadable_record_is_never_reported_as_nothing_having_run(
+    run_scope: None,
+) -> None:
+    """Saying "nothing ran" when the record cannot be read would invite an agent
+    to repeat an action that already took effect."""
+    from tests.tool_usage.test_tracker import BrokenRepository
+
+    tool = build_executed_tools_tool(ToolUsageContextProvider(BrokenRepository()), "openwebui")
+
+    answer = str(await tool.ainvoke({}))
+
+    assert "could not be read" in answer
+    assert "No tools have been executed" not in answer
+
+
+# --------------------------------------------------------------------------- #
+# Binding
+# --------------------------------------------------------------------------- #
+
+
+async def test_orchestrators_are_given_the_reporting_tool(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    captured: list[str] = []
+
+    class BindingCapture(AllToolsThenAnswerModel):
+        def bind_tools(self, tools: list[Any]) -> AllToolsThenAnswerModel:
+            captured.extend(tool.name for tool in tools)
+            return super().bind_tools(tools)
+
+    models["root-model"] = BindingCapture("root answer")
+
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    assert EXECUTED_TOOLS_TOOL_NAME in captured
+    assert "planner" in captured  # the children are still bound
+
+
+async def test_an_orchestrator_with_no_reachable_children_is_bound_no_tools(
+    tmp_path: Path,
+) -> None:
+    """A child filtered out for this caller must leave the model with nothing to
+    call — a convenience tool must not reopen a path access control closed."""
+    bound: list[list[str]] = []
+
+    class BindingCapture(AllToolsThenAnswerModel):
+        def bind_tools(self, tools: list[Any]) -> AllToolsThenAnswerModel:
+            bound.append([tool.name for tool in tools])
+            return super().bind_tools(tools)
+
+    model = BindingCapture("nothing to route to")
+    node = OrchestratorNode(
+        spec=OrchestratorSpec(
+            id="root",
+            name="root",
+            description="root",
+            model=ModelConfig(provider="fake", name="root", temperature=None),
+            prompts=OrchestratorPromptSet(),
+        ),
+        node_path="root",
+        model=cast(Any, model),
+        children=[],
+        filters=[],
+        base_dir=tmp_path,
+        usage_context=ToolUsageContextProvider(InMemoryToolUsageRepository()),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
+    )
+
+    await node({"message": "hi", "visited": []})
+
+    assert bound == []
+
+
+async def test_calling_the_report_is_not_recorded_as_tool_usage(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(tmp_path, models, repository=repository, run_id="run-1")
+
+    stored = await repository.list_for_run("run-1")
+    assert EXECUTED_TOOLS_TOOL_NAME not in {r.call.tool_name for r in stored}

--- a/tests/engine/test_shared_tool_usage.py
+++ b/tests/engine/test_shared_tool_usage.py
@@ -1,0 +1,505 @@
+"""Tool usage is shared across the agents of one run, through the repository.
+
+Two agents run under one orchestrator in a single run. What the first agent did
+must reach the second one without any of it travelling through ``GraphState`` —
+and without ever becoming conversation history or user-visible text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from agent_engine.core.spec import (
+    AgentSpec,
+    BasePromptSet,
+    GraphNode,
+    ModelConfig,
+    OrchestratorPromptSet,
+    OrchestratorSpec,
+    SystemMeta,
+    SystemSpec,
+    ToolSpec,
+)
+from agent_engine.engine.langgraph.engine import LangGraphEngine
+from agent_engine.engine.types import ChatMessage, ChatRole, RunResult
+from agent_engine.runtime.hooks import RunContext
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import ToolInvocationKind
+from tests.engine.usage_models import AllToolsThenAnswerModel
+
+AGENT = ToolInvocationKind.AGENT
+TOOL = ToolInvocationKind.TOOL
+
+USAGE_HEADER = "Execution record for this conversation"
+
+
+def model_config(name: str) -> ModelConfig:
+    return ModelConfig(provider="fake", name=name, temperature=None)
+
+
+def agent(node_id: str, tool_id: str, *, model_name: str | None = None) -> GraphNode:
+    return GraphNode(
+        node=AgentSpec(
+            id=node_id,
+            name=node_id,
+            description=f"{node_id} agent",
+            model=model_config(model_name or f"{node_id}-model"),
+            prompts=BasePromptSet(),
+            tools=(ToolSpec(tool_id, f"{tool_id} description"),),
+            auto_mode=True,
+        )
+    )
+
+
+def two_agent_system(children: list[GraphNode]) -> SystemSpec:
+    root = OrchestratorSpec(
+        id="root",
+        name="root",
+        description="root orchestrator",
+        model=model_config("root-model"),
+        prompts=OrchestratorPromptSet(),
+    )
+    return SystemSpec(
+        meta=SystemMeta(name="shared-usage"),
+        defaults=None,
+        graph=GraphNode(node=root, children=tuple(children)),
+    )
+
+
+def write_tool(base_dir: Path, tool_id: str, *, fails: bool = False) -> None:
+    tools_dir = base_dir / "plugins" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    body = (
+        "    raise RuntimeError('provider exploded')\n"
+        if fails
+        else "    return 'did: ' + message\n"
+    )
+    (tools_dir / f"{tool_id}.py").write_text(
+        f"def {tool_id}(message: str) -> str:\n{body}", encoding="utf-8"
+    )
+
+
+def model_factory_for(models: dict[str, AllToolsThenAnswerModel]) -> Callable[..., BaseChatModel]:
+    def factory(provider: str, name: str, temperature: float | None, **_: Any) -> BaseChatModel:
+        return cast(BaseChatModel, models[name])
+
+    return factory
+
+
+async def run_system(
+    tmp_path: Path,
+    models: dict[str, AllToolsThenAnswerModel],
+    *,
+    repository: InMemoryToolUsageRepository,
+    run_id: str,
+    conversation_id: str | None = None,
+    failing_tool: bool = False,
+    history: Sequence[ChatMessage] = (),
+) -> RunResult:
+    write_tool(tmp_path, "search")
+    write_tool(tmp_path, "get_file", fails=failing_tool)
+    spec = two_agent_system([agent("planner", "search"), agent("developer", "get_file")])
+    async with LangGraphEngine(
+        tmp_path,
+        model_factory=model_factory_for(models),
+        tool_usage_repository=repository,
+    ) as engine:
+        await engine.build(spec)
+        return await engine.run(
+            "please handle this",
+            history=history,
+            context=RunContext(run_id=run_id, conversation_id=conversation_id),
+        )
+
+
+def messages_of(model: AllToolsThenAnswerModel) -> list[Any]:
+    """The last message list this model was asked to complete."""
+    return model.seen[-1]
+
+
+def first_messages_of(model: AllToolsThenAnswerModel) -> list[Any]:
+    return model.seen[0]
+
+
+# --------------------------------------------------------------------------- #
+# Persistence: run → agent → tool call
+# --------------------------------------------------------------------------- #
+
+
+async def test_every_agents_tool_call_is_persisted_against_the_same_run(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-1", conversation_id="conv-1"
+    )
+
+    stored = [r for r in await repository.list_for_run("run-1") if r.call.kind is TOOL]
+    assert [(r.call.agent_id, r.call.tool_name, r.status.value) for r in stored] == [
+        ("planner", "search", "succeeded"),
+        ("developer", "get_file", "succeeded"),
+    ]
+
+
+async def test_a_record_carries_its_conversation_run_agent_and_call(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-1", conversation_id="conv-1"
+    )
+
+    call = next(
+        r.call for r in await repository.list_for_run("run-1") if r.call.tool_name == "get_file"
+    )
+    assert call.conversation_id == "conv-1"
+    assert call.run_id == "run-1"
+    assert call.agent_id == "developer"
+    assert call.agent_path == "root/developer"
+    assert call.tool_call_id
+
+
+async def test_delegating_to_a_child_agent_is_recorded_as_an_action(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    result = await run_system(tmp_path, models, repository=repository, run_id="run-1")
+
+    delegations = [r for r in await repository.list_for_run("run-1") if r.call.kind is AGENT]
+    assert [(r.call.agent_id, r.call.tool_name) for r in delegations] == [
+        ("root", "planner"),
+        ("root", "developer"),
+    ]
+    # The caller-facing trace still means real tool/MCP calls only.
+    assert [t.name for t in result.used_tools] == ["search", "get_file"]
+
+
+async def test_records_do_not_leak_between_runs(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(tmp_path, models, repository=repository, run_id="run-1")
+    await run_system(tmp_path, models, repository=repository, run_id="run-2")
+
+    for run_id in ("run-1", "run-2"):
+        stored = [r for r in await repository.list_for_run(run_id) if r.call.kind is TOOL]
+        assert {r.call.run_id for r in stored} == {run_id}
+        assert len(stored) == 2
+
+
+async def test_a_failed_tool_call_is_recorded_as_failed(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(tmp_path, models, repository=repository, run_id="run-1", failing_tool=True)
+
+    failed = [r for r in await repository.list_for_run("run-1") if r.status.value == "failed"]
+    assert [r.call.tool_name for r in failed] == ["get_file"]
+    assert failed[0].error is not None and "provider exploded" in failed[0].error
+
+
+# --------------------------------------------------------------------------- #
+# Model context: the later agent knows what the earlier one did
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_later_agent_sees_the_earlier_agents_tool_usage(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    developer_context = "\n".join(
+        str(m.content) for m in first_messages_of(models["developer-model"])
+    )
+    assert USAGE_HEADER in developer_context
+    assert "planner:\n- search [succeeded]" in developer_context
+
+
+async def test_the_orchestrator_sees_what_its_children_ran_before_synthesising(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    # The orchestrator's last turn is the synthesis, after both children returned.
+    synthesis = "\n".join(str(m.content) for m in messages_of(models["root-model"]))
+    assert USAGE_HEADER in synthesis
+    assert "planner:\n- search [succeeded]" in synthesis
+    assert "developer:\n- get_file [succeeded]" in synthesis
+
+
+async def test_a_later_turn_of_the_conversation_sees_the_earlier_turns_usage(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-1", conversation_id="conv-1"
+    )
+    models["root-model"].seen.clear()
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-2", conversation_id="conv-1"
+    )
+
+    # A follow-up message is a new run: without conversation scope this would be empty.
+    opening_turn = "\n".join(str(m.content) for m in first_messages_of(models["root-model"]))
+    assert USAGE_HEADER in opening_turn
+    assert "planner:\n- search [succeeded]" in opening_turn
+
+
+async def test_another_conversation_never_sees_this_ones_usage(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-1", conversation_id="conv-1"
+    )
+    models["root-model"].seen.clear()
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-2", conversation_id="conv-other"
+    )
+
+    opening_turn = "\n".join(str(m.content) for m in first_messages_of(models["root-model"]))
+    assert USAGE_HEADER not in opening_turn
+
+
+async def test_the_first_agent_starts_without_execution_context(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    planner_context = "\n".join(str(m.content) for m in first_messages_of(models["planner-model"]))
+    assert USAGE_HEADER not in planner_context
+
+
+async def test_execution_context_is_private_to_the_model_not_conversation_history(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    result = await run_system(
+        tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1"
+    )
+
+    conversational = [
+        m
+        for m in first_messages_of(models["developer-model"])
+        if isinstance(m, HumanMessage | AIMessage)
+    ]
+    assert conversational
+    assert all(USAGE_HEADER not in str(m.content) for m in conversational)
+    assert any(
+        USAGE_HEADER in str(m.content)
+        for m in first_messages_of(models["developer-model"])
+        if isinstance(m, SystemMessage)
+    )
+    assert USAGE_HEADER not in result.answer
+
+
+async def test_the_conversation_the_model_sees_is_exactly_the_supplied_history(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    history = (
+        ChatMessage(role=ChatRole.USER, content="earlier question"),
+        ChatMessage(role=ChatRole.ASSISTANT, content="earlier answer"),
+    )
+
+    await run_system(
+        tmp_path,
+        models,
+        repository=InMemoryToolUsageRepository(),
+        run_id="run-1",
+        history=history,
+    )
+
+    conversational = [
+        str(m.content)
+        for m in first_messages_of(models["root-model"])
+        if isinstance(m, HumanMessage | AIMessage)
+    ]
+    assert conversational == ["earlier question", "earlier answer", "please handle this"]
+
+
+async def test_the_user_facing_answer_never_carries_execution_metadata(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    result = await run_system(
+        tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1"
+    )
+
+    assert result.answer == "synthesized"
+    for record in result.used_tools:
+        assert record.name not in result.answer
+
+
+# --------------------------------------------------------------------------- #
+# Every level of the graph receives the context
+# --------------------------------------------------------------------------- #
+
+
+def nested_system() -> SystemSpec:
+    """root orchestrator → intermediate orchestrator → leaf agent."""
+    leaf = agent("user_management", "create_user", model_name="leaf-model")
+    middle = GraphNode(
+        node=OrchestratorSpec(
+            id="admin_management",
+            name="admin_management",
+            description="admin orchestrator",
+            model=model_config("mid-model"),
+            prompts=OrchestratorPromptSet(),
+        ),
+        children=(leaf,),
+    )
+    root = OrchestratorSpec(
+        id="openwebui",
+        name="openwebui",
+        description="root orchestrator",
+        model=model_config("root-model"),
+        prompts=OrchestratorPromptSet(),
+    )
+    return SystemSpec(
+        meta=SystemMeta(name="nested-usage"),
+        defaults=None,
+        graph=GraphNode(node=root, children=(middle,)),
+    )
+
+
+async def test_every_level_of_the_graph_sees_the_conversations_usage(tmp_path: Path) -> None:
+    models = {
+        "root-model": AllToolsThenAnswerModel("root answer"),
+        "mid-model": AllToolsThenAnswerModel("mid answer"),
+        "leaf-model": AllToolsThenAnswerModel("leaf answer"),
+    }
+    write_tool(tmp_path, "create_user")
+    repository = InMemoryToolUsageRepository()
+
+    async with LangGraphEngine(
+        tmp_path,
+        model_factory=model_factory_for(models),
+        tool_usage_repository=repository,
+    ) as engine:
+        await engine.build(nested_system())
+        await engine.run("create a user", context=RunContext(run_id="r1", conversation_id="c1"))
+        for model in models.values():
+            model.seen.clear()
+        # A new user message: a new run, the same conversation.
+        await engine.run("who did what?", context=RunContext(run_id="r2", conversation_id="c1"))
+
+    for name in ("root-model", "mid-model", "leaf-model"):
+        opening_turn = "\n".join(str(m.content) for m in first_messages_of(models[name]))
+        assert USAGE_HEADER in opening_turn, name
+        tools, delegations = opening_turn.split("### Agents delegated to")
+        assert "user_management:\n- create_user [succeeded]" in tools, name
+        # The child agent belongs to routing, never to the tools that ran.
+        assert "admin_management" not in tools, name
+        assert "openwebui -> admin_management" in delegations, name
+
+
+async def test_a_child_agent_is_bound_as_a_delegation_not_as_an_action(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    """An orchestrator reported a child agent as a tool it had run. Its own tool
+    list is where that belief came from, so the binding has to say otherwise."""
+    captured: list[str] = []
+
+    class BindingCapture(AllToolsThenAnswerModel):
+        def bind_tools(self, tools: list[Any]) -> AllToolsThenAnswerModel:
+            captured.extend(t.description for t in tools)
+            return super().bind_tools(tools)
+
+    models["root-model"] = BindingCapture("root answer")
+
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    assert any("Delegate this request to the 'planner' agent" in d for d in captured)
+
+
+# --------------------------------------------------------------------------- #
+# Freshness: the context tracks what happened during the turn
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_tool_that_ran_between_model_turns_appears_in_the_next_one(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    # The developer's second model turn follows the planner's tool call and its own.
+    developer = models["developer-model"]
+    assert len(developer.seen) == 2
+    second_turn = "\n".join(str(m.content) for m in developer.seen[1])
+    assert "planner:\n- search [succeeded]" in second_turn
+
+
+async def test_the_turns_own_tool_call_is_not_repeated_in_the_context(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    developer = models["developer-model"]
+    second_turn = developer.seen[1]
+    # get_file reached this model in full through the normal tool protocol...
+    assert any(isinstance(m, ToolMessage) for m in second_turn)
+    # ...so the execution context does not spend tokens repeating it.
+    execution_context = next(
+        str(m.content)
+        for m in second_turn
+        if isinstance(m, SystemMessage) and USAGE_HEADER in str(m.content)
+    )
+    assert "get_file" not in execution_context
+    assert "search [succeeded]" in execution_context
+
+
+async def test_an_agents_own_call_from_an_earlier_run_is_still_shown(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-1", conversation_id="conv-1"
+    )
+    models["developer-model"].seen.clear()
+    await run_system(
+        tmp_path, models, repository=repository, run_id="run-2", conversation_id="conv-1"
+    )
+
+    # Its own earlier work is not in this turn's messages, so it must be reported.
+    opening_turn = "\n".join(str(m.content) for m in first_messages_of(models["developer-model"]))
+    assert "developer:\n- get_file [succeeded]" in opening_turn
+
+
+# --------------------------------------------------------------------------- #
+# The public run trace stays a projection of the same records
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_run_trace_is_projected_from_the_repository(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    result = await run_system(
+        tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1"
+    )
+
+    assert [(t.agent_id, t.name, t.status) for t in result.used_tools] == [
+        ("planner", "search", "succeeded"),
+        ("developer", "get_file", "succeeded"),
+    ]
+
+
+async def test_the_normal_tool_result_still_reaches_the_model(
+    tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
+) -> None:
+    await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
+
+    tool_results = [
+        str(m.content) for m in messages_of(models["planner-model"]) if isinstance(m, ToolMessage)
+    ]
+    assert tool_results == ["did: go"]

--- a/tests/engine/test_shared_tool_usage.py
+++ b/tests/engine/test_shared_tool_usage.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages.tool import ToolCall
 
 from agent_engine.core.spec import (
     AgentSpec,
@@ -180,6 +181,54 @@ async def test_delegating_to_a_child_agent_is_recorded_as_an_action(
     ]
     # The caller-facing trace still means real tool/MCP calls only.
     assert [t.name for t in result.used_tools] == ["search", "get_file"]
+
+
+async def test_repeated_delegations_to_the_same_agent_are_both_visible(
+    tmp_path: Path,
+) -> None:
+    class DelegateTwiceModel(AllToolsThenAnswerModel):
+        def bind_tools(self, tools: list[Any]) -> AllToolsThenAnswerModel:
+            return DelegateTwiceModel(self._answer, [tool.name for tool in tools], self.seen)
+
+        def _respond(self, messages: list[Any]) -> AIMessage:
+            self.seen.append(list(messages))
+            if self._tool_names and not any(
+                isinstance(message, ToolMessage) for message in messages
+            ):
+                name = self._tool_names[0]
+                return AIMessage(
+                    content="",
+                    tool_calls=[
+                        ToolCall(name=name, args={"message": "first"}, id="delegate-1"),
+                        ToolCall(name=name, args={"message": "second"}, id="delegate-2"),
+                    ],
+                )
+            return AIMessage(content=self._answer)
+
+    models = {
+        "root-model": DelegateTwiceModel("synthesized"),
+        "planner-model": AllToolsThenAnswerModel("planned"),
+    }
+    write_tool(tmp_path, "search")
+    repository = InMemoryToolUsageRepository()
+    system = two_agent_system([agent("planner", "search")])
+
+    async with LangGraphEngine(
+        tmp_path,
+        model_factory=model_factory_for(models),
+        tool_usage_repository=repository,
+    ) as engine:
+        await engine.build(system)
+        await engine.run("please plan twice", context=RunContext(run_id="run-repeat"))
+
+    delegations = [
+        record
+        for record in await repository.list_for_run("run-repeat")
+        if record.call.kind is AGENT
+    ]
+    assert [record.call.tool_name for record in delegations] == ["planner", "planner"]
+    synthesis = "\n".join(str(message.content) for message in messages_of(models["root-model"]))
+    assert synthesis.count("root -> planner") == 2
 
 
 async def test_records_do_not_leak_between_runs(
@@ -439,22 +488,22 @@ async def test_a_tool_that_ran_between_model_turns_appears_in_the_next_one(
     assert "planner:\n- search [succeeded]" in second_turn
 
 
-async def test_the_turns_own_tool_call_is_not_repeated_in_the_context(
+async def test_the_turns_own_tool_call_remains_in_repository_context(
     tmp_path: Path, models: dict[str, AllToolsThenAnswerModel]
 ) -> None:
     await run_system(tmp_path, models, repository=InMemoryToolUsageRepository(), run_id="run-1")
 
     developer = models["developer-model"]
     second_turn = developer.seen[1]
-    # get_file reached this model in full through the normal tool protocol...
+    # The normal protocol and repository projection serve different purposes:
+    # one carries a result; the other is the authoritative execution record.
     assert any(isinstance(m, ToolMessage) for m in second_turn)
-    # ...so the execution context does not spend tokens repeating it.
     execution_context = next(
         str(m.content)
         for m in second_turn
         if isinstance(m, SystemMessage) and USAGE_HEADER in str(m.content)
     )
-    assert "get_file" not in execution_context
+    assert "get_file [succeeded]" in execution_context
     assert "search [succeeded]" in execution_context
 
 

--- a/tests/engine/usage_models.py
+++ b/tests/engine/usage_models.py
@@ -1,0 +1,44 @@
+"""Deterministic chat model shared by the engine tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages.tool import ToolCall
+
+
+class AllToolsThenAnswerModel:
+    """Calls every bound tool once, then answers. Records what it was asked."""
+
+    def __init__(
+        self,
+        answer: str,
+        tool_names: list[str] | None = None,
+        seen: list[list[Any]] | None = None,
+    ) -> None:
+        self._answer = answer
+        self._tool_names = tool_names or []
+        self.seen: list[list[Any]] = [] if seen is None else seen
+
+    def bind_tools(self, tools: list[Any]) -> AllToolsThenAnswerModel:
+        return AllToolsThenAnswerModel(self._answer, [t.name for t in tools], self.seen)
+
+    async def ainvoke(self, messages: list[Any]) -> AIMessage:
+        return self._respond(messages)
+
+    async def astream(self, messages: list[Any]) -> AsyncIterator[AIMessage]:
+        yield self._respond(messages)
+
+    def _respond(self, messages: list[Any]) -> AIMessage:
+        self.seen.append(list(messages))
+        if self._tool_names and not any(isinstance(m, ToolMessage) for m in messages):
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(name=name, args={"message": "go"}, id=f"call_{name}")
+                    for name in self._tool_names
+                ],
+            )
+        return AIMessage(content=self._answer)

--- a/tests/examples/test_enterprise_local_mcp.py
+++ b/tests/examples/test_enterprise_local_mcp.py
@@ -83,6 +83,9 @@ class ContextAwareSearchModel:
         if latest_user == self.follow_up:
             expected = [
                 (SystemMessage, None),
+                # The conversation's prior tool usage, supplied privately to the
+                # model — never as a conversation turn.
+                (SystemMessage, None),
                 (
                     HumanMessage,
                     "Find internal documents about the session approval security policy "
@@ -97,11 +100,12 @@ class ContextAwareSearchModel:
                 (HumanMessage, self.follow_up),
             ]
             for message, (expected_type, expected_content) in zip(
-                messages[:4], expected, strict=True
+                messages[:5], expected, strict=True
             ):
                 assert isinstance(message, expected_type)
                 if expected_content is not None:
                     assert message.content == expected_content
+            assert "Execution record for this conversation" in str(messages[1].content)
             self.saw_follow_up_context = True
             if latest_is_tool_result:
                 self.saw_follow_up_tool_result = True

--- a/tests/runtime/test_execution_limits.py
+++ b/tests/runtime/test_execution_limits.py
@@ -9,7 +9,11 @@ import pytest
 from agent_engine.core.execution import ExecutionPolicy
 from agent_engine.parsers.errors import ParseError
 from agent_engine.parsers.yaml.parser import YAMLParser
-from agent_engine.runtime.execution import ExecutionLimiter, ExecutionLimitExceeded
+from agent_engine.runtime.execution import (
+    ExecutionLimiter,
+    ExecutionLimitExceeded,
+    current_invocation,
+)
 
 _BASE = "system: {name: t}\nagents: {a: {description: d}}\ngraph: {a: }\n"
 
@@ -111,6 +115,26 @@ def test_duplicate_tool_call_blocked_and_not_counted() -> None:
         lim.register_tool_call("a", "t", {"x": 1})  # identical
     assert e.value.limit_name == "duplicate_tool_call"
     assert lim.state.total_tool_calls == 1  # blocked call was not counted
+
+
+def test_duplicate_tool_call_is_scoped_to_one_node_invocation() -> None:
+    lim = ExecutionLimiter(ExecutionPolicy(allow_duplicate_tool_calls=False, max_tool_calls=99))
+    first = current_invocation.set("activation-1")
+    try:
+        lim.register_tool_call("a", "t", {"x": 1})
+        with pytest.raises(ExecutionLimitExceeded) as error:
+            lim.register_tool_call("a", "t", {"x": 1})
+        assert error.value.limit_name == "duplicate_tool_call"
+    finally:
+        current_invocation.reset(first)
+
+    second = current_invocation.set("activation-2")
+    try:
+        lim.register_tool_call("a", "t", {"x": 1})
+    finally:
+        current_invocation.reset(second)
+
+    assert lim.state.total_tool_calls == 2
 
 
 def test_duplicates_allowed_when_policy_permits() -> None:

--- a/tests/tool_usage/adapters.py
+++ b/tests/tool_usage/adapters.py
@@ -1,0 +1,128 @@
+"""A second, genuinely persistent adapter used to pin the repository contract.
+
+It exists so the contract suite runs against more than the shipped in-memory
+store: if the contract can only be satisfied by a dict, it is not a contract.
+SQLite stands in for any out-of-process backend (Redis, PostgreSQL) — none of
+which may live in ``agent_engine`` itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationKind,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tool_usage (
+    run_id TEXT NOT NULL,
+    tool_call_id TEXT NOT NULL,
+    conversation_id TEXT,
+    agent_id TEXT NOT NULL,
+    agent_path TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    server_id TEXT,
+    status TEXT NOT NULL,
+    error TEXT,
+    recorded_at REAL NOT NULL,
+    seq INTEGER NOT NULL,
+    PRIMARY KEY (run_id, tool_call_id)
+)
+"""
+
+
+class SqliteToolUsageRepository:
+    """SQLite implementation of the same ``ToolUsageRepository`` contract.
+
+    ``record`` is an upsert on ``(run_id, tool_call_id)`` that keeps the row's
+    original sequence number, so call order survives a status update exactly as
+    it does in memory. The sequence is global, so a conversation's records order
+    across runs the same way they were made.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = str(path)
+
+    async def setup(self) -> None:
+        async with aiosqlite.connect(self._path) as db:
+            await db.execute(_SCHEMA)
+            await db.commit()
+
+    async def record(self, record: ToolInvocationRecord) -> None:
+        call = record.call
+        async with aiosqlite.connect(self._path, isolation_level=None) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            await db.execute(
+                """
+                INSERT INTO tool_usage (run_id, tool_call_id, conversation_id, agent_id,
+                                        agent_path, kind, tool_name, provider, server_id,
+                                        status, error, recorded_at, seq)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        (SELECT COALESCE(MAX(seq), 0) + 1 FROM tool_usage))
+                ON CONFLICT(run_id, tool_call_id) DO UPDATE SET
+                    status = excluded.status,
+                    error = excluded.error,
+                    recorded_at = excluded.recorded_at
+                """,
+                (
+                    call.run_id,
+                    call.tool_call_id,
+                    call.conversation_id,
+                    call.agent_id,
+                    call.agent_path,
+                    call.kind.value,
+                    call.tool_name,
+                    call.provider,
+                    call.server_id,
+                    record.status.value,
+                    record.error,
+                    record.recorded_at,
+                ),
+            )
+            await db.execute("COMMIT")
+
+    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
+        return await self._select("run_id", run_id)
+
+    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
+        return await self._select("conversation_id", conversation_id)
+
+    async def _select(self, column: str, value: str) -> tuple[ToolInvocationRecord, ...]:
+        """``column`` is always one of the two literals chosen by the callers above."""
+        async with aiosqlite.connect(self._path) as db:
+            cursor = await db.execute(
+                f"""
+                SELECT run_id, conversation_id, agent_id, agent_path, kind, tool_call_id,
+                       tool_name, provider, server_id, status, error, recorded_at
+                FROM tool_usage WHERE {column} = ? ORDER BY seq
+                """,
+                (value,),
+            )
+            rows = await cursor.fetchall()
+        return tuple(
+            ToolInvocationRecord(
+                call=ToolCallIdentity(
+                    run_id=row[0],
+                    conversation_id=row[1],
+                    agent_id=row[2],
+                    agent_path=row[3],
+                    kind=ToolInvocationKind(row[4]),
+                    tool_call_id=row[5],
+                    tool_name=row[6],
+                    provider=row[7],
+                    server_id=row[8],
+                ),
+                status=ToolInvocationStatus(row[9]),
+                error=row[10],
+                recorded_at=row[11],
+            )
+            for row in rows
+        )

--- a/tests/tool_usage/adapters.py
+++ b/tests/tool_usage/adapters.py
@@ -89,24 +89,55 @@ class SqliteToolUsageRepository:
             )
             await db.execute("COMMIT")
 
-    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
-        return await self._select("run_id", run_id)
+    async def list_for_run(
+        self,
+        run_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
+        return await self._select("run_id", run_id, limit=limit, kind=kind)
 
-    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
-        return await self._select("conversation_id", conversation_id)
+    async def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
+        return await self._select("conversation_id", conversation_id, limit=limit, kind=kind)
 
-    async def _select(self, column: str, value: str) -> tuple[ToolInvocationRecord, ...]:
+    async def _select(
+        self,
+        column: str,
+        value: str,
+        *,
+        limit: int | None,
+        kind: ToolInvocationKind | None,
+    ) -> tuple[ToolInvocationRecord, ...]:
         """``column`` is always one of the two literals chosen by the callers above."""
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be positive")
+        where = f"{column} = ?" + (" AND kind = ?" if kind is not None else "")
+        params: list[str | int] = [value]
+        if kind is not None:
+            params.append(kind.value)
+        suffix = " ORDER BY seq"
+        if limit is not None:
+            suffix = " ORDER BY seq DESC LIMIT ?"
+            params.append(limit)
         async with aiosqlite.connect(self._path) as db:
             cursor = await db.execute(
                 f"""
                 SELECT run_id, conversation_id, agent_id, agent_path, kind, tool_call_id,
                        tool_name, provider, server_id, status, error, recorded_at
-                FROM tool_usage WHERE {column} = ? ORDER BY seq
+                FROM tool_usage WHERE {where}{suffix}
                 """,
-                (value,),
+                params,
             )
-            rows = await cursor.fetchall()
+            rows = list(await cursor.fetchall())
+        if limit is not None:
+            rows.reverse()
         return tuple(
             ToolInvocationRecord(
                 call=ToolCallIdentity(

--- a/tests/tool_usage/test_context.py
+++ b/tests/tool_usage/test_context.py
@@ -1,0 +1,297 @@
+"""What the model is told about prior tool usage — and what it is not told."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent_engine.tool_usage.context import (
+    ToolUsageContextProvider,
+    ToolUsageScope,
+    format_executed_tools,
+)
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationKind,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from tests.tool_usage.test_tracker import BrokenRepository
+
+RUN = ToolUsageScope(run_id="run-1")
+CONVERSATION = ToolUsageScope(run_id="run-2", conversation_id="conv-1")
+
+
+def usage(
+    agent_id: str,
+    tool_name: str,
+    *,
+    run_id: str = "run-1",
+    conversation_id: str | None = "conv-1",
+    kind: ToolInvocationKind = ToolInvocationKind.TOOL,
+    status: ToolInvocationStatus = ToolInvocationStatus.SUCCEEDED,
+    error: str | None = None,
+) -> ToolInvocationRecord:
+    return ToolInvocationRecord(
+        call=ToolCallIdentity(
+            run_id=run_id,
+            agent_id=agent_id,
+            agent_path=f"root/{agent_id}",
+            tool_call_id=f"call-{agent_id}-{tool_name}",
+            tool_name=tool_name,
+            provider="mcp",
+            server_id="github",
+            conversation_id=conversation_id,
+            kind=kind,
+        ),
+        status=status,
+        error=error,
+    )
+
+
+async def filled_repository() -> InMemoryToolUsageRepository:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("planner", "github.search"))
+    await repository.record(usage("planner", "context7.query"))
+    await repository.record(usage("developer", "github.get_file"))
+    return repository
+
+
+async def test_context_groups_invocations_by_agent() -> None:
+    provider = ToolUsageContextProvider(await filled_repository())
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    assert "planner:\n- github.search [succeeded]\n- context7.query [succeeded]" in rendered
+    assert "developer:\n- github.get_file [succeeded]" in rendered
+
+
+async def test_context_carries_agent_tool_and_status_only() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(
+        usage("developer", "deploy", status=ToolInvocationStatus.FAILED, error="secret-token-leak")
+    )
+    provider = ToolUsageContextProvider(repository)
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    assert "deploy [failed]" in rendered
+    for internal in ("secret-token-leak", "call-developer-deploy", "github", "recorded_at"):
+        assert internal not in rendered
+
+
+async def test_a_run_with_no_usage_adds_nothing_to_the_prompt() -> None:
+    provider = ToolUsageContextProvider(InMemoryToolUsageRepository())
+
+    context = await provider.get(RUN)
+
+    assert context.is_empty
+    assert context.render() is None
+
+
+async def delegating_repository() -> InMemoryToolUsageRepository:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("user_management", "add_new_user"))
+    await repository.record(usage("openwebui", "admin_management", kind=ToolInvocationKind.AGENT))
+    return repository
+
+
+async def test_an_executed_tool_and_a_delegation_are_reported_apart() -> None:
+    """Regression: an orchestrator answered "the tool I ran is admin_management"
+    — the name of the child agent it had merely routed to. Its own children are
+    bound to it as tools, so the record has to name both levels and say which
+    is which."""
+    provider = ToolUsageContextProvider(await delegating_repository())
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    tools, delegations = rendered.split("### Agents delegated to")
+    assert "add_new_user [succeeded]" in tools
+    assert "admin_management" not in tools
+    assert "openwebui -> admin_management" in delegations
+
+
+async def test_successful_routing_is_reported_without_an_outcome() -> None:
+    provider = ToolUsageContextProvider(await delegating_repository())
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    # A path that worked is not an outcome the model should read as a tool result.
+    assert "openwebui -> admin_management\n" in f"{rendered}\n"
+
+
+async def test_routing_that_failed_is_reported_with_its_outcome() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(
+        usage(
+            "openwebui",
+            "admin_management",
+            kind=ToolInvocationKind.AGENT,
+            status=ToolInvocationStatus.FAILED,
+        )
+    )
+    provider = ToolUsageContextProvider(repository)
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    assert "openwebui -> admin_management [failed]" in rendered
+
+
+async def test_a_conversation_of_pure_routing_shows_no_tool_section() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("openwebui", "admin_management", kind=ToolInvocationKind.AGENT))
+    provider = ToolUsageContextProvider(repository)
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    assert "### Tools executed" not in rendered
+    assert "openwebui -> admin_management" in rendered
+
+
+async def test_delegations_can_be_switched_off_for_a_deployment() -> None:
+    provider = ToolUsageContextProvider(await delegating_repository(), include_delegations=False)
+
+    rendered = (await provider.get(RUN)).render()
+
+    assert rendered is not None
+    assert "add_new_user [succeeded]" in rendered
+    assert "admin_management" not in rendered
+
+
+async def test_a_scope_without_any_identity_yields_empty_context() -> None:
+    provider = ToolUsageContextProvider(await filled_repository())
+
+    assert (await provider.get(ToolUsageScope())).is_empty
+
+
+async def test_records_of_other_runs_never_leak_into_context() -> None:
+    provider = ToolUsageContextProvider(await filled_repository())
+
+    assert (await provider.get(ToolUsageScope(run_id="other-run"))).is_empty
+
+
+async def test_a_later_turn_sees_the_conversations_earlier_runs() -> None:
+    repository = await filled_repository()
+    provider = ToolUsageContextProvider(repository)
+
+    # A follow-up user message is a new run in the same conversation.
+    context = await provider.get(CONVERSATION)
+
+    assert [entry.tool_name for entry in context.entries] == [
+        "github.search",
+        "context7.query",
+        "github.get_file",
+    ]
+
+
+async def test_another_conversation_is_never_visible() -> None:
+    provider = ToolUsageContextProvider(await filled_repository())
+
+    scope = ToolUsageScope(run_id="run-9", conversation_id="conv-other")
+
+    assert (await provider.get(scope)).is_empty
+
+
+async def test_a_run_outside_any_conversation_falls_back_to_its_own_run() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("planner", "github.search", conversation_id=None))
+    provider = ToolUsageContextProvider(repository)
+
+    context = await provider.get(ToolUsageScope(run_id="run-1"))
+
+    assert [entry.tool_name for entry in context.entries] == ["github.search"]
+
+
+async def test_context_is_bounded_to_the_most_recent_invocations() -> None:
+    repository = InMemoryToolUsageRepository()
+    for index in range(10):
+        await repository.record(usage("planner", f"tool_{index}"))
+    provider = ToolUsageContextProvider(repository, max_entries=3)
+
+    context = await provider.get(RUN)
+
+    assert [entry.tool_name for entry in context.entries] == ["tool_7", "tool_8", "tool_9"]
+
+
+async def test_an_unreadable_repository_degrades_to_empty_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = ToolUsageContextProvider(BrokenRepository())
+
+    with caplog.at_level(logging.WARNING):
+        context = await provider.get(RUN)
+
+    assert context.is_empty
+    assert "tool usage context unavailable" in caplog.text
+
+
+async def test_a_trimmed_record_says_it_is_incomplete() -> None:
+    repository = InMemoryToolUsageRepository()
+    for index in range(5):
+        await repository.record(usage("planner", f"tool_{index}"))
+    provider = ToolUsageContextProvider(repository, max_entries=2)
+
+    context = await provider.get(RUN)
+    rendered = context.render()
+
+    assert context.truncated
+    assert rendered is not None
+    assert "not complete" in rendered
+
+
+async def test_a_complete_record_does_not_claim_to_be_trimmed() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("planner", "github.search"))
+    provider = ToolUsageContextProvider(repository, max_entries=2)
+
+    context = await provider.get(RUN)
+
+    assert not context.truncated
+    assert "not complete" not in str(context.render())
+
+
+async def test_the_report_is_bounded_and_says_so() -> None:
+    repository = InMemoryToolUsageRepository()
+    for index in range(5):
+        await repository.record(usage("planner", f"tool_{index}"))
+    provider = ToolUsageContextProvider(repository, report_max_entries=2)
+
+    report = format_executed_tools(await provider.get_executed_tools(RUN))
+
+    assert "tool_3" in report and "tool_4" in report
+    assert "tool_0" not in report
+    assert "not complete" in report
+
+
+async def test_the_report_still_lists_what_the_asking_turn_already_shows() -> None:
+    """`get` hides the turn's own calls; a direct question must not."""
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("planner", "github.search"))
+    provider = ToolUsageContextProvider(repository)
+
+    report = format_executed_tools(await provider.get_executed_tools(RUN))
+
+    assert "github.search" in report
+
+
+async def test_a_read_failure_propagates_from_the_report() -> None:
+    """The caller must be able to tell "unreadable" from "nothing ran"."""
+    provider = ToolUsageContextProvider(BrokenRepository())
+
+    with pytest.raises(RuntimeError):
+        await provider.get_executed_tools(RUN)
+
+
+def test_entry_limits_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        ToolUsageContextProvider(InMemoryToolUsageRepository(), max_entries=0)
+    with pytest.raises(ValueError):
+        ToolUsageContextProvider(InMemoryToolUsageRepository(), report_max_entries=0)

--- a/tests/tool_usage/test_context.py
+++ b/tests/tool_usage/test_context.py
@@ -33,13 +33,14 @@ def usage(
     kind: ToolInvocationKind = ToolInvocationKind.TOOL,
     status: ToolInvocationStatus = ToolInvocationStatus.SUCCEEDED,
     error: str | None = None,
+    tool_call_id: str | None = None,
 ) -> ToolInvocationRecord:
     return ToolInvocationRecord(
         call=ToolCallIdentity(
             run_id=run_id,
             agent_id=agent_id,
             agent_path=f"root/{agent_id}",
-            tool_call_id=f"call-{agent_id}-{tool_name}",
+            tool_call_id=tool_call_id or f"call-{agent_id}-{tool_name}",
             tool_name=tool_name,
             provider="mcp",
             server_id="github",
@@ -271,15 +272,35 @@ async def test_the_report_is_bounded_and_says_so() -> None:
     assert "not complete" in report
 
 
-async def test_the_report_still_lists_what_the_asking_turn_already_shows() -> None:
-    """`get` hides the turn's own calls; a direct question must not."""
+async def test_repeated_same_named_calls_remain_distinct_context_entries() -> None:
     repository = InMemoryToolUsageRepository()
-    await repository.record(usage("planner", "github.search"))
+    await repository.record(usage("planner", "github.search", tool_call_id="call-1"))
+    await repository.record(usage("planner", "github.search", tool_call_id="call-2"))
     provider = ToolUsageContextProvider(repository)
 
-    report = format_executed_tools(await provider.get_executed_tools(RUN))
+    context = await provider.get(RUN)
 
-    assert "github.search" in report
+    assert [entry.tool_name for entry in context.entries] == ["github.search", "github.search"]
+
+
+async def test_tool_only_context_does_not_underfill_after_many_delegations() -> None:
+    repository = InMemoryToolUsageRepository()
+    await repository.record(usage("worker", "first-tool", tool_call_id="tool-1"))
+    for index in range(10):
+        await repository.record(
+            usage(
+                "root",
+                f"child-{index}",
+                kind=ToolInvocationKind.AGENT,
+                tool_call_id=f"delegate-{index}",
+            )
+        )
+    await repository.record(usage("worker", "last-tool", tool_call_id="tool-2"))
+    provider = ToolUsageContextProvider(repository, max_entries=2, include_delegations=False)
+
+    context = await provider.get(RUN)
+
+    assert [entry.tool_name for entry in context.entries] == ["first-tool", "last-tool"]
 
 
 async def test_a_read_failure_propagates_from_the_report() -> None:

--- a/tests/tool_usage/test_repository_contract.py
+++ b/tests/tool_usage/test_repository_contract.py
@@ -16,6 +16,7 @@ import pytest
 from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
 from agent_engine.tool_usage.models import (
     ToolCallIdentity,
+    ToolInvocationKind,
     ToolInvocationRecord,
     ToolInvocationStatus,
 )
@@ -32,6 +33,7 @@ def usage(
     conversation_id: str | None = None,
     status: ToolInvocationStatus = ToolInvocationStatus.SUCCEEDED,
     error: str | None = None,
+    kind: ToolInvocationKind = ToolInvocationKind.TOOL,
 ) -> ToolInvocationRecord:
     return ToolInvocationRecord(
         call=ToolCallIdentity(
@@ -41,6 +43,7 @@ def usage(
             tool_call_id=tool_call_id or f"{agent_id}:{tool_name}",
             tool_name=tool_name,
             conversation_id=conversation_id,
+            kind=kind,
         ),
         status=status,
         error=error,
@@ -202,3 +205,65 @@ async def test_listing_returns_a_snapshot_that_later_writes_do_not_change(
     await repository.record(usage("run-1", "developer", "github.get_file"))
 
     assert len(snapshot) == 1
+
+
+@pytest.mark.parametrize("scope", ["run", "conversation"])
+async def test_bounded_listing_returns_the_latest_records_in_chronological_order(
+    repository: ToolUsageRepository,
+    scope: str,
+) -> None:
+    for index in range(5):
+        await repository.record(
+            usage(
+                "run-1",
+                "planner",
+                f"tool-{index}",
+                tool_call_id=f"call-{index}",
+                conversation_id="conv-1",
+            )
+        )
+
+    stored = (
+        await repository.list_for_run("run-1", limit=2)
+        if scope == "run"
+        else await repository.list_for_conversation("conv-1", limit=2)
+    )
+
+    assert [record.call.tool_name for record in stored] == ["tool-3", "tool-4"]
+
+
+@pytest.mark.parametrize("scope", ["run", "conversation"])
+async def test_kind_filter_is_applied_before_the_limit(
+    repository: ToolUsageRepository,
+    scope: str,
+) -> None:
+    await repository.record(
+        usage("run-1", "worker", "first-tool", tool_call_id="a", conversation_id="conv-1")
+    )
+    for index in range(4):
+        await repository.record(
+            usage(
+                "run-1",
+                "root",
+                f"child-{index}",
+                tool_call_id=f"child-{index}",
+                conversation_id="conv-1",
+                kind=ToolInvocationKind.AGENT,
+            )
+        )
+    await repository.record(
+        usage("run-1", "worker", "last-tool", tool_call_id="z", conversation_id="conv-1")
+    )
+
+    stored = (
+        await repository.list_for_run("run-1", limit=2, kind=ToolInvocationKind.TOOL)
+        if scope == "run"
+        else await repository.list_for_conversation("conv-1", limit=2, kind=ToolInvocationKind.TOOL)
+    )
+
+    assert [record.call.tool_name for record in stored] == ["first-tool", "last-tool"]
+
+
+async def test_limit_must_be_positive(repository: ToolUsageRepository) -> None:
+    with pytest.raises(ValueError, match="limit must be positive"):
+        await repository.list_for_run("run-1", limit=0)

--- a/tests/tool_usage/test_repository_contract.py
+++ b/tests/tool_usage/test_repository_contract.py
@@ -1,0 +1,204 @@
+"""One behavioral contract, two persistence backends.
+
+Every consumer of ``ToolUsageRepository`` — tracker, context provider, run
+trace — depends on these guarantees and nothing else, so an adapter that passes
+here is substitutable (Liskov) for the one the engine ships with.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from agent_engine.tool_usage.repository import ToolUsageRepository
+from tests.tool_usage.adapters import SqliteToolUsageRepository
+
+
+def usage(
+    run_id: str,
+    agent_id: str,
+    tool_name: str,
+    *,
+    tool_call_id: str | None = None,
+    conversation_id: str | None = None,
+    status: ToolInvocationStatus = ToolInvocationStatus.SUCCEEDED,
+    error: str | None = None,
+) -> ToolInvocationRecord:
+    return ToolInvocationRecord(
+        call=ToolCallIdentity(
+            run_id=run_id,
+            agent_id=agent_id,
+            agent_path=f"root/{agent_id}",
+            tool_call_id=tool_call_id or f"{agent_id}:{tool_name}",
+            tool_name=tool_name,
+            conversation_id=conversation_id,
+        ),
+        status=status,
+        error=error,
+    )
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+async def repository(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> AsyncIterator[ToolUsageRepository]:
+    if request.param == "memory":
+        yield InMemoryToolUsageRepository()
+        return
+    sqlite_repository = SqliteToolUsageRepository(tmp_path / "usage.db")
+    await sqlite_repository.setup()
+    yield sqlite_repository
+
+
+async def test_implements_the_repository_protocol(repository: ToolUsageRepository) -> None:
+    assert isinstance(repository, ToolUsageRepository)
+
+
+async def test_records_are_grouped_by_run_and_kept_in_call_order(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(usage("run-1", "planner", "github.search"))
+    await repository.record(usage("run-1", "developer", "github.get_file"))
+
+    stored = await repository.list_for_run("run-1")
+
+    assert [(r.call.agent_id, r.call.tool_name) for r in stored] == [
+        ("planner", "github.search"),
+        ("developer", "github.get_file"),
+    ]
+
+
+async def test_runs_are_isolated(repository: ToolUsageRepository) -> None:
+    await repository.record(usage("run-1", "planner", "github.search"))
+    await repository.record(usage("run-2", "planner", "context7.query"))
+
+    assert [r.call.tool_name for r in await repository.list_for_run("run-1")] == ["github.search"]
+    assert [r.call.tool_name for r in await repository.list_for_run("run-2")] == ["context7.query"]
+
+
+async def test_unknown_run_has_no_records(repository: ToolUsageRepository) -> None:
+    assert list(await repository.list_for_run("never-ran")) == []
+
+
+async def test_a_conversation_spans_the_runs_it_contains(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(usage("run-1", "planner", "github.search", conversation_id="conv-1"))
+    await repository.record(usage("run-2", "developer", "deploy", conversation_id="conv-1"))
+    await repository.record(usage("run-3", "planner", "other", conversation_id="conv-2"))
+
+    stored = await repository.list_for_conversation("conv-1")
+
+    assert [(r.call.run_id, r.call.tool_name) for r in stored] == [
+        ("run-1", "github.search"),
+        ("run-2", "deploy"),
+    ]
+
+
+async def test_unknown_conversation_has_no_records(repository: ToolUsageRepository) -> None:
+    assert list(await repository.list_for_conversation("never-chatted")) == []
+
+
+async def test_a_record_without_a_conversation_is_reachable_by_run_only(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(usage("run-1", "planner", "github.search"))
+
+    assert len(await repository.list_for_run("run-1")) == 1
+    assert list(await repository.list_for_conversation("conv-1")) == []
+
+
+async def test_an_updated_record_keeps_its_place_in_the_conversation(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(
+        usage("run-1", "planner", "first", tool_call_id="a", conversation_id="conv-1")
+    )
+    await repository.record(
+        usage("run-2", "developer", "second", tool_call_id="b", conversation_id="conv-1")
+    )
+    await repository.record(
+        usage(
+            "run-1",
+            "planner",
+            "first",
+            tool_call_id="a",
+            conversation_id="conv-1",
+            status=ToolInvocationStatus.FAILED,
+        )
+    )
+
+    stored = await repository.list_for_conversation("conv-1")
+
+    assert [(r.call.tool_name, r.status.value) for r in stored] == [
+        ("first", "failed"),
+        ("second", "succeeded"),
+    ]
+
+
+async def test_same_tool_from_two_agents_keeps_both_attributions(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(usage("run-1", "developer", "github.get_file"))
+    await repository.record(usage("run-1", "reviewer", "github.get_file"))
+
+    stored = await repository.list_for_run("run-1")
+
+    assert {r.call.agent_id for r in stored} == {"developer", "reviewer"}
+    assert len(stored) == 2
+
+
+async def test_recording_the_same_invocation_twice_updates_it_in_place(
+    repository: ToolUsageRepository,
+) -> None:
+    call_id = "call-abc"
+    await repository.record(usage("run-1", "developer", "deploy", tool_call_id=call_id))
+    await repository.record(
+        usage(
+            "run-1",
+            "developer",
+            "deploy",
+            tool_call_id=call_id,
+            status=ToolInvocationStatus.FAILED,
+            error="boom",
+        )
+    )
+
+    stored = await repository.list_for_run("run-1")
+
+    assert len(stored) == 1
+    assert stored[0].status is ToolInvocationStatus.FAILED
+    assert stored[0].error == "boom"
+
+
+async def test_concurrent_writes_do_not_lose_records(repository: ToolUsageRepository) -> None:
+    await asyncio.gather(
+        *(
+            repository.record(usage("run-1", f"agent-{i}", "tool", tool_call_id=f"call-{i}"))
+            for i in range(50)
+        )
+    )
+
+    stored = await repository.list_for_run("run-1")
+
+    assert len({r.call.tool_call_id for r in stored}) == 50
+
+
+async def test_listing_returns_a_snapshot_that_later_writes_do_not_change(
+    repository: ToolUsageRepository,
+) -> None:
+    await repository.record(usage("run-1", "planner", "github.search"))
+    snapshot = await repository.list_for_run("run-1")
+
+    await repository.record(usage("run-1", "developer", "github.get_file"))
+
+    assert len(snapshot) == 1

--- a/tests/tool_usage/test_tracker.py
+++ b/tests/tool_usage/test_tracker.py
@@ -1,0 +1,96 @@
+"""The tracker's job: one execution event in, one domain record out."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
+from agent_engine.tool_usage.models import (
+    ToolCallIdentity,
+    ToolInvocationRecord,
+    ToolInvocationStatus,
+)
+from agent_engine.tool_usage.tracker import ToolUsageTracker
+
+
+def call(agent_id: str = "developer", tool_name: str = "github.get_file") -> ToolCallIdentity:
+    return ToolCallIdentity(
+        run_id="run-1",
+        agent_id=agent_id,
+        agent_path=f"root/{agent_id}",
+        tool_call_id="call-abc",
+        tool_name=tool_name,
+        provider="mcp",
+        server_id="github",
+    )
+
+
+class BrokenRepository:
+    """A repository whose backend is down, for the degradation policies."""
+
+    async def record(self, record: ToolInvocationRecord) -> None:
+        raise RuntimeError("backend unreachable")
+
+    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
+        raise RuntimeError("backend unreachable")
+
+    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
+        raise RuntimeError("backend unreachable")
+
+
+@pytest.mark.parametrize(
+    ("record_call", "expected"),
+    [
+        (lambda t: t.record_success(call()), ToolInvocationStatus.SUCCEEDED),
+        (lambda t: t.record_denied(call()), ToolInvocationStatus.DENIED),
+    ],
+)
+async def test_outcomes_are_persisted_with_their_status(
+    record_call: Callable[[ToolUsageTracker], Awaitable[None]],
+    expected: ToolInvocationStatus,
+) -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await record_call(ToolUsageTracker(repository))
+
+    stored = await repository.list_for_run("run-1")
+    assert [r.status for r in stored] == [expected]
+
+
+async def test_failure_keeps_the_error_and_the_call_identity() -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await ToolUsageTracker(repository).record_failure(call(), error="connection refused")
+
+    stored = await repository.list_for_run("run-1")
+    assert stored[0].status is ToolInvocationStatus.FAILED
+    assert stored[0].error == "connection refused"
+    assert stored[0].call.agent_id == "developer"
+    assert stored[0].call.provider == "mcp"
+    assert stored[0].call.server_id == "github"
+
+
+async def test_error_text_is_bounded() -> None:
+    repository = InMemoryToolUsageRepository()
+
+    await ToolUsageTracker(repository).record_failure(call(), error="x" * 5_000)
+
+    stored = await repository.list_for_run("run-1")
+    assert stored[0].error is not None
+    assert len(stored[0].error) == 200
+
+
+async def test_a_repository_failure_never_breaks_the_tool_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tracker = ToolUsageTracker(BrokenRepository())
+
+    with caplog.at_level(logging.WARNING):
+        await tracker.record_success(call())
+
+    assert "tool usage not recorded" in caplog.text
+    fields = getattr(caplog.records[0], "fields", {})
+    assert fields["tool_call_id"] == "call-abc"

--- a/tests/tool_usage/test_tracker.py
+++ b/tests/tool_usage/test_tracker.py
@@ -10,6 +10,7 @@ import pytest
 from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
 from agent_engine.tool_usage.models import (
     ToolCallIdentity,
+    ToolInvocationKind,
     ToolInvocationRecord,
     ToolInvocationStatus,
 )
@@ -34,10 +35,22 @@ class BrokenRepository:
     async def record(self, record: ToolInvocationRecord) -> None:
         raise RuntimeError("backend unreachable")
 
-    async def list_for_run(self, run_id: str) -> tuple[ToolInvocationRecord, ...]:
+    async def list_for_run(
+        self,
+        run_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
         raise RuntimeError("backend unreachable")
 
-    async def list_for_conversation(self, conversation_id: str) -> tuple[ToolInvocationRecord, ...]:
+    async def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        limit: int | None = None,
+        kind: ToolInvocationKind | None = None,
+    ) -> tuple[ToolInvocationRecord, ...]:
         raise RuntimeError("backend unreachable")
 
 


### PR DESCRIPTION
## Shared tool usage across agents

Tool usage was collected in a Python list seeded from `GraphState["used_tools"]`,
merged upward by `OrchestratorNode` after each child returned, and handed back as a
state delta. That ownership model caused three problems:

- an agent could not see what another agent had already run, because the merge
  happened only *after* the child finished;
- nothing survived the run, so a later turn of the same conversation started blind;
- `AgentNode` owned persistence, approval, execution, hooks and tracking at once,
  and a distributed backend had nowhere to plug in.

### Approach

Execution metadata now has its own subsystem, `agent_engine/tool_usage/`, with the
repository as the source of truth. `GraphState["used_tools"]` is removed entirely.

```
Tool execution
      │
      ▼
ToolUsageTracker ──► ToolUsageRepository        (conversation → run → agent → tool call)
                            │
              ┌─────────────┴─────────────┐
              ▼                           ▼
   ToolUsageContextProvider        as_usage_records
   private model context           RunResult.used_tools
```

- **`ToolUsageRepository`** (Protocol, two read scopes + one write) persists one
  record per logical invocation, identified by `(run_id, tool_call_id)`. `record`
  is an upsert on that identity, so an approval resume updates rather than
  duplicates. Ships with a process-local adapter; the contract suite also runs
  against a SQLite adapter so a future Redis/PostgreSQL adapter has a behavioural
  target to meet.
- **`ToolUsageTracker`** writes outcomes (`succeeded` / `failed` / `denied`) and
  decides nothing else.
- **`ToolUsageContextProvider`** projects records into a private system-role block,
  re-read before *every* model turn, so a synthesis turn reflects what the children
  it just called actually did.
- **`ToolInvoker`** takes over the tool pipeline — identity, limits, approval gate,
  idempotency, provider execution, hooks, recording — leaving nodes with prompt
  building and the model loop. It is a move, not a second execution path.

Both leaf agents and orchestrators receive the context. Backend selection lives only
in `agent_manager/composition.py`.

### Design decisions worth reviewing

**Conversation *and* run scope.** Records carry both. A follow-up user message is a
new `run_id`, so conversation scope is what gives continuity across turns; run scope
keeps execution-level traceability and remains what `RunResult.used_tools` reports.

**The projection is not the record.** Only agent, tool name and status reach the
model — no arguments, results, ids, timestamps or error text. A trimmed record says
so rather than passing itself off as complete.

**Non-duplication.** An invocation the asking agent made in the run it is currently
executing is skipped while its own `AIMessage` + `ToolMessage` pair is in the turn —
the model already has it in full. The same agent's calls from an earlier run or node
entry *are* shown.

**`list_executed_tools`.** An orchestrator's children are bound to it as tools, so
asked "which tools have you run?" it named the child agent it had delegated to — and
kept doing so through four rounds of instruction and record wording, because from its
own tool list that answer is true. Orchestrators are now bound a read-only engine tool
that returns the executed tools from the repository, so the answer comes from data
rather than from an instruction the model can ignore. It is not approval-gated
(orchestrator-level tools never were), not counted against child-agent limits, and
not itself recorded. A configured child of that name wins.

**Failure semantics.** Recording is observability: a write failure is logged and
swallowed, so a metadata problem cannot fail a completed tool call. A *read* failure
on the explicit report is **not** swallowed — reporting "nothing has run" when the
record is unreadable would invite repeating an action that already took effect.

### Contract changes (ADR 0001)

- `GraphState["used_tools"]` removed. `RunResult.used_tools` keeps its shape for
  callers and is now projected from the repository.
- `ToolUsageStatus` gains `"denied"`. The HTTP/widget field is a free string.
- `LangGraphEngine.__init__` gains `tool_usage_repository` (defaults to in-memory).
- Orchestrators are bound `list_executed_tools`; child agents are described to their
  parent as delegations rather than actions.
- Two identical calls by one agent in one run now collapse to a single record — they
  are one logical invocation. The previous list appended twice.

### Human-in-the-Loop

Unchanged and verified: approve, deny, approve-for-this-session, suspension and
resume all behave as before. One logical invocation leaves one record across a
suspend and its replay, with the same `run_id`, agent and `tool_call_id` as the
`ApprovalRecord`. Approval decides *whether* a call runs; tracking records *what
happened to it* — separate subsystems sharing identifiers, not responsibilities.

### Testing

765 tests pass (`make check` clean). New coverage: repository contract against two
independent backends, cross-agent and cross-turn awareness, per-agent attribution,
run/conversation isolation, context freshness between model turns, delegation never
offered as a tool, the reporting tool's content and failure mode, and the HITM
lifecycle. Also pinned: the record never becomes conversation history, never reaches
the answer, and never repeats what the current turn already shows the model.