### PR TITLE
fix(runtime): scope duplicate-tool-call detection to one agent invocation

### DIFF
--- a/src/agent_engine/engine/langgraph/helpers.py
+++ b/src/agent_engine/engine/langgraph/helpers.py
@@ -102,7 +102,7 @@ async def run_tool_loop(
             logger.debug("[%s] ← tool_call: %s(%s)", node_path, tc["name"], tc["args"])
             content = await invoke_tool(tc)
             logger.debug("[%s] → tool_result[%s]: %s", node_path, tc["name"], content[:300])
-            messages.append(ToolMessage(content=content, tool_call_id=tc["id"]))
+            messages.append(ToolMessage(content=content, tool_call_id=tc["id"], name=tc["name"]))
         response = await invoke_model(model, messages, state)
     return response
 

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import time
+import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
@@ -38,6 +39,7 @@ from agent_engine.runtime.execution import (
     ExecutionLimitExceeded,
     blocked_message,
     current_execution,
+    current_invocation,
     log_limit,
 )
 from agent_engine.runtime.hooks import (
@@ -187,26 +189,33 @@ class AgentNode:
 
     async def _run(self, system_prompt: str, state: GraphState) -> GraphState:
         """Drive the model + tool loop until the model stops requesting tools."""
-        user_msg: str = state.get("message", "")
-        messages = model_context(system_prompt, state.get("history", []), user_msg)
-        logger.debug("[%s] system:\n%s", self._node_path, system_prompt)
-        logger.debug("[%s] → user: %s", self._node_path, user_msg)
+        # One id for this activation of this agent, so duplicate-call detection
+        # covers this conversation only — never a sibling delegation to the same
+        # agent, which starts fresh and shares nothing with this one.
+        invocation_reset = current_invocation.set(uuid.uuid4().hex)
+        try:
+            user_msg: str = state.get("message", "")
+            messages = model_context(system_prompt, state.get("history", []), user_msg)
+            logger.debug("[%s] system:\n%s", self._node_path, system_prompt)
+            logger.debug("[%s] → user: %s", self._node_path, user_msg)
 
-        visited: list[str] = [*state.get("visited", []), self._node_path]
-        emit_route(state, tuple(visited))
+            visited: list[str] = [*state.get("visited", []), self._node_path]
+            emit_route(state, tuple(visited))
 
-        used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
+            used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
 
-        async def invoke_tool(tc: dict[str, Any]) -> str:
-            return await self._invoke_tool(tc, used_tools)
+            async def invoke_tool(tc: dict[str, Any]) -> str:
+                return await self._invoke_tool(tc, used_tools)
 
-        response = await run_tool_loop(
-            self._bound_model, messages, state, self._node_path, invoke_tool
-        )
-        answer = as_text(response.content)
-        logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
+            response = await run_tool_loop(
+                self._bound_model, messages, state, self._node_path, invoke_tool
+            )
+            answer = as_text(response.content)
+            logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
 
-        return {"visited": visited, "answer": answer, "used_tools": used_tools}
+            return {"visited": visited, "answer": answer, "used_tools": used_tools}
+        finally:
+            current_invocation.reset(invocation_reset)
 
     async def _invoke_tool(self, tc: dict[str, Any], used_tools: list[ToolUsageRecord]) -> str:
         """Resolve, gate, and execute one tool call for both local and MCP tools.
@@ -606,47 +615,54 @@ class OrchestratorNode:
         state: GraphState,
     ) -> GraphState:
         """Drive the orchestrator LLM tool loop and return the synthesised answer."""
-        visited: list[str] = [*state.get("visited", []), self._node_path]
-        used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
+        # One id for this activation of this orchestrator — see AgentNode._run.
+        invocation_reset = current_invocation.set(uuid.uuid4().hex)
+        try:
+            visited: list[str] = [*state.get("visited", []), self._node_path]
+            used_tools: list[ToolUsageRecord] = list(state.get("used_tools", []))
 
-        # Build tools here so they share the live `visited` / `used_tools` lists.
-        tools = [self._make_tool(e, state, visited, used_tools) for e in candidates]
-        bound_model = self._model.bind_tools(tools) if tools else self._model
-        if self._fallback_model is not None:
-            bound_fallback = (
-                self._fallback_model.bind_tools(tools) if tools else self._fallback_model
+            # Build tools here so they share the live `visited` / `used_tools` lists.
+            tools = [self._make_tool(e, state, visited, used_tools) for e in candidates]
+            bound_model = self._model.bind_tools(tools) if tools else self._model
+            if self._fallback_model is not None:
+                bound_fallback = (
+                    self._fallback_model.bind_tools(tools) if tools else self._fallback_model
+                )
+                bound_model = bound_model.with_fallbacks(
+                    [bound_fallback], exceptions_to_handle=(Exception,)
+                )
+            tool_by_name = {t.name: t for t in tools}
+
+            user_msg: str = state.get("message", "")
+            messages = model_context(system_prompt, state.get("history", []), user_msg)
+            logger.debug(
+                "[%s] system:\n%s\ntools: %s", self._node_path, system_prompt, list(tool_by_name)
             )
-            bound_model = bound_model.with_fallbacks(
-                [bound_fallback], exceptions_to_handle=(Exception,)
+            logger.debug("[%s] → user: %s", self._node_path, user_msg)
+
+            emit_route(state, tuple(visited))
+
+            async def invoke_tool(tc: dict[str, Any]) -> str:
+                tool = tool_by_name.get(tc["name"])
+                if tool is None:
+                    return f"Unknown agent: {tc['name']}"
+                # Limit orchestrator→child-agent invocations. A blocked call returns a
+                # controlled message instead of running the child.
+                limiter = current_execution.get()
+                if limiter is not None:
+                    try:
+                        limiter.register_child_call(self._node_path, tc["name"])
+                    except ExecutionLimitExceeded as exc:
+                        log_limit(exc)
+                        return blocked_message(exc)
+                return cast(str, await tool.ainvoke(tc["args"]))
+
+            response = await run_tool_loop(
+                bound_model, messages, state, self._node_path, invoke_tool
             )
-        tool_by_name = {t.name: t for t in tools}
+            answer = as_text(response.content)
+            logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
 
-        user_msg: str = state.get("message", "")
-        messages = model_context(system_prompt, state.get("history", []), user_msg)
-        logger.debug(
-            "[%s] system:\n%s\ntools: %s", self._node_path, system_prompt, list(tool_by_name)
-        )
-        logger.debug("[%s] → user: %s", self._node_path, user_msg)
-
-        emit_route(state, tuple(visited))
-
-        async def invoke_tool(tc: dict[str, Any]) -> str:
-            tool = tool_by_name.get(tc["name"])
-            if tool is None:
-                return f"Unknown agent: {tc['name']}"
-            # Limit orchestrator→child-agent invocations. A blocked call returns a
-            # controlled message instead of running the child.
-            limiter = current_execution.get()
-            if limiter is not None:
-                try:
-                    limiter.register_child_call(self._node_path, tc["name"])
-                except ExecutionLimitExceeded as exc:
-                    log_limit(exc)
-                    return blocked_message(exc)
-            return cast(str, await tool.ainvoke(tc["args"]))
-
-        response = await run_tool_loop(bound_model, messages, state, self._node_path, invoke_tool)
-        answer = as_text(response.content)
-        logger.debug("[%s] ← response: %s", self._node_path, answer[:300])
-
-        return {"visited": visited, "answer": answer, "used_tools": used_tools}
+            return {"visited": visited, "answer": answer, "used_tools": used_tools}
+        finally:
+            current_invocation.reset(invocation_reset)

--- a/src/agent_engine/runtime/execution.py
+++ b/src/agent_engine/runtime/execution.py
@@ -87,8 +87,17 @@ class ExecutionLimiter:
 
     def register_tool_call(self, agent_id: str, tool_name: str, args: object) -> None:
         """Authorize one local/MCP tool call. Raises on a blocked duplicate, the
-        per-run total, or the per-agent limit. Blocked calls are NOT counted."""
-        signature = _signature(agent_id, tool_name, args)
+        per-run total, or the per-agent limit. Blocked calls are NOT counted.
+
+        Duplicate detection is scoped to the current invocation (see
+        ``current_invocation``), not the whole run: two sibling activations of
+        the same agent — e.g. an orchestrator delegating to ``user_management``
+        twice for unrelated reasons — start with a fresh, empty conversation
+        each time and cannot see each other's tool results. Blocking the second
+        one and telling it to "use the previous result" would refer to a result
+        it never received.
+        """
+        signature = _signature(current_invocation.get(), agent_id, tool_name, args)
         if not self._policy.allow_duplicate_tool_calls and signature in self._state.seen_signatures:
             raise ExecutionLimitExceeded(
                 "duplicate_tool_call", 1, 0, agent_id=agent_id, tool_name=tool_name
@@ -137,9 +146,19 @@ current_execution: ContextVar[ExecutionLimiter | None] = ContextVar(
     "current_execution", default=None
 )
 
+#: Identifies one node activation (one agent or orchestrator running its own
+#: model/tool loop) within the run. Set once at the top of that node's ``_run``
+#: and left untouched for every tool call inside it, so an agent's own repeated
+#: call to the same tool is still caught. A sibling activation of the same
+#: agent — a fresh delegation with no memory of the first — gets its own id and
+#: is never confused with it, whether the two run sequentially or, once
+#: fan-out lands, concurrently: each concurrent task gets an isolated copy of
+#: this context var, so parallel siblings never see each other's id.
+current_invocation: ContextVar[str | None] = ContextVar("current_invocation", default=None)
 
-def _signature(agent_id: str, tool_name: str, args: object) -> str:
-    """Opaque, stable signature for duplicate detection: agent + tool + args.
+
+def _signature(invocation_id: str | None, agent_id: str, tool_name: str, args: object) -> str:
+    """Opaque, stable signature for duplicate detection: invocation + agent + tool + args.
 
     Arguments are serialized deterministically but the result is only ever stored
     in a set and compared — never logged."""
@@ -147,7 +166,7 @@ def _signature(agent_id: str, tool_name: str, args: object) -> str:
         serialized = json.dumps(args, sort_keys=True, default=str)
     except (TypeError, ValueError):
         serialized = repr(args)
-    return f"{agent_id}\x1f{tool_name}\x1f{serialized}"
+    return f"{invocation_id}\x1f{agent_id}\x1f{tool_name}\x1f{serialized}"
 
 
 def log_limit(exc: ExecutionLimitExceeded) -> None:

--- a/tests/runtime/test_execution_limits.py
+++ b/tests/runtime/test_execution_limits.py
@@ -9,7 +9,11 @@ import pytest
 from agent_engine.core.execution import ExecutionPolicy
 from agent_engine.parsers.errors import ParseError
 from agent_engine.parsers.yaml.parser import YAMLParser
-from agent_engine.runtime.execution import ExecutionLimiter, ExecutionLimitExceeded
+from agent_engine.runtime.execution import (
+    ExecutionLimiter,
+    ExecutionLimitExceeded,
+    current_invocation,
+)
 
 _BASE = "system: {name: t}\nagents: {a: {description: d}}\ngraph: {a: }\n"
 
@@ -118,6 +122,39 @@ def test_duplicates_allowed_when_policy_permits() -> None:
     lim.register_tool_call("a", "t", {"x": 1})
     lim.register_tool_call("a", "t", {"x": 1})  # no raise
     assert lim.state.total_tool_calls == 2
+
+
+def test_duplicate_detection_scoped_to_invocation_not_agent() -> None:
+    """Two fresh activations of the same agent (e.g. an orchestrator delegating
+    to `user_management` twice for unrelated reasons) must not collide just
+    because they share an agent id: each starts a conversation with no memory
+    of the other, so a repeat call is legitimate in each, not a duplicate."""
+    lim = ExecutionLimiter(ExecutionPolicy(allow_duplicate_tool_calls=False, max_tool_calls=99))
+
+    reset_a = current_invocation.set("invocation-a")
+    lim.register_tool_call("user_management", "all_user_details", {})
+    current_invocation.reset(reset_a)
+
+    reset_b = current_invocation.set("invocation-b")
+    lim.register_tool_call("user_management", "all_user_details", {})  # must not raise
+    current_invocation.reset(reset_b)
+
+    assert lim.state.total_tool_calls == 2
+
+
+def test_duplicate_still_blocked_within_same_invocation() -> None:
+    """The guard's real job — stopping one agent from looping on the same call
+    within its own conversation — must still hold."""
+    lim = ExecutionLimiter(ExecutionPolicy(allow_duplicate_tool_calls=False, max_tool_calls=99))
+
+    reset = current_invocation.set("invocation-a")
+    try:
+        lim.register_tool_call("user_management", "all_user_details", {})
+        with pytest.raises(ExecutionLimitExceeded) as e:
+            lim.register_tool_call("user_management", "all_user_details", {})
+        assert e.value.limit_name == "duplicate_tool_call"
+    finally:
+        current_invocation.reset(reset)
 
 
 def test_child_agent_calls_capped() -> None:


### PR DESCRIPTION
## Summary
- Two sibling delegations to the same agent shared a single run-wide dedup signature, so a fresh delegation could collide with an unrelated earlier call and get blocked with a misleading "use the previous result" message it had no way to see.
- Add a `current_invocation` ContextVar set once per `AgentNode`/`OrchestratorNode` activation, folded into the dedup signature, so detection is scoped to one agent's own conversation instead of the whole run. A real repeat within the same invocation is still blocked.
- Attach the tool name to `ToolMessage` alongside `tool_call_id` so traces are self-descriptive.

## Context
Diagnosed from production Langfuse traces (Open WebUI deployment on this engine) showing repeated re-listing / re-confirmation loops: an orchestrator delegating twice to `user_management` in one run got its second, unrelated call blocked as a "duplicate," and the model was told to reuse a result it had never received.

## Test plan
- [x] `pytest tests/runtime/test_execution_limits.py` — new tests cover: sibling invocations of the same agent no longer collide; a real repeat within one invocation is still blocked.
- [x] `pytest tests/ -k "node or orchestrator or engine or execution"` — no regressions.
- [ ] Manual verification against the production trace scenario (delegate → sibling delegate to same agent → no false block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)