### PR TITLE
feat(cli): handle tool approvals in remote chat

### DIFF
--- a/src/agentctl/chat.py
+++ b/src/agentctl/chat.py
@@ -330,7 +330,18 @@ async def run_remote_chat(
         echo(BANNER, err=True)
         echo(f"Session: {headers[SESSION_HEADER]}", err=True)
         for question in _iter_questions(read_line):
-            await _answer_remote(client, base, question, stream=stream, headers=headers, echo=echo)
+            try:
+                await _answer_remote(
+                    client,
+                    base,
+                    question,
+                    stream=stream,
+                    headers=headers,
+                    read_line=read_line,
+                    echo=echo,
+                )
+            except _StopChat:
+                return
     finally:
         if owns_client:
             await client.aclose()
@@ -343,6 +354,7 @@ async def _answer_remote(
     *,
     stream: bool,
     headers: dict[str, str],
+    read_line: ReadLine,
     echo: Callable[..., None],
 ) -> None:
     """Send one question to the server. Network/server errors never kill the loop."""
@@ -350,9 +362,13 @@ async def _answer_remote(
 
     try:
         if stream:
-            await _remote_stream(client, base, question, headers=headers, echo=echo)
+            await _remote_stream(
+                client, base, question, headers=headers, read_line=read_line, echo=echo
+            )
         else:
-            await _remote_invoke(client, base, question, headers=headers, echo=echo)
+            await _remote_invoke(
+                client, base, question, headers=headers, read_line=read_line, echo=echo
+            )
     except httpx.HTTPError as exc:
         echo(f"✗ request failed: {exc}", err=True)
 
@@ -363,6 +379,7 @@ async def _remote_invoke(
     question: str,
     *,
     headers: dict[str, str],
+    read_line: ReadLine,
     echo: Callable[..., None],
 ) -> None:
     resp = await client.post(f"{base}/invoke", json={"message": question}, headers=headers)
@@ -370,7 +387,49 @@ async def _remote_invoke(
         echo(f"✗ server error {resp.status_code}: {_error_detail(resp)}", err=True)
         return
     data = resp.json()
+    if data.get("status") == "pending_approval":
+        data = await _resolve_remote_approvals(
+            client, base, headers, data, read_line=read_line, echo=echo
+        )
+        if data is None:
+            return
     echo(f"{ANSWER_PREFIX}{data.get('answer', '')}")
+
+
+async def _resolve_remote_approvals(
+    client: httpx.AsyncClient,
+    base: str,
+    headers: dict[str, str],
+    data: dict[str, object],
+    *,
+    read_line: ReadLine,
+    echo: Callable[..., None],
+) -> dict[str, object] | None:
+    """Prompt and resume until a run completes or stops requesting approvals.
+
+    Mirrors ``_resolve_local_approvals``'s loop shape, but over HTTP: every
+    decision is sent to ``/decision`` (not ``/approve``/``/reject``), since it
+    accepts all three ``ApprovalDecision`` values with one request shape.
+    Returns ``None`` (instead of raising) on a non-200 response, consistent
+    with how ``_answer_remote`` already treats other HTTP errors — the caller
+    should treat that as "nothing more to print" and move on.
+    """
+    while data.get("status") == "pending_approval":
+        pending_raw = data.get("pending_approval")
+        if not isinstance(pending_raw, dict):
+            raise RuntimeError("The server paused for approval without approval details.")
+        pending = PendingApproval(**pending_raw)
+        decision = _prompt_for_approval(pending, read_line=read_line, echo=echo)
+        resp = await client.post(
+            f"{base}/runs/{pending.run_id}/approvals/{pending.approval_id}/decision",
+            json={"decision": decision.value},
+            headers=headers,
+        )
+        if resp.status_code != 200:
+            echo(f"✗ server error {resp.status_code}: {_error_detail(resp)}", err=True)
+            return None
+        data = resp.json()
+    return data
 
 
 async def _remote_stream(
@@ -379,10 +438,12 @@ async def _remote_stream(
     question: str,
     *,
     headers: dict[str, str],
+    read_line: ReadLine,
     echo: Callable[..., None],
 ) -> None:
     sys.stdout.write(ANSWER_PREFIX)
     sys.stdout.flush()
+    pending: PendingApproval | None = None
     async with client.stream(
         "POST", f"{base}/stream", json={"message": question}, headers=headers
     ) as resp:
@@ -398,11 +459,37 @@ async def _remote_stream(
             if payload.get("type") == "answer_delta" and payload.get("content"):
                 sys.stdout.write(payload["content"])
                 sys.stdout.flush()
+            elif payload.get("type") == "pending_approval":
+                pending = _pending_approval_from_stream_event(payload)
             elif payload.get("type") == "error":
                 sys.stdout.write("\n")
                 echo(f"✗ {payload.get('detail', 'stream error')}", err=True)
                 return
     sys.stdout.write("\n")
+
+    if pending is None:
+        return
+    data: dict[str, object] = {"status": "pending_approval", "pending_approval": pending.__dict__}
+    resolved = await _resolve_remote_approvals(
+        client, base, headers, data, read_line=read_line, echo=echo
+    )
+    if resolved is not None:
+        echo(f"{ANSWER_PREFIX}{resolved.get('answer', '')}")
+
+
+def _pending_approval_from_stream_event(payload: dict[str, object]) -> PendingApproval:
+    """The SSE ``pending_approval`` event carries the same fields flat (not
+    nested), unlike the ``/invoke``/``/decision`` JSON response shape."""
+    return PendingApproval(
+        run_id=str(payload["run_id"]),
+        approval_id=str(payload["approval_id"]),
+        agent_id=str(payload["agent_id"]),
+        tool_name=str(payload["tool_name"]),
+        description=str(payload["description"]),
+        provider=payload.get("provider") or "local",  # type: ignore[arg-type]
+        server_id=payload.get("server_id"),  # type: ignore[arg-type]
+        arguments=payload.get("arguments") or {},  # type: ignore[arg-type]
+    )
 
 
 def _error_detail(resp: httpx.Response) -> str:

--- a/tests/cli/test_chat_command.py
+++ b/tests/cli/test_chat_command.py
@@ -633,3 +633,240 @@ async def test_remote_network_error_does_not_kill_loop() -> None:
             client=client,
         )
     assert any("request failed" in line for line in echo.lines)
+
+
+# ---------------------------------------------------------------------------
+# remote mode: human approval and resume
+# ---------------------------------------------------------------------------
+
+
+def _pending_json(pending: PendingApproval) -> dict[str, object]:
+    return {
+        "run_id": pending.run_id,
+        "approval_id": pending.approval_id,
+        "agent_id": pending.agent_id,
+        "tool_name": pending.tool_name,
+        "description": pending.description,
+        "provider": pending.provider,
+        "server_id": pending.server_id,
+        "arguments": pending.arguments,
+    }
+
+
+async def test_remote_chat_prompts_for_approval_and_resumes_allow_once() -> None:
+    pending = pending_approval()
+    decisions_sent: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/invoke":
+            return httpx.Response(
+                200,
+                json={
+                    "answer": "",
+                    "status": "pending_approval",
+                    "pending_approval": _pending_json(pending),
+                },
+            )
+        decisions_sent.append((request.url.path, json.loads(request.content)))
+        return httpx.Response(200, json={"answer": "architecture", "status": "completed"})
+
+    echo = CollectingEcho()
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            read_line=scripted_reader(["question", "o"]),
+            echo=echo,
+            client=client,
+        )
+
+    assert decisions_sent == [
+        (
+            f"/runs/{pending.run_id}/approvals/{pending.approval_id}/decision",
+            {"decision": "allow_once"},
+        )
+    ]
+    assert "  Tool      : deepwiki.read_docs (mcp)" in echo.lines
+    assert "Agent > architecture" in echo.lines
+
+
+async def test_remote_chat_resumes_with_allow_for_session() -> None:
+    pending = pending_approval()
+    decisions_sent: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/invoke":
+            return httpx.Response(
+                200,
+                json={
+                    "answer": "",
+                    "status": "pending_approval",
+                    "pending_approval": _pending_json(pending),
+                },
+            )
+        decisions_sent.append(json.loads(request.content))
+        return httpx.Response(200, json={"answer": "done", "status": "completed"})
+
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            read_line=scripted_reader(["question", "s"]),
+            echo=CollectingEcho(),
+            client=client,
+        )
+
+    assert decisions_sent == [{"decision": "allow_for_session"}]
+
+
+async def test_remote_chat_resumes_with_deny() -> None:
+    pending = pending_approval()
+    decisions_sent: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/invoke":
+            return httpx.Response(
+                200,
+                json={
+                    "answer": "",
+                    "status": "pending_approval",
+                    "pending_approval": _pending_json(pending),
+                },
+            )
+        decisions_sent.append(json.loads(request.content))
+        return httpx.Response(200, json={"answer": "denied", "status": "completed"})
+
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            read_line=scripted_reader(["question", "d"]),
+            echo=CollectingEcho(),
+            client=client,
+        )
+
+    assert decisions_sent == [{"decision": "deny"}]
+
+
+async def test_remote_chat_handles_multiple_approvals_in_one_run() -> None:
+    first = pending_approval()
+    second = pending_approval(approval_id="approval-2", tool_name="read_page")
+    responses = iter(
+        [
+            {"answer": "", "status": "pending_approval", "pending_approval": _pending_json(first)},
+            {"answer": "", "status": "pending_approval", "pending_approval": _pending_json(second)},
+            {"answer": "complete", "status": "completed"},
+        ]
+    )
+    seen: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.url.path, json.loads(request.content)))
+        return httpx.Response(200, json=next(responses))
+
+    echo = CollectingEcho()
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            # Only "question" is a real user message; "o"/"d" must be consumed
+            # as approval-prompt answers, not sent as separate /invoke calls.
+            read_line=scripted_reader(["question", "o", "d"]),
+            echo=echo,
+            client=client,
+        )
+
+    assert [path for path, _ in seen] == [
+        "/invoke",
+        f"/runs/{first.run_id}/approvals/{first.approval_id}/decision",
+        f"/runs/{second.run_id}/approvals/{second.approval_id}/decision",
+    ]
+    assert [body["decision"] for _, body in seen[1:]] == ["allow_once", "deny"]
+    assert "Agent > complete" in echo.lines
+
+
+async def test_remote_chat_stops_when_approval_input_ends() -> None:
+    pending = pending_approval()
+    decision_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal decision_calls
+        if request.url.path == "/invoke":
+            return httpx.Response(
+                200,
+                json={
+                    "answer": "",
+                    "status": "pending_approval",
+                    "pending_approval": _pending_json(pending),
+                },
+            )
+        decision_calls += 1
+        return httpx.Response(200, json={"answer": "should not get here", "status": "completed"})
+
+    echo = CollectingEcho()
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            read_line=scripted_reader(["question"]),  # EOF right at the approval prompt
+            echo=echo,
+            client=client,
+        )
+
+    assert decision_calls == 0
+    assert not any(line.startswith("Agent > ") for line in echo.lines)
+
+
+async def test_remote_stream_prompts_and_resumes_pending_approval() -> None:
+    pending = pending_approval()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/stream":
+            payload = {"type": "pending_approval", **_pending_json(pending)}
+            sse = f"data: {json.dumps(payload)}\n\n"
+            return httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+        return httpx.Response(200, json={"answer": "stream resumed", "status": "completed"})
+
+    echo = CollectingEcho()
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=True,
+            read_line=scripted_reader(["question", "allow once"]),
+            echo=echo,
+            client=client,
+        )
+
+    assert "Agent > stream resumed" in echo.lines
+
+
+async def test_remote_decision_error_does_not_kill_loop() -> None:
+    pending = pending_approval()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/invoke":
+            body = json.loads(request.content)
+            if body["message"] == "first":
+                return httpx.Response(
+                    200,
+                    json={
+                        "answer": "",
+                        "status": "pending_approval",
+                        "pending_approval": _pending_json(pending),
+                    },
+                )
+            return httpx.Response(200, json={"answer": "second works", "status": "completed"})
+        return httpx.Response(404, json={"detail": "run not found"})
+
+    echo = CollectingEcho()
+    async with _mock_client(handler) as client:
+        await run_remote_chat(
+            "http://srv",
+            stream=False,
+            read_line=scripted_reader(["first", "o", "second"]),
+            echo=echo,
+            client=client,
+        )
+
+    assert any("server error 404" in line and "run not found" in line for line in echo.lines)
+    assert "Agent > second works" in echo.lines


### PR DESCRIPTION
Fixes #107.

Modifies `_remote_invoke` and `_remote_stream` and sets up a `_resolve_remote_approvals` function to handle pending approvals for `agentctl --url`. More details have been provided in the issue.
Added remote-mode approval tests in `tests/cli/test_chat_command.py`. Verified that the tests fail without the fix and pass with it.

_Note: Different from #29, which is about agent_manager/the widget lacking approval support entirely. This issue is specifically about agentctl._