### PR TITLE
Feat/support cancel interrupt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ vite/dist/
 coverage/
 test-results/
 
-# Local runtime SQLite database (default database_url)
+# Local runtime SQLite database (when explicitly configured)
 chat.db
 
 # =========================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ rendering, and the CLI (`validate`, `inspect`, `generate`, `run`, `serve`,
 Bedrock. Two HTTP API layers exist: a thin `agent_engine` API (`/invoke`,
 `/stream`), started by `agentctl serve` (default port `8090`) — stateless, no
 persistence, no web client — and `agent_manager` — a conversation lifecycle
-service built on top of it with SQLite-backed persistence, SSE streaming, and
-the official React web client, started by the separate `agent-manager`
-console script (default port `8100`). `agentctl chat` is a separate, ephemeral
+service built on top of it with process-local storage by default, opt-in
+SQLite/Postgres persistence, SSE streaming, and the official React web client,
+started by the separate `agent-manager` console script (default port `8100`).
+`agentctl chat` is a separate, ephemeral
 developer console that persists nothing (see `docs/ARCHITECTURE.md` §14 for
 detail). Basic observability
 (structured logging plus a Langfuse callback provider) is wired in. A
@@ -168,7 +169,7 @@ split, not the original plan:
     ├── agent_manager/         ← conversation/session lifecycle service, built on agent_engine
     │   ├── domain/                 conversation/message/session models + repository contract
     │   ├── application/            ConversationService (send/stream, prior-context assembly)
-    │   ├── infrastructure/persistence/  SQLite (default) + Alembic migrations
+    │   ├── infrastructure/persistence/  memory default; optional SQL + Alembic
     │   └── api/                    FastAPI app: `/conversations` endpoints, SSE streaming,
     │                                official React web client (`api/static/widget/`)
     └── agentctl/              ← CLI: validate, inspect, generate, run, serve, chat

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,9 +66,8 @@ The long-term promise:
 > **implemented**. Model access supports Anthropic and Amazon Bedrock. Two
 > HTTP API layers exist: a thin stateless API directly over the engine
 > (`/invoke`, `/stream` in `agent_engine`) and a conversation-lifecycle service
-> built on top of it (`agent_manager`) with process-local storage by default,
-> opt-in SQLite/Postgres persistence, SSE streaming, and an embeddable JS/React
-> chat widget. Basic observability
+> built on top of it (`agent_manager`) with SQLite-backed persistence, SSE
+> streaming, and an embeddable JS/React chat widget. Basic observability
 > (structured logging + a Langfuse callback provider) is wired in, and a
 > `Dockerfile` provides a basic container image. The access plugin **is**
 > wired into child filtering, but the request-context gate that should feed it
@@ -154,8 +153,7 @@ Responsibilities:
   optional structured prior user/assistant turns supplied by its caller, and
   owns no conversation memory. The optional
   `agent_manager` layer sits in front of it and **does** own conversation
-  memory: it retains messages per conversation/session (process-local by
-  default, or persisted when a database URL is configured),
+  memory: it persists messages per conversation/session (SQLite by default),
   loads prior messages in order, passes them through the engine's typed history
   boundary, and exposes
   `/conversations` endpoints and SSE streaming
@@ -622,13 +620,12 @@ also what serves the embeddable chat widget. `agentctl chat` talks to neither
 server by default; in `--url` mode it talks to `agentctl serve`'s stateless
 `/invoke`/`/stream` API and does not persist anything.
 
-**Conversation storage (✅ done, not in the original task list):**
+**Conversation persistence (✅ done, not in the original task list):**
 `agent_manager` is a DDD-style service (`domain/`, `application/`,
 `infrastructure/persistence/`) providing `ConversationService` (send/stream,
-structured prior-context assembly, final-response storage), a process-local
-`MemoryRepository` by default, plus an opt-in `SqlRepository` with Alembic
-migrations and tables for conversations, messages, users, and sessions. It is
-wired into both `agentctl run`/`chat`
+structured prior-context assembly, final-response persistence), a SQLite-backed
+`SqlRepository` with Alembic migrations, and tables for conversations,
+messages, users, and sessions. It is wired into both `agentctl run`/`chat`
 (CLI) and the `agent_manager` API server. `agent_engine` has no dependency on
 `agent_manager`; the boundary is one-directional.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,8 +66,9 @@ The long-term promise:
 > **implemented**. Model access supports Anthropic and Amazon Bedrock. Two
 > HTTP API layers exist: a thin stateless API directly over the engine
 > (`/invoke`, `/stream` in `agent_engine`) and a conversation-lifecycle service
-> built on top of it (`agent_manager`) with SQLite-backed persistence, SSE
-> streaming, and an embeddable JS/React chat widget. Basic observability
+> built on top of it (`agent_manager`) with process-local storage by default,
+> opt-in SQLite/Postgres persistence, SSE streaming, and an embeddable JS/React
+> chat widget. Basic observability
 > (structured logging + a Langfuse callback provider) is wired in, and a
 > `Dockerfile` provides a basic container image. The access plugin **is**
 > wired into child filtering, but the request-context gate that should feed it
@@ -153,7 +154,8 @@ Responsibilities:
   optional structured prior user/assistant turns supplied by its caller, and
   owns no conversation memory. The optional
   `agent_manager` layer sits in front of it and **does** own conversation
-  memory: it persists messages per conversation/session (SQLite by default),
+  memory: it retains messages per conversation/session (process-local by
+  default, or persisted when a database URL is configured),
   loads prior messages in order, passes them through the engine's typed history
   boundary, and exposes
   `/conversations` endpoints and SSE streaming
@@ -620,12 +622,13 @@ also what serves the embeddable chat widget. `agentctl chat` talks to neither
 server by default; in `--url` mode it talks to `agentctl serve`'s stateless
 `/invoke`/`/stream` API and does not persist anything.
 
-**Conversation persistence (✅ done, not in the original task list):**
+**Conversation storage (✅ done, not in the original task list):**
 `agent_manager` is a DDD-style service (`domain/`, `application/`,
 `infrastructure/persistence/`) providing `ConversationService` (send/stream,
-structured prior-context assembly, final-response persistence), a SQLite-backed
-`SqlRepository` with Alembic migrations, and tables for conversations,
-messages, users, and sessions. It is wired into both `agentctl run`/`chat`
+structured prior-context assembly, final-response storage), a process-local
+`MemoryRepository` by default, plus an opt-in `SqlRepository` with Alembic
+migrations and tables for conversations, messages, users, and sessions. It is
+wired into both `agentctl run`/`chat`
 (CLI) and the `agent_manager` API server. `agent_engine` has no dependency on
 `agent_manager`; the boundary is one-directional.
 

--- a/docs/HUMAN_IN_THE_LOOP.md
+++ b/docs/HUMAN_IN_THE_LOOP.md
@@ -197,7 +197,8 @@ When a call requires approval, the `ApprovalProvider` for this runtime
    `status="pending_approval"` and a sanitized `pending_approval` payload. **No
    tool ran; for MCP, no `tools/call` was sent.**
 
-To resume, `Engine.resume(run_id, approval_id, decision)`:
+To resume, `Engine.resume(run_id, approval_id, decision)` or the streamed
+`Engine.resume_stream(...)` capability:
 
 > **Compatibility note:** Session-bound approvals now fail closed. Callers of
 > `resume(...)` and the approval HTTP endpoints must propagate the same session
@@ -206,7 +207,8 @@ To resume, `Engine.resume(run_id, approval_id, decision)`:
 
 1. **Atomically claims** the approval (`PENDING → RESUMING`) — exactly one caller
    wins (see §7).
-2. Resumes the **same** LangGraph thread from its checkpoint via
+2. Moves the run through `RESUMING → RUNNING` and resumes the **same** LangGraph
+   thread from its checkpoint via
    `Command(resume={"decision": ...})`. The graph is not restarted, the agent is
    not re-selected, and intent/planning are not re-run.
 3. The node re-executes, the coordinator interprets the typed decision, and:
@@ -234,14 +236,19 @@ tool_call_id  the agent's requested tool call
 execution_id  one actual execution attempt (idempotency key)
 ```
 
-Run states: `RUNNING → PENDING_APPROVAL → RESUMING → COMPLETED | FAILED`, with
-validated transitions (no `COMPLETED → RESUMING`, no `REJECTED → APPROVED`).
+Run states normally follow
+`RUNNING → PENDING_APPROVAL → RESUMING → RUNNING → COMPLETED | FAILED`, with
+validated transitions (no `COMPLETED → RESUMING`, no `REJECTED → APPROVED`). An
+explicit user cancellation also permits active `RUNNING → CANCELLED` and
+pending `PENDING_APPROVAL → CANCELLED` transitions.
 
-`CANCELLED` is also terminal and is reachable only from `RUNNING` or `RESUMING`.
-It records that a streaming consumer disconnected or stopped iteration, so the
-engine cancelled the graph instead of continuing model calls for an abandoned
-stream. Losing a stream after the run reaches `PENDING_APPROVAL` does not cancel
-the run: its durable checkpoint remains valid for a later human decision.
+`CANCELLED` is terminal. For an executing run, it records that a streaming
+consumer disconnected or stopped iteration, so the engine cancelled the graph
+instead of continuing model calls. Losing a stream after the run reaches
+`PENDING_APPROVAL` does not itself cancel the run: its durable checkpoint remains
+valid for a later human decision. The owner can instead explicitly cancel that
+pending run; its approval is atomically rejected and the checkpoint becomes
+unreachable through resume.
 
 ## 6. Checkpointer selection
 
@@ -334,6 +341,11 @@ others get a stable `ApprovalAlreadyProcessed`. In-memory this is a locked
 transition; the shared-DB implementation maps it to a conditional
 `UPDATE ... WHERE status = 'pending'`.
 
+**Cancellation race.** Pending-run cancellation performs the competing atomic
+`PENDING → REJECTED` approval transition. Exactly one of cancellation or resume
+can win. If resume has already claimed the approval, cancellation returns a
+conflict and does not imply that an external side effect can be rolled back.
+
 **Session-repository safety.** The in-memory adapter guards lookup, grant,
 revocation, expiry removal, and session cleanup with one async lock. Repeated
 grants replace the value for the same immutable key and cannot create duplicates.
@@ -390,6 +402,8 @@ capability inside the conversation ownership boundary:
 
 ```text
 POST /conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision
+POST /conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision/stream
+POST /conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/cancel
 ```
 
 Its body carries one typed value: `allow_once`, `deny`, or
@@ -402,10 +416,28 @@ completed but the response or first database write failed, retrying the same
 decision recovers the result from the completed graph checkpoint and does not
 duplicate the assistant turn or tool execution.
 
+The widget uses `/decision/stream`. Its first lifecycle event is
+`resume_started` with the original `run_id`; later route, token, approval, and
+final events come from the same graph thread. Aborting this response closes the
+engine-owned resume stream, cancels its LangGraph task, and atomically moves the
+same run to `CANCELLED`. Partial assistant output is not persisted as a completed
+assistant message.
+
+The `/cancel` route is a separate terminal lifecycle action, not a fourth
+approval decision and not an alias for `DENY`. It is allowed only while the
+approval remains pending. A successful response returns
+`{"run_id": "...", "status": "cancelled"}`; a decision that already won the
+atomic race returns 409.
+
 The bundled widget renders these decisions as **Approve**, **Deny**, and
-**Approve for this session**. The last option reuses the existing session
-permission key, so later calls to the same provider-qualified tool by the same
-agent in the same conversation do not prompt again.
+**Approve for this session**, plus a separate **Cancel run** action. Cancel
+remains available while a decision request is in flight so the two requests can
+race at the authoritative backend. After `resume_started`, the ordinary active
+execution **Stop** control replaces pending cancellation. The textarea and Edit
+remain available for drafting, while submit stays blocked until the active run
+finishes. The last approval option reuses the existing session permission key,
+so later calls to the same provider-qualified tool by the same agent in the same
+conversation do not prompt again.
 
 A pending-approval payload contains `run_id`, `approval_id`, `agent_id`,
 `tool_name`, a human-readable `description` (stating the tool has **not** run

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,8 @@ implemented, so protected-node access control is not actually enforced today.
 11. [CLAUDE_CODE_WORKFLOW.md](CLAUDE_CODE_WORKFLOW.md) — using Claude Code in this repo.
 12. [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) — how to work in this repo.
 13. [ROADMAP.md](ROADMAP.md) — phased plan.
-14. [adr/](adr/) — architecture decision records for contract-level changes.
+14. [adr/](adr/) — architecture decision records for contract-level changes,
+    including [immutable conversation branches](adr/0002-conversation-lifecycle-and-immutable-branches.md).
 
 ## Relationship to other directories
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ table above:
 | Runtime hooks (auth/policy/audit/context-enrichment, incl. `transform_tool_result`) | ✅ done | `agent_engine/runtime/hooks/`, [RUNTIME_HOOKS.md](RUNTIME_HOOKS.md) |
 | Per-run execution-limit guardrails | ✅ done | `agent_engine/core/execution.py`, `agent_engine/runtime/execution.py`, [EXECUTION_LIMITS.md](EXECUTION_LIMITS.md) |
 | Amazon Bedrock model provider (in addition to Anthropic) | ✅ done | `agent_engine/models/factory.py` |
-| Conversation persistence (SQLite default, sessions, users) | ✅ done | `agent_manager/` |
+| Conversation storage (memory default; optional SQLite/Postgres) | ✅ done | `agent_manager/` |
 | Embeddable JS/React chat widget | ✅ done | `agent_manager/api/static/widget/` |
 | Long-term / cross-conversation memory | ⏳ planned | — |
 
@@ -109,8 +109,9 @@ are all implemented. The originally planned `agentctl graph` shipped as
 **Phase 9 — API server (✅ done).** Two layers exist: `agent_engine/api/app.py`
 is a thin, stateless FastAPI app directly over the engine (`/health`,
 `/invoke`, `/stream`); `agent_manager/api/` is a conversation-lifecycle API
-(`/conversations`, message history, SSE streaming) backed by SQLite
-persistence, plus the embeddable JS/React chat widget served as a static
+(`/conversations`, message history, SSE streaming) backed by process memory by
+default or explicit SQLite/Postgres persistence, plus the embeddable JS/React
+chat widget served as a static
 asset.
 
 **Phase 10 — Docker / deployment (✅ done, basic container).** A root

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ table above:
 | Runtime hooks (auth/policy/audit/context-enrichment, incl. `transform_tool_result`) | ✅ done | `agent_engine/runtime/hooks/`, [RUNTIME_HOOKS.md](RUNTIME_HOOKS.md) |
 | Per-run execution-limit guardrails | ✅ done | `agent_engine/core/execution.py`, `agent_engine/runtime/execution.py`, [EXECUTION_LIMITS.md](EXECUTION_LIMITS.md) |
 | Amazon Bedrock model provider (in addition to Anthropic) | ✅ done | `agent_engine/models/factory.py` |
-| Conversation storage (memory default; optional SQLite/Postgres) | ✅ done | `agent_manager/` |
+| Conversation persistence (SQLite default, sessions, users) | ✅ done | `agent_manager/` |
 | Embeddable JS/React chat widget | ✅ done | `agent_manager/api/static/widget/` |
 | Long-term / cross-conversation memory | ⏳ planned | — |
 
@@ -109,9 +109,8 @@ are all implemented. The originally planned `agentctl graph` shipped as
 **Phase 9 — API server (✅ done).** Two layers exist: `agent_engine/api/app.py`
 is a thin, stateless FastAPI app directly over the engine (`/health`,
 `/invoke`, `/stream`); `agent_manager/api/` is a conversation-lifecycle API
-(`/conversations`, message history, SSE streaming) backed by process memory by
-default or explicit SQLite/Postgres persistence, plus the embeddable JS/React
-chat widget served as a static
+(`/conversations`, message history, SSE streaming) backed by SQLite
+persistence, plus the embeddable JS/React chat widget served as a static
 asset.
 
 **Phase 10 — Docker / deployment (✅ done, basic container).** A root

--- a/docs/RUNTIME_HOOKS.md
+++ b/docs/RUNTIME_HOOKS.md
@@ -325,6 +325,11 @@ updated `RunContext`; `before_mcp_request` may return an updated
 observe-only — their return value is ignored.** (Mutating a pending tool call or
 an MCP response is not supported in this version.)
 
+`on_run_start` may enrich request context, but it cannot replace `run_id`. That
+identifier is allocated by the caller or engine before hooks run and remains the
+authoritative identity shared by lifecycle persistence, conversation history,
+checkpoints, approvals, and stream events.
+
 In **managed plugin mode**, a method receives a single `HookInvocation` whose
 `.payload` is the same context object (use `event.payload_as(ToolCallContext)`
 for a typed view) and whose `.run_context` carries the active `RunContext`.

--- a/docs/RUNTIME_LIFECYCLE.md
+++ b/docs/RUNTIME_LIFECYCLE.md
@@ -69,13 +69,25 @@ engine never stores that history on `RuntimeEngine`.
 `agent_manager` owns conversation history through its repository. Before a
 turn, `ConversationService` loads prior messages for the session and appends the
 new user message. It passes the prior turns through the engine's structured
-history argument, then appends any emitted final assistant response when stream
-consumption ends, including after a later cleanup failure or client disconnect.
+history argument. For streaming runs, it persists a final assistant response
+before exposing that terminal event to the HTTP consumer. Disconnecting before
+a terminal event instead closes the engine stream, cancels the graph producer,
+and retains only the user message plus authoritative cancelled-run metadata.
 During a model tool loop, the tool-call message and matching tool result remain
 structured and ordered for the provider. A run paused for tool
 approval stores its continuation in the LangGraph checkpoint keyed by `run_id`;
 session-wide approval grants live in a separate approval repository keyed by
-session and tool identity.
+session and tool identity. Normal stream completion does not cancel a suspended
+approval. An explicit owner cancellation atomically rejects the pending
+approval, transitions the run to terminal `CANCELLED`, and prevents later
+resume.
+
+After a decision claims an approval, the same run transitions
+`PENDING_APPROVAL → RESUMING → RUNNING`. Streamed resume and initial execution
+both use the engine's owned graph-task channel. Closing either consumer cancels
+and awaits that task, records available partial token usage, and atomically
+transitions the run to `CANCELLED`; only an observed finalized event is
+persisted as a successful assistant response.
 
 Starting a new session therefore selects both an empty conversation history and
 an empty approval scope without putting either kind of request state on the
@@ -111,6 +123,14 @@ async with LangGraphEngine(base_dir) as engine:
 `agentctl run --stream` uses this flow and writes `answer_delta` content to
 stdout as chunks arrive. It does not print the completed answer again after the
 final event.
+
+The engine holds a terminal event until its consumer accepts it and lifecycle
+finalization succeeds. This prevents a completed producer with a queued final
+answer from racing a disconnect into conversation history that has neither an
+assistant response nor a cancelled run. On cancellation, token usage already
+reported by the provider is persisted before the run transitions to
+`CANCELLED`; usage that a provider reports only at normal completion is not
+available after an early abort.
 
 ---
 

--- a/docs/WIDGET.md
+++ b/docs/WIDGET.md
@@ -129,8 +129,17 @@ POST /conversations/{id}/messages/stream
 
 Assistant text is rendered as `answer_delta` events arrive. The final event
 settles the answer and emits `agent-chat:answer` with the safe route/tool
-metadata. If streaming is unavailable or fails before a usable answer, the
-widget falls back to the regular non-streaming send endpoint.
+metadata. A failed streaming mutation is not automatically replayed through the
+non-streaming endpoint because a network failure cannot prove that the first
+request made no state change.
+
+If a tool pauses for human approval, the widget shows **Approve**, **Deny**,
+**Approve for this session**, and a separate **Cancel run** action. Cancel is
+terminal and remains available while an approval decision is applying; the
+backend atomically decides which request wins. Once execution resumes, the
+textarea and Edit remain available for preparing a draft, submission stays
+blocked, and the send action becomes **Stop**. Stop aborts the actual resumed
+graph execution under the original `run_id`.
 
 See [WIDGET_ARCHITECTURE.md](WIDGET_ARCHITECTURE.md) for the implementation
 details and next-step plan.

--- a/docs/WIDGET_ARCHITECTURE.md
+++ b/docs/WIDGET_ARCHITECTURE.md
@@ -90,29 +90,60 @@ GET  /conversations/{id}/messages
 POST /conversations/{id}/messages
 POST /conversations/{id}/messages/stream
 POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/decision
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/decision/stream
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/cancel
 ```
 
-The non-streaming endpoint remains as a fallback. The streaming endpoint returns
-Server-Sent Events over a POST request, so the browser client uses `fetch()` and
-`ReadableStream` instead of `EventSource`.
+The non-streaming endpoint remains available to explicit API clients. The widget
+does not automatically replay a failed streaming mutation through it, because a
+network failure cannot prove the original request made no state change. The
+streaming endpoint returns Server-Sent Events over a POST request, so the browser
+client uses `fetch()` and `ReadableStream` instead of `EventSource`.
 
 Streaming events include:
 
+- `turn_started` — the persisted user-message and run identities for this turn.
 - `answer_delta` — append assistant text as it arrives.
 - `route` — update the visited agent/sub-agent path.
 - `tool_started`, `tool_succeeded`, `tool_failed` — update tool activity.
 - `final` — authoritative final answer and metadata.
 - `pending_approval` — sanitized tool request, provider/server identity, masked
   arguments, and the identifiers required to resume it.
+- `resume_started` — the existing run has left suspension and is executing
+  again under the same `run_id`.
 - `error` — stream failure.
 
-When a stream pauses for approval, the assistant entry renders three actions:
+While a turn runs, the composer remains editable but cannot submit another
+turn; its primary action becomes **Stop**. Stopping aborts the response-owned
+stream and therefore cancels and awaits the graph producer. The persisted user
+message remains visible with run status `cancelled`, while the widget projects
+that lifecycle state as *Generation stopped*. That label is not an assistant
+message and never enters model context.
+
+Previous user messages expose **Edit**. Submitting an edit sends
+`edit_message_id`; the manager appends a new user message at that message's
+parent and selects the new immutable branch. Original messages and downstream
+runs are retained rather than updated or deleted.
+
+A user may also explicitly edit the prompt of a pending-approval run. Submitting
+that edit creates a new branch and run; it does not decide, cancel, or mutate the
+old approval. A later resume of the old approval stays attached to its inactive
+original branch.
+
+When a stream pauses for approval, the assistant entry renders three decisions:
 **Approve** (`allow_once`), **Deny** (`deny`), and **Approve for this session**
-(`allow_for_session`). While a decision is in flight the controls are disabled;
-the completed resume replaces the approval card in place rather than starting a
-second conversation turn. Decision retries are idempotent: a completed graph
-result is recovered from its checkpoint and the assistant message is appended
-once by its stable run-derived id.
+(`allow_for_session`), plus a distinct **Cancel run** lifecycle action. Decision
+controls are disabled while a decision is in flight, but Cancel remains
+available: the backend atomically lets either cancellation or the approval claim
+win. A successful cancellation replaces the card with *Generation stopped* and
+unblocks the composer. Once resume starts, both new turns and approval resumes
+use an engine-owned graph task. The textarea and Edit stay available for draft
+preparation, submit stays blocked, and the primary action becomes **Stop**. Stop
+aborts the resume stream and therefore cancels the actual graph task and the
+same run. The completed resume replaces the approval card in place rather than
+starting a second conversation turn. Decision retries are
+idempotent: a completed graph result is recovered from its checkpoint and the
+assistant message is appended once by its stable run-derived id.
 
 ## Agent Connection Behavior
 
@@ -134,10 +165,19 @@ Automated coverage verifies:
 - Messages are sent through the conversation API.
 - Streaming SSE responses update the assistant message.
 - All three approval actions resume the existing run without duplicate requests.
+- Pending approvals can be terminally cancelled, including during an in-flight
+  decision, without executing the tool when cancellation wins.
+- Active approval resumes expose editable drafts and Stop while preventing a
+  concurrent submission; stopping cancels the graph and preserves no partial
+  assistant message.
 - Session approval suppresses the next prompt for the same scoped tool.
 - Stale conversation ids are recovered automatically.
 - Browser demos still work through Playwright.
 - The backend stream endpoint emits SSE frames.
+- Cancellation remains visible after history reload without persisting fake
+  assistant content.
+- Editing selects a new branch and excludes the original descendants from model
+  context.
 
 Manual verification with the real demo config verifies:
 

--- a/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
+++ b/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
@@ -72,9 +72,9 @@ message, which is already a stable domain identity.
   durable run records. Because no database environment currently exists, no new
   migration revision was created; the existing fresh-database baseline revision
   was updated in place.
-- With no database URL configured, the manager composes process-local
-  conversation and run repositories and opens no SQL connection. Setting
-  `EXTRA_DB_URL` or `DATABASE_URL` opts into SQL persistence and Alembic.
+- The default persistent SQLite database is unchanged. Only an explicitly
+  in-memory SQLite URL composes process-local conversation and run repositories
+  and skips Alembic, so tests and throwaway processes open no file.
 
 ## Consequences
 
@@ -92,8 +92,8 @@ message, which is already a stable domain identity.
 - External side effects completed before cancellation are not rolled back.
 - If an approval claim wins before cancellation, the cancellation request
   returns a conflict because execution may already have started.
-- Unconfigured conversation history and run state are lost on process restart;
-  deployments that require durability must configure a database URL.
+- Conversation history and run state configured as in-memory SQLite are lost on
+  process restart; that remains an explicit opt-out from the persistent default.
 - Provider-reported usage observed before cancellation is retained. Providers
   that report usage only after a cancelled request cannot be counted exactly.
 

--- a/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
+++ b/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
@@ -75,6 +75,10 @@ message, which is already a stable domain identity.
 - The default persistent SQLite database is unchanged. Only an explicitly
   in-memory SQLite URL composes process-local conversation and run repositories
   and skips Alembic, so tests and throwaway processes open no file.
+- Branch traversal stays a repository concern: the SQL adapter walks
+  `parent_message_id` from the head in a recursive CTE that also carries the
+  limit, and run lifecycle state is projected through one batched lookup, so
+  reading history costs neither a full-session scan nor a query per run.
 
 ## Consequences
 

--- a/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
+++ b/docs/adr/0002-conversation-lifecycle-and-immutable-branches.md
@@ -1,0 +1,113 @@
+# ADR 0002 — Conversation lifecycle and immutable message branches
+
+- **Status:** Accepted
+- **Date:** 2026-08-15
+
+## Context
+
+Conversation messages were stored as one append-only list, even though the
+schema already carried an unused `parent_message_id`. Cancelling a run left its
+user message but the history API could not project the authoritative run state,
+so the widget removed all evidence of the stopped turn. Editing an earlier user
+message cannot safely update that row or reuse its descendants: every later
+answer was produced from the original content.
+
+The browser also did not receive a streaming response until the engine emitted
+its first event. That made cancellation before the first model token dependent
+on cancellation of an ordinary request handler rather than on the response-owned
+stream generator.
+
+## Decision
+
+One `conversation_id` owns an immutable message tree.
+
+- `ConversationMessage.parent_message_id` points to the preceding message in
+  that branch.
+- `ConversationSession.head_message_id` selects the active root-to-leaf path.
+- A normal turn appends at the selected head. An edit appends a new user message
+  at the edited message's parent and atomically selects it as the new head.
+- Existing descendants remain stored and unchanged. A late assistant result is
+  stored on its original branch but selects itself only if its parent is still
+  the active head.
+- Model context and the history API traverse only the selected ancestry path.
+  The synthetic UI label `Generation stopped` is never persisted or passed to
+  the engine.
+- The engine's existing `run_id` and `RunRepository` remain authoritative for
+  lifecycle state. Manager deployments inject a durable SQL adapter for that
+  contract into both engine and conversation service. Preparing a turn registers
+  its run before `turn_started`, so disconnecting before engine iteration can
+  still make the run terminal rather than leaving it `running` forever.
+- The manager prepares and persists the turn before returning the streaming
+  response. Its first SSE frame is `turn_started`, carrying the authoritative
+  `run_id` and `message_id`; graph execution is owned by the response generator.
+- A terminal engine event is acknowledged before the run becomes `COMPLETED`,
+  and the manager persists its assistant message before exposing that event to
+  HTTP. A disconnect that wins before acknowledgement cancels the run instead
+  of losing a queued final answer.
+- Failed or disconnected stream mutations are never replayed automatically via
+  the non-streaming endpoint; without a client idempotency key, delivery failure
+  cannot prove that the original request made no state change.
+- A suspended approval remains resumable when its SSE response ends. The
+  conversation owner may explicitly terminalize it through the pending-approval
+  cancellation route. Cancellation atomically competes with the approval claim,
+  so either cancellation or resume wins, never both.
+- Approval resumes used by the widget are response-owned SSE executions. New
+  turns and resumed turns share the engine's owned graph-task cancellation
+  path; resume retains the original run and transitions
+  `PENDING_APPROVAL → RESUMING → RUNNING` before emitting work.
+
+No separate `branch_id` is introduced. A branch is identified by its leaf/head
+message, which is already a stable domain identity.
+
+## Contract changes
+
+- Conversation history items expose `message_id`, `run_id`, and `status`.
+- Send/stream requests accept optional `edit_message_id`.
+- Streaming adds a manager-owned `turn_started` event.
+- Pending approvals add a separate `/cancel` lifecycle endpoint; cancellation is
+  not represented as an approval decision or as `DENY`.
+- Approval decisions add `/decision/stream`; its `resume_started` event carries
+  the original `run_id`, and disconnecting it cancels the active graph task.
+- Conversation sessions gain `head_message_id`; manager persistence includes
+  durable run records. Because no database environment currently exists, no new
+  migration revision was created; the existing fresh-database baseline revision
+  was updated in place.
+- With no database URL configured, the manager composes process-local
+  conversation and run repositories and opens no SQL connection. Setting
+  `AGENT_DB_URL` or `DATABASE_URL` opts into SQL persistence and Alembic.
+
+## Consequences
+
+- Original content, completed descendants, pending approvals, and checkpoints
+  remain immutable and addressable after an edit.
+- Resuming an approval after its prompt was edited away attaches the result to
+  the original user message without selecting that inactive branch.
+- Retry, regenerate, and branch navigation can reuse the same tree by selecting
+  or appending from a different message head.
+- The active conversation view is linear even though cold storage is a tree.
+- Token budget accounting remains cumulative across every executed branch,
+  because editing does not refund model/tool work already consumed.
+- Repository compare-and-append rejects concurrent head changes before starting
+  a second execution on stale context.
+- External side effects completed before cancellation are not rolled back.
+- If an approval claim wins before cancellation, the cancellation request
+  returns a conflict because execution may already have started.
+- Unconfigured conversation history and run state are lost on process restart;
+  deployments that require durability must configure a database URL.
+- Provider-reported usage observed before cancellation is retained. Providers
+  that report usage only after a cancelled request cannot be counted exactly.
+
+## Alternatives
+
+Creating a new conversation and copying the inherited prefix was rejected: it
+duplicates history, weakens message/run provenance, and makes branch navigation
+look like unrelated threads. Adding both `branch_id` and parent links was also
+rejected because the leaf message already identifies a branch.
+
+## Enforcement
+
+- Repository contract tests run the ancestry/head behavior against memory and
+  SQL adapters.
+- Service tests assert exact edited and cancelled model contexts.
+- API and browser tests assert lifecycle projection, edit identity, immutable
+  downstream replacement, cancellation display, and reload behavior.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -84,9 +84,7 @@ On failure a `{"type": "error", "detail": "..."}` event is emitted.
 
 Base URL: `http://localhost:8100`
 
-Manages multi-turn conversations using process memory by default, without
-opening a database connection. Set `EXTRA_DB_URL` (or `DATABASE_URL`) to an
-explicit SQLite or Postgres URL when history must survive process restarts.
+Manages multi-turn conversations with history persisted in SQLite (or Postgres via `EXTRA_DB_URL`).
 
 ### Caller identity
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -84,7 +84,9 @@ On failure a `{"type": "error", "detail": "..."}` event is emitted.
 
 Base URL: `http://localhost:8100`
 
-Manages multi-turn conversations with history persisted in SQLite (or Postgres via `DATABASE_URL`).
+Manages multi-turn conversations using process memory by default, without
+opening a database connection. Set `AGENT_DB_URL` (or `DATABASE_URL`) to an
+explicit SQLite or Postgres URL when history must survive process restarts.
 
 ### Caller identity
 
@@ -227,6 +229,38 @@ emitted before `done`.
 The event schema also declares `tool_started` / `tool_succeeded` /
 `tool_failed` types for per-tool progress; the engine does not emit them yet.
 </Note>
+
+### Pending approval actions
+
+When a send or stream response has `status: "pending_approval"`, use its
+`run_id` and `approval_id` to decide or cancel the suspended run:
+
+```text
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/decision
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/decision/stream
+POST /conversations/{id}/runs/{run_id}/approvals/{approval_id}/cancel
+```
+
+The decision body is one of `allow_once`, `deny`, or `allow_for_session`:
+
+```json
+{ "decision": "allow_once" }
+```
+
+Cancellation is a separate terminal lifecycle action, not an alias for
+`deny`. It succeeds only while the approval is pending and returns:
+
+```json
+{ "run_id": "…", "status": "cancelled" }
+```
+
+All routes authorize the conversation owner. If approval and cancellation
+race, exactly one wins; the loser receives `409`.
+
+The widget uses `/decision/stream`. It returns SSE beginning with
+`resume_started` and the same `run_id`, followed by ordinary execution events.
+Disconnecting that response cancels the resumed graph task and moves the run to
+`cancelled`; it does not merely hide browser output.
 
 ### `GET /conversations/{id}/messages`
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -57,9 +57,7 @@ The engine itself holds no per-request state. Everything specific to a request l
     Stateless. Takes a `messages` array, returns a response. No memory, no sessions. Port 8090.
   </Card>
   <Card title="agent-manager" icon="database">
-    Adds conversation storage, session management, and SSE streaming on top of
-    the engine. Storage is process-local unless a SQLite/Postgres URL is
-    configured. Serves the embeddable widget. Port 8100.
+    Adds conversation persistence, session management, and SSE streaming on top of the engine. Serves the embeddable widget. Port 8100.
   </Card>
 </CardGroup>
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -57,7 +57,9 @@ The engine itself holds no per-request state. Everything specific to a request l
     Stateless. Takes a `messages` array, returns a response. No memory, no sessions. Port 8090.
   </Card>
   <Card title="agent-manager" icon="database">
-    Adds conversation persistence, session management, and SSE streaming on top of the engine. Serves the embeddable widget. Port 8100.
+    Adds conversation storage, session management, and SSE streaming on top of
+    the engine. Storage is process-local unless a SQLite/Postgres URL is
+    configured. Serves the embeddable widget. Port 8100.
   </Card>
 </CardGroup>
 

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -69,7 +69,7 @@ port first: stop `make dev`, and `make down` if the Docker stack is up.
 | ----------------- | ------------------------------------------------------------ |
 | Script path       | `src/agent_manager/cli.py` — check the dropdown says *Script path*, not *Module name* (as a module it's `agent_manager.cli`) |
 | Parameters        | `--config examples/starter/agents.yaml --host 127.0.0.1`      |
-| Working directory | the repository root — `chat.db` and `.env` resolve against it |
+| Working directory | the repository root — `.env` and any explicitly configured relative database path resolve against it |
 
 Debug it, open http://localhost:8100/playground, send a message — breakpoints
 hit.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -100,9 +100,7 @@ The stateless engine — no database, no widget. Good for embedding into your ow
 
 ## With conversation history and widget
 
-Adds multi-turn sessions, SSE streaming, and an embeddable chat widget. Storage
-is process-local unless a database URL is explicitly configured; the example
-below opts into a SQLite file mounted with the workspace.
+Adds persistent conversations, multi-turn sessions, SSE streaming, and an embeddable chat widget.
 
 <Steps>
   <Step title="Same agents.yml">
@@ -116,7 +114,6 @@ below opts into a SQLite file mounted with the workspace.
       -v $(pwd):/workspace \
       -w /workspace \
       -e ANTHROPIC_API_KEY=sk-... \
-      -e EXTRA_DB_URL=sqlite+aiosqlite:///chat.db \
       ghcr.io/extra-org/extra:latest \
       agent-manager --config agents.yml --port 8100
     ```

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -100,7 +100,9 @@ The stateless engine — no database, no widget. Good for embedding into your ow
 
 ## With conversation history and widget
 
-Adds persistent conversations, multi-turn sessions, SSE streaming, and an embeddable chat widget.
+Adds multi-turn sessions, SSE streaming, and an embeddable chat widget. Storage
+is process-local unless a database URL is explicitly configured; the example
+below opts into a SQLite file mounted with the workspace.
 
 <Steps>
   <Step title="Same agents.yml">
@@ -114,6 +116,7 @@ Adds persistent conversations, multi-turn sessions, SSE streaming, and an embedd
       -v $(pwd):/workspace \
       -w /workspace \
       -e ANTHROPIC_API_KEY=sk-... \
+      -e AGENT_DB_URL=sqlite+aiosqlite:///chat.db \
       ghcr.io/extra-org/extra:latest \
       agent-manager --config agents.yml --port 8100
     ```

--- a/examples/starter/.env.example
+++ b/examples/starter/.env.example
@@ -29,7 +29,7 @@ OPENAI_BASE_URL=http://127.0.0.1:11434/v1
 # budget is so the user sees it coming.
 # CONTEXT_MAX_TOKENS=2000
 
-# Optional — storage configuration (defaults to process memory; set a URL to persist):
+# Optional — storage configuration (defaults to SQLite chat.db):
 # EXTRA_DB_BACKEND=postgres
 # EXTRA_DB_URL=postgresql://user:pass@host/db
 

--- a/src/agent_engine/approvals/manager.py
+++ b/src/agent_engine/approvals/manager.py
@@ -278,6 +278,43 @@ class ApprovalManager:
         )
         return claimed
 
+    async def cancel_pending(
+        self,
+        *,
+        run_id: str,
+        approval_id: str,
+        caller_user_id: str | None = None,
+        caller_auth_ref: str | None = None,
+    ) -> ApprovalRecord:
+        """Atomically win cancellation against a competing approval decision."""
+        record = await self.get_authorized(
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_auth_ref,
+        )
+        try:
+            cancelled = await self._approvals.reject_pending(approval_id)
+        except InvalidStateTransition as exc:
+            log(
+                logger,
+                logging.INFO,
+                "approval cancellation lost race",
+                run_id=run_id,
+                approval_id=approval_id,
+                status=record.status.value,
+            )
+            raise ApprovalAlreadyProcessed(approval_id, record.status.value) from exc
+        log(
+            logger,
+            logging.INFO,
+            "pending approval cancelled",
+            run_id=run_id,
+            approval_id=approval_id,
+            tool_call_id=cancelled.tool_call_id,
+        )
+        return cancelled
+
     @staticmethod
     def _ensure_authorized(
         record: ApprovalRecord,

--- a/src/agent_engine/approvals/models.py
+++ b/src/agent_engine/approvals/models.py
@@ -50,7 +50,9 @@ _RUN_TRANSITIONS: dict[RunStatus, frozenset[RunStatus]] = {
             RunStatus.CANCELLED,
         }
     ),
-    RunStatus.PENDING_APPROVAL: frozenset({RunStatus.RESUMING, RunStatus.FAILED}),
+    RunStatus.PENDING_APPROVAL: frozenset(
+        {RunStatus.RESUMING, RunStatus.FAILED, RunStatus.CANCELLED}
+    ),
     RunStatus.RESUMING: frozenset(
         {
             RunStatus.RUNNING,
@@ -74,8 +76,13 @@ _APPROVAL_TRANSITIONS: dict[ApprovalStatus, frozenset[ApprovalStatus]] = {
 
 
 def ensure_run_transition(current: RunStatus, target: RunStatus) -> None:
-    if target not in _RUN_TRANSITIONS[current]:
+    if not can_transition_run(current, target):
         raise InvalidStateTransition("run", current.value, target.value)
+
+
+def can_transition_run(current: RunStatus, target: RunStatus) -> bool:
+    """Return whether the canonical run state machine allows this edge."""
+    return target in _RUN_TRANSITIONS[current]
 
 
 def ensure_approval_transition(current: ApprovalStatus, target: ApprovalStatus) -> None:

--- a/src/agent_engine/approvals/repository.py
+++ b/src/agent_engine/approvals/repository.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 from typing import Protocol, runtime_checkable
 
-from agent_engine.approvals.errors import ApprovalNotFound
+from agent_engine.approvals.errors import ApprovalNotFound, InvalidStateTransition
 from agent_engine.approvals.models import (
     ApprovalRecord,
     ApprovalStatus,
@@ -28,6 +28,7 @@ class ApprovalRepository(Protocol):
     async def get_by_tool_call(self, run_id: str, tool_call_id: str) -> ApprovalRecord | None: ...
     async def get_pending_for_run(self, run_id: str) -> ApprovalRecord | None: ...
     async def claim(self, approval_id: str) -> ApprovalRecord: ...
+    async def reject_pending(self, approval_id: str) -> ApprovalRecord: ...
     async def set_status(self, approval_id: str, target: ApprovalStatus) -> ApprovalRecord: ...
 
 
@@ -84,6 +85,25 @@ class InMemoryApprovalRepository:
             # which the manager maps to ApprovalAlreadyProcessed.
             ensure_approval_transition(record.status, ApprovalStatus.RESUMING)
             record.transition(ApprovalStatus.RESUMING)
+            return record
+
+    async def reject_pending(self, approval_id: str) -> ApprovalRecord:
+        """Atomically reject an approval only while it is still pending.
+
+        This compare-and-set races safely with :meth:`claim`: cancellation and
+        approval can never both win for the same tool call.
+        """
+        async with self._lock:
+            record = self._approvals.get(approval_id)
+            if record is None:
+                raise ApprovalNotFound(approval_id)
+            if record.status != ApprovalStatus.PENDING:
+                # Keep the public failure consistent with ``claim`` while
+                # forbidding cancellation of an already-resuming tool call.
+                raise InvalidStateTransition(
+                    "approval", record.status.value, ApprovalStatus.REJECTED.value
+                )
+            record.transition(ApprovalStatus.REJECTED)
             return record
 
     async def set_status(self, approval_id: str, target: ApprovalStatus) -> ApprovalRecord:

--- a/src/agent_engine/engine/engine.py
+++ b/src/agent_engine/engine/engine.py
@@ -67,3 +67,39 @@ class ApprovalEngine(Protocol):
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
     ) -> RunResult: ...
+
+
+@runtime_checkable
+class ApprovalCancellationEngine(Protocol):
+    """Optional engine capability for terminally cancelling a pending HITL run."""
+
+    async def cancel_pending_approval(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> None: ...
+
+
+@runtime_checkable
+class ApprovalStreamingEngine(Protocol):
+    """Optional engine capability for streaming an existing HITL run."""
+
+    def resume_stream(
+        self,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision | str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> AsyncIterator[RunStreamEvent]: ...
+
+
+@runtime_checkable
+class RunStatusEngine(Protocol):
+    """Optional engine capability exposing authoritative run lifecycle state."""
+
+    async def get_run_status(self, run_id: str) -> str: ...

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from collections.abc import AsyncIterator, Callable, Iterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any, cast
@@ -605,20 +605,14 @@ class LangGraphEngine(Engine):
         """
         app, lifecycle = self._require_built("resuming")
         kind = parse_decision(decision)
-        approval = await self._approval_manager.claim(
+        ctx = await self._activate_approval_resume(
+            lifecycle,
             run_id=run_id,
             approval_id=approval_id,
             caller_user_id=caller_user_id,
-            caller_auth_ref=caller_session_id,
+            caller_session_id=caller_session_id,
         )
         approved = kind != ApprovalDecision.DENY
-        ctx = RunContext(
-            run_id=run_id,
-            conversation_id=approval.auth_ref,
-            user_id=approval.authorized_user_id,
-            organization_id=approval.organization_id,
-            metadata={"approval_id": approval.approval_id},
-        )
         log(
             logger,
             logging.INFO,
@@ -648,9 +642,141 @@ class LangGraphEngine(Engine):
                     decision=kind.value,
                 )
                 return run_result
+            except asyncio.CancelledError:
+                await asyncio.shield(
+                    lifecycle.cancel(ctx, reason="approval resume request cancelled")
+                )
+                raise
             except Exception as exc:
                 await lifecycle.fail(ctx, exc)
                 raise
+
+    async def resume_stream(
+        self,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision | str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        """Resume one approval through the same owned stream used by new runs."""
+        app, lifecycle = self._require_built("streaming an approval resume")
+        kind = parse_decision(decision)
+        ctx = await self._activate_approval_resume(
+            lifecycle,
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_session_id=caller_session_id,
+        )
+        approved = kind != ApprovalDecision.DENY
+
+        async def finalize_approval() -> None:
+            await self._approval_manager.finalize(approval_id, approved=approved)
+
+        log(
+            logger,
+            logging.INFO,
+            "resume stream started",
+            run_id=run_id,
+            approval_id=approval_id,
+            decision=kind.value,
+        )
+        command: Command[Any] = Command(resume={"decision": kind.value})
+        execution = cast(
+            AsyncGenerator[RunStreamEvent, None],
+            self._stream_execution(
+                app,
+                lifecycle,
+                ctx,
+                command,
+                after_invoke=finalize_approval,
+                started_event=RunStreamEvent(type="resume_started", run_id=run_id),
+            ),
+        )
+        try:
+            async for event in execution:
+                yield event
+        finally:
+            await execution.aclose()
+
+    async def _activate_approval_resume(
+        self,
+        lifecycle: RunLifecycle,
+        *,
+        run_id: str,
+        approval_id: str,
+        caller_user_id: str | None,
+        caller_session_id: str | None,
+    ) -> RunContext:
+        """Claim and activate one resume without an interruptible ownership gap.
+
+        The response may be cancelled before its first SSE frame. Shielding this
+        short transition ensures that cancellation observes either an unclaimed
+        approval or an active run that it can terminally cancel, never a claimed
+        approval stranded before graph-task ownership begins.
+        """
+
+        async def activate() -> RunContext:
+            approval = await self._approval_manager.claim(
+                run_id=run_id,
+                approval_id=approval_id,
+                caller_user_id=caller_user_id,
+                caller_auth_ref=caller_session_id,
+            )
+            ctx = RunContext(
+                run_id=run_id,
+                conversation_id=approval.auth_ref,
+                user_id=approval.authorized_user_id,
+                organization_id=approval.organization_id,
+                metadata={"approval_id": approval.approval_id},
+            )
+            await lifecycle.activate_resume(ctx)
+            return ctx
+
+        activation = asyncio.create_task(activate())
+        try:
+            return await asyncio.shield(activation)
+        except asyncio.CancelledError:
+            try:
+                ctx = await asyncio.shield(activation)
+            except Exception:
+                # The claim lost or activation failed, so there is no active
+                # execution owned by this request to terminally cancel.
+                pass
+            else:
+                await asyncio.shield(
+                    lifecycle.cancel(ctx, reason="approval resume request cancelled")
+                )
+            raise
+
+    async def cancel_pending_approval(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> None:
+        """Cancel a suspended HITL run if no approval decision has claimed it."""
+        _, lifecycle = self._require_built("cancelling a pending approval")
+        approval = await self._approval_manager.cancel_pending(
+            run_id=run_id,
+            approval_id=approval_id,
+            caller_user_id=caller_user_id,
+            caller_auth_ref=caller_session_id,
+        )
+        await lifecycle.cancel(
+            RunContext(
+                run_id=run_id,
+                conversation_id=approval.auth_ref,
+                user_id=approval.authorized_user_id,
+                organization_id=approval.organization_id,
+                metadata={"approval_id": approval.approval_id},
+            ),
+            reason="user cancelled pending approval",
+        )
 
     async def stream(
         self,
@@ -665,24 +791,56 @@ class LangGraphEngine(Engine):
         state = _initial_state(
             message, history=history, ctx=ctx, expose_run_context=context is not None
         )
+        execution = cast(
+            AsyncGenerator[RunStreamEvent, None],
+            self._stream_execution(app, lifecycle, ctx, state),
+        )
+        try:
+            async for event in execution:
+                yield event
+        finally:
+            await execution.aclose()
+
+    async def _stream_execution(
+        self,
+        app: RunGraph,
+        lifecycle: RunLifecycle,
+        ctx: RunContext,
+        graph_input: Any,
+        *,
+        after_invoke: Callable[[], Awaitable[None]] | None = None,
+        started_event: RunStreamEvent | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        """Own one active graph leg and cancel it when its consumer leaves."""
         channel = StreamChannel()
         tokens = TokenUsage()
         with self._run_scope(ctx, sinks=channel.sinks(token=tokens.add)):
             task = asyncio.create_task(
-                self._stream_graph(app, lifecycle, ctx, state, channel=channel, tokens=tokens)
+                self._stream_graph(
+                    app,
+                    lifecycle,
+                    ctx,
+                    graph_input,
+                    channel=channel,
+                    tokens=tokens,
+                    after_invoke=after_invoke,
+                )
             )
+            if started_event is not None:
+                channel.emit(started_event)
             try:
                 async for event in channel.events():
                     yield event
                 await task
             finally:
-                await self._stop_abandoned_stream(task, lifecycle, ctx)
+                await self._stop_abandoned_stream(task, lifecycle, ctx, tokens)
 
-    @staticmethod
     async def _stop_abandoned_stream(
+        self,
         task: asyncio.Task[None],
         lifecycle: RunLifecycle,
         ctx: RunContext,
+        tokens: TokenUsage,
     ) -> None:
         """Stop a graph producer when its stream is closed before completion."""
         if task.done():
@@ -690,17 +848,33 @@ class LangGraphEngine(Engine):
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
-        await asyncio.shield(lifecycle.cancel(ctx))
+        await asyncio.shield(self._cancel_abandoned_run(lifecycle, ctx, tokens))
+
+    async def _cancel_abandoned_run(
+        self,
+        lifecycle: RunLifecycle,
+        ctx: RunContext,
+        tokens: TokenUsage,
+    ) -> None:
+        """Persist reported partial usage, then make cancellation terminal."""
+        try:
+            if tokens.totals() != (None, None):
+                await self._record_token_usage(ctx, tokens)
+        except Exception:
+            logger.exception("failed to record token usage for cancelled run")
+        finally:
+            await lifecycle.cancel(ctx)
 
     async def _stream_graph(
         self,
         app: RunGraph,
         lifecycle: RunLifecycle,
         ctx: RunContext,
-        state: dict[str, Any],
+        graph_input: Any,
         *,
         channel: StreamChannel,
         tokens: TokenUsage,
+        after_invoke: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         """Execute the graph for a streamed run and report the outcome.
 
@@ -710,18 +884,21 @@ class LangGraphEngine(Engine):
         channel: an exception raised here would reach nobody.
         """
         try:
-            result = await self._invoke_graph(app, ctx, state)
+            result = await self._invoke_graph(app, ctx, graph_input)
             token_usage = await self._record_token_usage(ctx, tokens)
+            if after_invoke is not None:
+                await after_invoke()
             pending = await self._pending_result(ctx, result, token_usage=token_usage)
             if pending is not None:
                 channel.emit(_pending_approval_event(self._system_name, pending))
                 return
             run_result = await self._completed_result(ctx, result, token_usage=token_usage)
-            await lifecycle.succeed(
-                ctx,
-                run_result,
-                on_completed=lambda: channel.emit(_final_event(self._system_name, run_result)),
-            )
+            terminal = channel.publish_terminal(_final_event(self._system_name, run_result))
+            await terminal.accepted.wait()
+            try:
+                await lifecycle.succeed(ctx, run_result)
+            finally:
+                terminal.finalized.set()
         except Exception as exc:
             await lifecycle.fail(ctx, exc)
             channel.abort(exc)

--- a/src/agent_engine/engine/langgraph/helpers.py
+++ b/src/agent_engine/engine/langgraph/helpers.py
@@ -123,19 +123,26 @@ async def invoke_model(model: Any, messages: list[Any], state: GraphState) -> An
     answer_stream = sinks.answer
     if answer_stream is None:
         response = await model.ainvoke(messages)
-    else:
-        streamed = None
+        usage = getattr(response, "usage_metadata", None)
+        if sinks.token is not None and usage:
+            sinks.token(usage.get("input_tokens", 0), usage.get("output_tokens", 0))
+        return response
+
+    streamed = None
+    try:
         async for chunk in model.astream(messages):
             streamed = chunk if streamed is None else streamed + chunk
             text = as_text(getattr(chunk, "content", ""))
             if text:
                 answer_stream(text)
-        response = streamed or AIMessage(content="")
-    if sinks.token is not None:
-        usage = getattr(response, "usage_metadata", None)
-        if usage:
+    finally:
+        # Providers commonly attach usage to a final stream chunk. Reading the
+        # accumulated partial response in ``finally`` preserves any usage they
+        # reported even when the consumer cancels before normal completion.
+        usage = getattr(streamed, "usage_metadata", None)
+        if sinks.token is not None and usage:
             sinks.token(usage.get("input_tokens", 0), usage.get("output_tokens", 0))
-    return response
+    return streamed or AIMessage(content="")
 
 
 async def run_tool_loop(

--- a/src/agent_engine/engine/langgraph/run_lifecycle.py
+++ b/src/agent_engine/engine/langgraph/run_lifecycle.py
@@ -44,7 +44,10 @@ class RunLifecycle:
     async def begin(self, context: RunContext | None) -> RunContext:
         """Open a run. ``on_run_start`` may replace the context, so it runs
         before registration."""
-        ctx = await self._hooks.run_run_start(self.identify(context))
+        identified = self.identify(context)
+        ctx = await self._hooks.run_run_start(identified)
+        if ctx.run_id != identified.run_id:
+            raise ValueError("on_run_start hooks cannot replace the authoritative run_id")
         await self._register(ctx)
         log(logger, logging.INFO, "run started", run_id=ctx.run_id, system=self._system_name)
         return ctx
@@ -83,6 +86,18 @@ class RunLifecycle:
             tools=len(result.used_tools),
         )
 
+    async def activate_resume(self, ctx: RunContext) -> None:
+        """Move a claimed suspended run back into active execution."""
+        if not await self._mark(ctx.run_id, RunStatus.RUNNING):
+            raise RuntimeError(f"run {ctx.run_id!r} cannot enter running state after resume")
+        log(
+            logger,
+            logging.INFO,
+            "run resumed",
+            run_id=ctx.run_id,
+            system=self._system_name,
+        )
+
     async def fail(self, ctx: RunContext, error: Exception) -> None:
         """Close a run that raised. Never raises, so the original error survives."""
         log(
@@ -96,13 +111,8 @@ class RunLifecycle:
         await self._mark(ctx.run_id, RunStatus.FAILED)
         await self._hooks.run_run_error(ctx, error)
 
-    async def cancel(self, ctx: RunContext) -> None:
-        """Close an in-flight run whose streaming consumer went away.
-
-        A suspended run remains pending because its checkpoint is durable and
-        can still be resumed from another connection. Completed and failed runs
-        are terminal already, so cancellation leaves them unchanged too.
-        """
+    async def cancel(self, ctx: RunContext, *, reason: str = "consumer abandoned stream") -> None:
+        """Terminally close a running, resuming, or explicitly cancelled pending run."""
         if await self._mark(ctx.run_id, RunStatus.CANCELLED):
             log(
                 logger,
@@ -110,7 +120,7 @@ class RunLifecycle:
                 "run cancelled",
                 run_id=ctx.run_id,
                 system=self._system_name,
-                reason="consumer abandoned stream",
+                reason=reason,
             )
 
     async def _mark(self, run_id: str | None, target: RunStatus) -> bool:

--- a/src/agent_engine/engine/langgraph/run_lifecycle.py
+++ b/src/agent_engine/engine/langgraph/run_lifecycle.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import Callable
 
 from agent_engine.approvals.models import RunRecord, RunStatus
 from agent_engine.engine.types import RunResult
@@ -11,10 +10,6 @@ from agent_engine.runs.repository import RunRepository
 from agent_engine.runtime.hooks import HookManager, RunContext, RunEndContext
 
 logger = logging.getLogger(__name__)
-
-
-def _noop() -> None:
-    """Default ``on_completed`` callback: publish nothing between the phases."""
 
 
 class RunLifecycle:
@@ -64,17 +59,10 @@ class RunLifecycle:
             )
         )
 
-    async def succeed(
-        self,
-        ctx: RunContext,
-        result: RunResult,
-        *,
-        on_completed: Callable[[], None] = _noop,
-    ) -> None:
-        """Close a run that produced an answer. ``on_completed`` fires between
-        the status change and ``on_run_end``; callers depend on that order."""
+    async def succeed(self, ctx: RunContext, result: RunResult) -> None:
+        """Close a run that produced an answer. The terminal-event handshake that
+        used to interleave here now lives in ``StreamChannel``."""
         await self._mark(ctx.run_id, RunStatus.COMPLETED)
-        on_completed()
         await self._hooks.run_run_end(ctx, self._end_context(ctx, result))
         log(
             logger,

--- a/src/agent_engine/engine/langgraph/stream_channel.py
+++ b/src/agent_engine/engine/langgraph/stream_channel.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
 
 from agent_engine.runtime.streaming import RunStreamEvent, StreamSinks
+
+
+@dataclass
+class _TerminalEvent:
+    event: RunStreamEvent
+    accepted: asyncio.Event = field(default_factory=asyncio.Event)
+    finalized: asyncio.Event = field(default_factory=asyncio.Event)
 
 
 class StreamChannel:
     """An in-order channel of :class:`RunStreamEvent` for one streamed run."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[RunStreamEvent | BaseException | None] = asyncio.Queue()
+        self._queue: asyncio.Queue[RunStreamEvent | _TerminalEvent | BaseException | None] = (
+            asyncio.Queue()
+        )
 
     def sinks(self, *, token: Callable[[int, int], None]) -> StreamSinks:
         """Per-run sinks publishing onto this channel. Install before creating
@@ -24,6 +34,16 @@ class StreamChannel:
     def emit(self, event: RunStreamEvent) -> None:
         """Publish an event. Non-blocking, so it is safe from sync sink callbacks."""
         self._queue.put_nowait(event)
+
+    def publish_terminal(self, event: RunStreamEvent) -> _TerminalEvent:
+        """Publish a terminal event whose lifecycle must be acknowledged.
+
+        Holding the producer open prevents an abandoned consumer from racing a
+        queued-but-unobserved final answer into a completed run.
+        """
+        terminal = _TerminalEvent(event)
+        self._queue.put_nowait(terminal)
+        return terminal
 
     def abort(self, error: BaseException) -> None:
         """Hand a producer failure to the consumer, after anything already emitted."""
@@ -42,4 +62,9 @@ class StreamChannel:
                 return
             if isinstance(item, BaseException):
                 raise item
+            if isinstance(item, _TerminalEvent):
+                item.accepted.set()
+                await item.finalized.wait()
+                yield item.event
+                continue
             yield item

--- a/src/agent_engine/runs/in_memory.py
+++ b/src/agent_engine/runs/in_memory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 
 from agent_engine.approvals.errors import InvalidStateTransition
@@ -83,6 +83,15 @@ class InMemoryRunRepository:
     async def get(self, run_id: str) -> RunRecord | None:
         entry = self._get_unexpired_entry(run_id)
         return None if entry is None else entry.record
+
+    async def get_many(self, run_ids: Collection[str]) -> dict[str, RunRecord]:
+        """Resolve many ids against the same dict, skipping unknown and expired ones."""
+        found: dict[str, RunRecord] = {}
+        for run_id in run_ids:
+            entry = self._get_unexpired_entry(run_id)
+            if entry is not None:
+                found[run_id] = entry.record
+        return found
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
         now = self._clock()

--- a/src/agent_engine/runs/repository.py
+++ b/src/agent_engine/runs/repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from typing import Protocol, runtime_checkable
 
 from agent_engine.approvals.models import RunRecord, RunStatus
@@ -29,6 +30,15 @@ class RunRepository(Protocol):
 
     async def get(self, run_id: str) -> RunRecord | None:
         """Return the stored run, or ``None`` when ``run_id`` is unknown."""
+        ...
+
+    async def get_many(self, run_ids: Collection[str]) -> dict[str, RunRecord]:
+        """Return the stored runs for ``run_ids``, keyed by id.
+
+        Unknown ids are simply absent. Implementations must answer in a bounded
+        number of round trips so callers projecting many runs at once — history
+        endpoints in particular — do not degrade into one query per run.
+        """
         ...
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:

--- a/src/agent_engine/runtime/streaming.py
+++ b/src/agent_engine/runtime/streaming.py
@@ -59,6 +59,7 @@ RunStreamEventType = Literal[
     "tool_failed",
     "final",
     "pending_approval",
+    "resume_started",
 ]
 
 

--- a/src/agent_manager/api/app.py
+++ b/src/agent_manager/api/app.py
@@ -47,6 +47,7 @@ def create_app(config_path: str, settings: Settings | None = None) -> FastAPI:
                 base_dir,
                 session_approval_repository=repositories.session_approvals,
                 tool_usage_repository=repositories.tool_usage,
+                run_repository=repositories.runs,
             ) as engine,
         ):
             await engine.build(spec)
@@ -59,6 +60,7 @@ def create_app(config_path: str, settings: Settings | None = None) -> FastAPI:
                 snapshot_ttl_seconds=settings.snapshot_ttl_seconds,
                 system_name=spec.meta.name,
                 config_path=str(Path(config_path).resolve()),
+                run_repository=repositories.runs,
             )
             yield
 

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from contextlib import contextmanager
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -23,6 +23,7 @@ from agent_manager.api.deps import CallerIdentity, get_caller_identity, get_prin
 from agent_manager.api.schemas import (
     AnonymousPassResponse,
     ApprovalDecisionRequest,
+    CancelRunResponse,
     ConversationSummary,
     CreateConversationRequest,
     CreateConversationResponse,
@@ -39,7 +40,9 @@ from agent_manager.api.schemas import (
 from agent_manager.application import (
     ConversationAccessDenied,
     ConversationAlreadyExists,
+    ConversationBranchConflict,
     ConversationLinkRefused,
+    ConversationMessageNotFound,
     ConversationNotFound,
     ConversationService,
     ConversationTokenBudgetExceeded,
@@ -65,6 +68,8 @@ _HTTP_ERRORS: dict[type[Exception], tuple[int, Any]] = {
     ConversationAccessDenied: (403, "conversation owned by another user"),
     ConversationAlreadyExists: (409, "conversation id already taken"),
     ConversationTokenBudgetExceeded: (429, _BUDGET_EXCEEDED_DETAIL),
+    ConversationMessageNotFound: (404, "message not found on active conversation branch"),
+    ConversationBranchConflict: (409, "conversation branch changed; reload and try again"),
     ConversationLinkRefused: (403, "a visitor cannot adopt another visitor"),
 }
 
@@ -134,7 +139,17 @@ async def list_conversations(service: Service, caller: Caller) -> list[Conversat
 async def list_messages(conversation_id: str, service: Service, caller: Caller) -> list[MessageOut]:
     with _as_http_error():
         msgs = await service.history(conversation_id, caller)
-    return [MessageOut(role=m.role, content=m.content, created_at=m.created_at) for m in msgs]
+    return [
+        MessageOut(
+            message_id=m.message_id,
+            run_id=m.run_id,
+            role=m.role,
+            content=m.content,
+            status=m.status,
+            created_at=m.created_at,
+        )
+        for m in msgs
+    ]
 
 
 @router.get("/conversations/{conversation_id}/usage", response_model=TokenBudgetResponse)
@@ -189,7 +204,12 @@ async def send_message(
 ) -> SendMessageResponse:
     try:
         with _as_http_error():
-            result = await service.send(conversation_id, body.message, caller)
+            result = await service.send(
+                conversation_id,
+                body.message,
+                caller,
+                edit_message_id=body.edit_message_id,
+            )
     except HTTPException:
         raise
 
@@ -240,6 +260,97 @@ async def decide_approval(
     return _run_response(result)
 
 
+@router.post(
+    "/conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision/stream"
+)
+async def stream_approval_decision(
+    conversation_id: str,
+    run_id: str,
+    approval_id: str,
+    body: ApprovalDecisionRequest,
+    service: Service,
+    caller: Caller,
+) -> StreamingResponse:
+    with _as_http_error():
+        stream = cast(
+            AsyncGenerator[RunStreamEvent, None],
+            await service.stream_approval(
+                conversation_id,
+                run_id,
+                approval_id,
+                body.decision,
+                caller,
+            ),
+        )
+
+    async def event_source() -> AsyncIterator[str]:
+        try:
+            async for event in stream:
+                payload = _to_stream_event(event).model_dump(exclude_none=True)
+                yield f"event: {event.type}\ndata: {json.dumps(payload)}\n\n"
+        except ApprovalError as exc:
+            logger.info(
+                "approval resume stream rejected",
+                extra={"run_id": run_id, "approval_id": approval_id},
+            )
+            _, detail = _APPROVAL_HTTP_ERRORS.get(
+                type(exc), (409, "approval could not be processed")
+            )
+            payload = {"type": "error", "error": detail}
+            yield f"event: error\ndata: {json.dumps(payload)}\n\n"
+        except Exception:
+            logger.exception(
+                "approval resume stream failed",
+                extra={"run_id": run_id, "approval_id": approval_id},
+            )
+            payload = {"type": "error", "error": _INTERNAL_ERROR_MESSAGE}
+            yield f"event: error\ndata: {json.dumps(payload)}\n\n"
+        finally:
+            await stream.aclose()
+        yield "event: done\ndata: [DONE]\n\n"
+
+    return StreamingResponse(event_source(), media_type="text/event-stream")
+
+
+@router.post(
+    "/conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/cancel",
+    response_model=CancelRunResponse,
+)
+async def cancel_pending_approval(
+    conversation_id: str,
+    run_id: str,
+    approval_id: str,
+    service: Service,
+    caller: Caller,
+) -> CancelRunResponse:
+    try:
+        with _as_http_error():
+            await service.cancel_pending_approval(
+                conversation_id,
+                run_id,
+                approval_id,
+                caller,
+            )
+    except HTTPException:
+        raise
+    except ApprovalError as exc:
+        logger.info(
+            "approval cancellation rejected",
+            extra={"run_id": run_id, "approval_id": approval_id},
+        )
+        status, detail = _APPROVAL_HTTP_ERRORS.get(
+            type(exc), (409, "approval could not be cancelled")
+        )
+        raise HTTPException(status_code=status, detail=detail) from None
+    except Exception:
+        logger.exception(
+            "approval cancellation failed",
+            extra={"run_id": run_id, "approval_id": approval_id},
+        )
+        raise HTTPException(status_code=500, detail=_INTERNAL_ERROR_MESSAGE) from None
+    return CancelRunResponse(run_id=run_id)
+
+
 def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
     return StreamEventOut(
         type=event.type,
@@ -266,27 +377,46 @@ def _to_stream_event(event: RunStreamEvent) -> StreamEventOut:
 async def stream_message(
     conversation_id: str, body: SendMessageRequest, service: Service, caller: Caller
 ) -> StreamingResponse:
-    stream = service.stream(conversation_id, body.message, caller)
-
-    try:
-        with _as_http_error():
-            first = await stream.__anext__()
-    except StopAsyncIteration:
-        first = None
+    with _as_http_error():
+        turn = await service.prepare_turn(
+            conversation_id,
+            body.message,
+            caller,
+            edit_message_id=body.edit_message_id,
+        )
+    stream = cast(
+        AsyncGenerator[RunStreamEvent, None],
+        service.stream_turn(turn),
+    )
 
     async def event_source() -> AsyncIterator[str]:
+        suspended = False
+        exhausted = False
         try:
-            if first is not None:
-                payload = _to_stream_event(first).model_dump(exclude_none=True)
-                yield f"event: {first.type}\ndata: {json.dumps(payload)}\n\n"
+            started = StreamEventOut(
+                type="turn_started",
+                run_id=turn.run_id,
+                message_id=turn.message_id,
+            ).model_dump(exclude_none=True)
+            yield f"event: turn_started\ndata: {json.dumps(started)}\n\n"
             async for event in stream:
+                suspended = suspended or event.type == "pending_approval"
                 payload = _to_stream_event(event).model_dump(exclude_none=True)
                 yield f"event: {event.type}\ndata: {json.dumps(payload)}\n\n"
+            exhausted = True
         except Exception:
+            await service.fail_turn(turn)
             logger.exception("conversation stream failed")
             payload = {"type": "error", "error": _INTERNAL_ERROR_MESSAGE}
             yield f"event: error\ndata: {json.dumps(payload)}\n\n"
         finally:
-            yield "event: done\ndata: [DONE]\n\n"
+            # StreamingResponse cancellation closes the application-owned
+            # generator, which in turn cancels and awaits the graph producer.
+            try:
+                await stream.aclose()
+            finally:
+                if not exhausted and not suspended:
+                    await service.cancel_turn(turn)
+        yield "event: done\ndata: [DONE]\n\n"
 
     return StreamingResponse(event_source(), media_type="text/event-stream")

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -403,6 +403,8 @@ async def stream_message(
             exhausted = True
         except Exception:
             await service.fail_turn(turn)
+            # The run is already terminal; `finally` must not try to cancel it.
+            exhausted = True
             logger.exception("conversation stream failed")
             payload = {"type": "error", "error": _INTERNAL_ERROR_MESSAGE}
             yield f"event: error\ndata: {json.dumps(payload)}\n\n"

--- a/src/agent_manager/api/routes.py
+++ b/src/agent_manager/api/routes.py
@@ -293,10 +293,7 @@ async def stream_approval_decision(
                 "approval resume stream rejected",
                 extra={"run_id": run_id, "approval_id": approval_id},
             )
-            _, detail = _APPROVAL_HTTP_ERRORS.get(
-                type(exc), (409, "approval could not be processed")
-            )
-            payload = {"type": "error", "error": detail}
+            payload = {"type": "error", "error": approval_public_message(exc)}
             yield f"event: error\ndata: {json.dumps(payload)}\n\n"
         except Exception:
             logger.exception(
@@ -338,10 +335,10 @@ async def cancel_pending_approval(
             "approval cancellation rejected",
             extra={"run_id": run_id, "approval_id": approval_id},
         )
-        status, detail = _APPROVAL_HTTP_ERRORS.get(
-            type(exc), (409, "approval could not be cancelled")
-        )
-        raise HTTPException(status_code=status, detail=detail) from None
+        raise HTTPException(
+            status_code=approval_http_status(exc),
+            detail=approval_public_message(exc),
+        ) from None
     except Exception:
         logger.exception(
             "approval cancellation failed",

--- a/src/agent_manager/api/schemas.py
+++ b/src/agent_manager/api/schemas.py
@@ -48,13 +48,17 @@ class ConversationSummary(BaseModel):
 
 
 class MessageOut(BaseModel):
+    message_id: str
+    run_id: str | None = None
     role: Role
     content: str
+    status: str
     created_at: datetime
 
 
 class SendMessageRequest(BaseModel):
     message: str
+    edit_message_id: str | None = None
 
 
 class ToolRecord(BaseModel):
@@ -90,6 +94,11 @@ class ApprovalDecisionRequest(BaseModel):
     decision: ApprovalDecision
 
 
+class CancelRunResponse(BaseModel):
+    run_id: str
+    status: str = "cancelled"
+
+
 class TokenBudgetResponse(BaseModel):
     used_tokens: int
     max_tokens: int | None = None
@@ -109,6 +118,7 @@ class StreamEventOut(BaseModel):
     system_name: str | None = None
     used_tools: list[ToolRecord] | None = None
     run_id: str | None = None
+    message_id: str | None = None
     approval_id: str | None = None
     agent_id: str | None = None
     description: str | None = None

--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -52168,10 +52168,11 @@ var AgentChatClient = class {
     const response = await this.request(`/conversations/${conversationId}/messages`);
     return await response.json();
   }
-  async sendMessage(conversationId, message) {
+  async sendMessage(conversationId, message, signal, editMessageId) {
     const response = await this.request(`/conversations/${conversationId}/messages`, {
       method: "POST",
-      body: JSON.stringify({ message })
+      body: JSON.stringify({ message, edit_message_id: editMessageId }),
+      signal
     });
     return parseRunResponse(await response.json());
   }
@@ -52185,6 +52186,23 @@ var AgentChatClient = class {
     );
     return parseRunResponse(await response.json());
   }
+  async *streamApproval(conversationId, runId, approvalId, decision, signal) {
+    const response = await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/decision/stream`,
+      {
+        method: "POST",
+        body: JSON.stringify({ decision }),
+        signal
+      }
+    );
+    yield* readSseResponse(response);
+  }
+  async cancelApproval(conversationId, runId, approvalId) {
+    await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/cancel`,
+      { method: "POST", body: "{}" }
+    );
+  }
   async getUsage(conversationId) {
     const response = await this.request(`/conversations/${conversationId}/usage`);
     const data = await response.json();
@@ -52195,37 +52213,45 @@ var AgentChatClient = class {
       severity: data.severity ?? "normal"
     };
   }
-  async *streamMessage(conversationId, message) {
+  async *streamMessage(conversationId, message, signal, editMessageId) {
     const response = await this.request(`/conversations/${conversationId}/messages/stream`, {
       method: "POST",
-      body: JSON.stringify({ message })
+      body: JSON.stringify({ message, edit_message_id: editMessageId }),
+      signal
     });
-    if (!response.body) {
-      throw new Error("Streaming response has no body");
-    }
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const frames = buffer.split(/\n\n/);
-        buffer = frames.pop() ?? "";
-        for (const frame of frames) {
-          const event2 = parseSseFrame(frame);
-          if (event2) yield event2;
-        }
-      }
-      buffer += decoder.decode();
-      const event = parseSseFrame(buffer);
-      if (event) yield event;
-    } finally {
-      reader.releaseLock();
-    }
+    yield* readSseResponse(response);
   }
 };
+async function* readSseResponse(response) {
+  if (!response.body) {
+    throw new Error("Streaming response has no body");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split(/\r?\n\r?\n/);
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const event2 = parseSseFrame(frame);
+        if (event2) yield event2;
+      }
+    }
+    buffer += decoder.decode();
+    const event = parseSseFrame(buffer);
+    if (event) yield event;
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+    }
+    reader.releaseLock();
+  }
+}
 function parseRunResponse(data) {
   return {
     answer: String(data.answer || ""),
@@ -52530,8 +52556,14 @@ var __iconNode10 = [
 ];
 var SquarePen = createLucideIcon("square-pen", __iconNode10);
 
-// node_modules/lucide-react/dist/esm/icons/wrench.mjs
+// node_modules/lucide-react/dist/esm/icons/square.mjs
 var __iconNode11 = [
+  ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
+];
+var Square = createLucideIcon("square", __iconNode11);
+
+// node_modules/lucide-react/dist/esm/icons/wrench.mjs
+var __iconNode12 = [
   [
     "path",
     {
@@ -52540,14 +52572,14 @@ var __iconNode11 = [
     }
   ]
 ];
-var Wrench = createLucideIcon("wrench", __iconNode11);
+var Wrench = createLucideIcon("wrench", __iconNode12);
 
 // node_modules/lucide-react/dist/esm/icons/x.mjs
-var __iconNode12 = [
+var __iconNode13 = [
   ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
   ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
 ];
-var X = createLucideIcon("x", __iconNode12);
+var X = createLucideIcon("x", __iconNode13);
 
 // src/agent_manager/api/static/widget/react/AgentChatApp.tsx
 var import_react10 = __toESM(require_react(), 1);
@@ -53064,9 +53096,11 @@ var MessageResponse = (0, import_react8.memo)(function MessageResponse2({
 function PromptInput({
   children: children2,
   className,
+  submitEnabled = true,
   onSubmit
 }) {
   function submit(form) {
+    if (!submitEnabled) return;
     const input = form.elements.namedItem("message");
     const text10 = input?.value.trim() ?? "";
     if (!text10) return;
@@ -53116,8 +53150,22 @@ function PromptInputTextarea({
 function PromptInputFooter({ children: children2 }) {
   return /* @__PURE__ */ (0, import_jsx_runtime3.jsx)("div", { className: "prompt-footer", children: children2 });
 }
-function PromptInputSubmit({ disabled }) {
-  return /* @__PURE__ */ (0, import_jsx_runtime3.jsx)("button", { "aria-label": "Send message", className: "send", disabled, type: "submit", children: /* @__PURE__ */ (0, import_jsx_runtime3.jsx)(Send, { "aria-hidden": "true" }) });
+function PromptInputSubmit({
+  disabled,
+  running = false,
+  onStop
+}) {
+  return /* @__PURE__ */ (0, import_jsx_runtime3.jsx)(
+    "button",
+    {
+      "aria-label": running ? "Stop generating" : "Send message",
+      className: "send",
+      disabled,
+      onClick: running ? onStop : void 0,
+      type: running ? "button" : "submit",
+      children: running ? /* @__PURE__ */ (0, import_jsx_runtime3.jsx)(Square, { "aria-hidden": "true" }) : /* @__PURE__ */ (0, import_jsx_runtime3.jsx)(Send, { "aria-hidden": "true" })
+    }
+  );
 }
 function Tool({ children: children2, defaultOpen = false }) {
   return /* @__PURE__ */ (0, import_jsx_runtime3.jsx)("details", { className: "tool", open: defaultOpen, children: children2 });
@@ -53157,6 +53205,16 @@ var TOOL_STATUS = {
 };
 function reduceStreamEvent(entry, event) {
   switch (event.type) {
+    case "turn_started":
+      return entry;
+    case "resume_started":
+      return {
+        ...entry,
+        typing: true,
+        approval: void 0,
+        approvalSubmitting: false,
+        approvalError: void 0
+      };
     case "answer_delta":
       return { ...entry, text: entry.text + (event.content ?? "") };
     case "route":
@@ -53237,26 +53295,38 @@ function useConversation(client, endpoint, onReplaced) {
     [endpoint, startConversation, onReplaced]
   );
   const send = (0, import_react9.useCallback)(
-    async (conversationId, text10) => {
+    async (conversationId, text10, signal, editMessageId) => {
       try {
-        return await client.sendMessage(conversationId, text10);
+        return await client.sendMessage(conversationId, text10, signal, editMessageId);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await replace2(conversationId), text10);
+        return client.sendMessage(await replace2(conversationId), text10, signal);
       }
     },
     [client, replace2]
   );
   const stream = (0, import_react9.useCallback)(
-    async function* (conversationId, text10) {
+    async function* (conversationId, text10, signal, editMessageId) {
       try {
-        yield* client.streamMessage(conversationId, text10);
+        yield* client.streamMessage(conversationId, text10, signal, editMessageId);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await replace2(conversationId), text10);
+        yield* client.streamMessage(await replace2(conversationId), text10, signal);
       }
     },
     [client, replace2]
+  );
+  const decideApproval = (0, import_react9.useCallback)(
+    (conversationId, runId, approvalId, decision) => client.decideApproval(conversationId, runId, approvalId, decision),
+    [client]
+  );
+  const streamApproval = (0, import_react9.useCallback)(
+    (conversationId, runId, approvalId, decision, signal) => client.streamApproval(conversationId, runId, approvalId, decision, signal),
+    [client]
+  );
+  const cancelApproval = (0, import_react9.useCallback)(
+    (conversationId, runId, approvalId) => client.cancelApproval(conversationId, runId, approvalId),
+    [client]
   );
   const loadHistory = (0, import_react9.useCallback)(
     async (conversationId) => {
@@ -53296,6 +53366,9 @@ function useConversation(client, endpoint, onReplaced) {
       ensureId,
       send,
       stream,
+      decideApproval,
+      streamApproval,
+      cancelApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -53307,6 +53380,9 @@ function useConversation(client, endpoint, onReplaced) {
       ensureId,
       send,
       stream,
+      decideApproval,
+      streamApproval,
+      cancelApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -53328,22 +53404,16 @@ var terminalApprovalMessage = (status) => {
   return "This approval is no longer available. You can continue chatting.";
 };
 var newId = randomId;
-var toEntry = (message) => ({
-  id: newId(),
-  role: message.role === "user" ? "user" : "ai",
-  text: message.content
-});
-var applyRunResponse = (entry, response) => ({
-  ...entry,
-  text: response.answer,
-  typing: false,
-  error: false,
-  route: response.visited ?? entry.route,
-  tools: response.used_tools ?? entry.tools,
-  approval: response.pending_approval ?? void 0,
-  approvalSubmitting: false,
-  approvalError: void 0
-});
+var toEntries = (message) => {
+  const entry = {
+    id: newId(),
+    messageId: message.message_id,
+    runId: message.run_id ?? void 0,
+    role: message.role === "user" ? "user" : "ai",
+    text: message.content
+  };
+  return message.role === "user" && message.status === "cancelled" ? [entry, { id: newId(), role: "ai", text: "", status: "cancelled" }] : [entry];
+};
 function AgentChatApp({
   client,
   config,
@@ -53354,24 +53424,58 @@ function AgentChatApp({
   const inline = config.mode === "inline";
   const [open, setOpen] = (0, import_react10.useState)(inline);
   const [loaded, setLoaded] = (0, import_react10.useState)(false);
-  const [sending, setSending] = (0, import_react10.useState)(false);
+  const [activeExecution, setActiveExecution] = (0, import_react10.useState)(null);
   const [budgetExceeded, setBudgetExceeded] = (0, import_react10.useState)(false);
   const [entriesById, setEntriesById] = (0, import_react10.useState)({});
   const [usageById, setUsageById] = (0, import_react10.useState)({});
   const [activeId, setActiveId] = (0, import_react10.useState)("");
+  const [editing, setEditing] = (0, import_react10.useState)(null);
   const entries = entriesById[activeId] ?? [];
   const usage = usageById[activeId] ?? null;
+  const isExecutionActive = activeExecution !== null;
   const awaitingApproval = entries.some((entry) => entry.approval !== void 0);
+  const approvalBlocksComposer = awaitingApproval && editing === null && !isExecutionActive;
+  const canEdit = true;
+  const canSubmit = !isExecutionActive && !budgetExceeded && !approvalBlocksComposer;
+  const canStop = isExecutionActive;
   const [threads, setThreads] = (0, import_react10.useState)([]);
   const [threadsOpen, setThreadsOpen] = (0, import_react10.useState)(false);
   const launcherRef = (0, import_react10.useRef)(null);
   const inputRef = (0, import_react10.useRef)(null);
   const approvalRequestsRef = (0, import_react10.useRef)(/* @__PURE__ */ new Set());
+  const approvalCancellationRequestsRef = (0, import_react10.useRef)(/* @__PURE__ */ new Set());
+  const activeExecutionRef = (0, import_react10.useRef)(null);
+  const replacementIdsRef = (0, import_react10.useRef)(/* @__PURE__ */ new Map());
+  const resolveConversationId = (0, import_react10.useCallback)((conversationId) => {
+    let resolved = conversationId;
+    while (replacementIdsRef.current.has(resolved)) {
+      resolved = replacementIdsRef.current.get(resolved);
+    }
+    return resolved;
+  }, []);
   const onReplaced = (0, import_react10.useCallback)((staleId, freshId) => {
+    replacementIdsRef.current.set(staleId, freshId);
     setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
     setActiveId((current) => current === staleId ? freshId : current);
   }, []);
   const conversation = useConversation(client, config.endpoint, onReplaced);
+  (0, import_react10.useEffect)(
+    () => () => {
+      activeExecutionRef.current?.controller.abort();
+    },
+    []
+  );
+  const beginExecution = (0, import_react10.useCallback)((execution) => {
+    if (activeExecutionRef.current !== null) return false;
+    activeExecutionRef.current = execution;
+    setActiveExecution(execution);
+    return true;
+  }, []);
+  const finishExecution = (0, import_react10.useCallback)((controller) => {
+    if (activeExecutionRef.current?.controller !== controller) return;
+    activeExecutionRef.current = null;
+    setActiveExecution(null);
+  }, []);
   const refreshUsage = (0, import_react10.useCallback)(
     async (cid) => {
       const next2 = await conversation.loadUsage(cid);
@@ -53386,7 +53490,7 @@ function AgentChatApp({
   const loadThread = (0, import_react10.useCallback)(
     async (cid) => {
       const history = await conversation.loadHistory(cid);
-      putEntries(cid, () => history.map(toEntry));
+      putEntries(cid, () => history.flatMap(toEntries));
     },
     [conversation, putEntries]
   );
@@ -53403,8 +53507,8 @@ function AgentChatApp({
     if (inline) void loadHistory();
   }, [inline, loadHistory]);
   (0, import_react10.useEffect)(() => {
-    if (open && !awaitingApproval) inputRef.current?.focus({ preventScroll: true });
-  }, [open, loaded, sending, awaitingApproval]);
+    if (open && !approvalBlocksComposer) inputRef.current?.focus({ preventScroll: true });
+  }, [open, loaded, isExecutionActive, approvalBlocksComposer]);
   const openChat = (0, import_react10.useCallback)(async () => {
     if (inline) return;
     setOpen(true);
@@ -53437,104 +53541,250 @@ function AgentChatApp({
     inputRef.current?.focus({ preventScroll: true });
   }, [conversation]);
   const replaceEntry = (0, import_react10.useCallback)(
-    (cid, id, entry) => putEntries(cid, (prev) => prev.map((current) => current.id === id ? entry : current)),
-    [putEntries]
-  );
-  const sendWithoutStreaming = (0, import_react10.useCallback)(
-    async (cid, text10, entryId) => {
-      try {
-        const answer = await conversation.send(cid, text10);
-        replaceEntry(
-          cid,
-          entryId,
-          applyRunResponse({ id: entryId, role: "ai", text: "" }, answer)
-        );
-        if (!answer.pending_approval) {
-          onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
-        }
-      } catch (error) {
-        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
-        if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
-          setBudgetExceeded(true);
-        }
-        const errorMessage = is4xx ? error.message : GENERIC_ERROR;
-        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: errorMessage, error: true });
-      }
+    (cid, id, entry) => {
+      const resolvedId = resolveConversationId(cid);
+      putEntries(
+        resolvedId,
+        (prev) => prev.map((current) => current.id === id ? entry : current)
+      );
     },
-    [conversation, onAnswer, replaceEntry]
+    [putEntries, resolveConversationId]
   );
+  const stop = (0, import_react10.useCallback)(() => {
+    activeExecution?.controller.abort();
+  }, [activeExecution]);
+  const editMessage = (0, import_react10.useCallback)((entry) => {
+    if (!entry.messageId || !inputRef.current) return;
+    setEditing({ messageId: entry.messageId, previousDraft: inputRef.current.value });
+    inputRef.current.value = entry.text;
+    inputRef.current.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    inputRef.current.focus({ preventScroll: true });
+  }, []);
+  const cancelEditing = (0, import_react10.useCallback)(() => {
+    if (inputRef.current && editing) {
+      inputRef.current.value = editing.previousDraft;
+      inputRef.current.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      inputRef.current.focus({ preventScroll: true });
+    }
+    setEditing(null);
+  }, [editing]);
   const decideApproval = (0, import_react10.useCallback)(
-    async (cid, entryId, approval, decision) => {
-      if (approvalRequestsRef.current.has(approval.approval_id)) return;
+    async (cid, initialEntry, approval, decision) => {
+      if (approvalRequestsRef.current.has(approval.approval_id) || activeExecutionRef.current !== null) {
+        return;
+      }
+      const controller = new AbortController();
+      if (!beginExecution({
+        controller,
+        runId: approval.run_id,
+        source: "approval"
+      })) {
+        return;
+      }
       approvalRequestsRef.current.add(approval.approval_id);
       putEntries(
         cid,
         (prev) => prev.map(
-          (entry) => entry.id === entryId ? { ...entry, approvalSubmitting: true, approvalError: void 0 } : entry
+          (entry2) => entry2.id === initialEntry.id ? { ...entry2, approvalSubmitting: true, approvalError: void 0 } : entry2
         )
       );
+      let entry = initialEntry;
+      let completed = false;
+      let resumeStarted = false;
       try {
-        const result = await client.decideApproval(
+        for await (const event of conversation.streamApproval(
           cid,
           approval.run_id,
           approval.approval_id,
-          decision
-        );
+          decision,
+          controller.signal
+        )) {
+          if (controller.signal.aborted && event.type !== "final") break;
+          resumeStarted || (resumeStarted = event.type === "resume_started");
+          completed || (completed = event.type === "final");
+          entry = reduceStreamEvent(entry, event);
+          replaceEntry(cid, initialEntry.id, entry);
+        }
+        if (controller.signal.aborted && !completed) {
+          if (!resumeStarted) {
+            await conversation.cancelApproval(cid, approval.run_id, approval.approval_id).catch(() => {
+            });
+          }
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: "",
+            status: "cancelled"
+          });
+          return;
+        }
+        replaceEntry(cid, initialEntry.id, { ...entry, typing: false });
+        if (completed && !entry.approval) {
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+        }
+      } catch (error) {
+        if (controller.signal.aborted && !completed) {
+          if (!resumeStarted) {
+            await conversation.cancelApproval(cid, approval.run_id, approval.approval_id).catch(() => {
+            });
+          }
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: "",
+            status: "cancelled"
+          });
+          return;
+        }
+        if (completed) {
+          replaceEntry(cid, initialEntry.id, { ...entry, typing: false });
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+          return;
+        }
+        if (resumeStarted) {
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: GENERIC_ERROR,
+            error: true
+          });
+          return;
+        }
+        const terminal = isTerminalApprovalError(error);
         putEntries(
           cid,
-          (prev) => prev.map((entry) => entry.id === entryId ? applyRunResponse(entry, result) : entry)
+          (prev) => prev.map(
+            (entry2) => entry2.id === initialEntry.id && entry2.approval?.approval_id === approval.approval_id && !entry2.approvalCancelling ? {
+              ...entry2,
+              ...terminal ? {
+                text: terminalApprovalMessage(error.status),
+                error: true,
+                approval: void 0
+              } : {},
+              approvalSubmitting: false,
+              approvalError: terminal ? void 0 : GENERIC_ERROR
+            } : entry2
+          )
         );
-        if (!result.pending_approval) {
-          onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
-        }
+      } finally {
+        approvalRequestsRef.current.delete(approval.approval_id);
+        finishExecution(controller);
+        void refreshUsage(cid);
+      }
+    },
+    [
+      beginExecution,
+      conversation,
+      finishExecution,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry
+    ]
+  );
+  const cancelApproval = (0, import_react10.useCallback)(
+    async (cid, entryId, approval) => {
+      if (approvalCancellationRequestsRef.current.has(approval.approval_id)) return;
+      approvalCancellationRequestsRef.current.add(approval.approval_id);
+      putEntries(
+        cid,
+        (prev) => prev.map(
+          (entry) => entry.id === entryId ? { ...entry, approvalCancelling: true, approvalError: void 0 } : entry
+        )
+      );
+      try {
+        await conversation.cancelApproval(cid, approval.run_id, approval.approval_id);
+        putEntries(
+          cid,
+          (prev) => prev.map(
+            (entry) => entry.id === entryId ? { id: entry.id, role: "ai", text: "", status: "cancelled" } : entry
+          )
+        );
       } catch (error) {
         const terminal = isTerminalApprovalError(error);
         putEntries(
           cid,
           (prev) => prev.map(
-            (entry) => entry.id === entryId ? terminal ? {
+            (entry) => entry.id === entryId && entry.approval?.approval_id === approval.approval_id ? {
               ...entry,
-              text: terminalApprovalMessage(error.status),
-              error: true,
-              approval: void 0,
-              approvalSubmitting: false,
-              approvalError: void 0
-            } : {
-              ...entry,
-              approvalSubmitting: false,
-              approvalError: GENERIC_ERROR
+              ...terminal ? {
+                text: terminalApprovalMessage(error.status),
+                error: true,
+                approval: void 0
+              } : {},
+              approvalCancelling: false,
+              approvalError: terminal ? void 0 : GENERIC_ERROR
             } : entry
           )
         );
       } finally {
-        approvalRequestsRef.current.delete(approval.approval_id);
+        approvalCancellationRequestsRef.current.delete(approval.approval_id);
         void refreshUsage(cid);
       }
     },
-    [client, onAnswer, putEntries, refreshUsage]
+    [conversation, putEntries, refreshUsage]
   );
   const submit = (0, import_react10.useCallback)(
-    async (text10) => {
+    async (text10, editMessageId) => {
+      if (activeExecutionRef.current !== null) return;
       const cid = await conversation.ensureId();
       setActiveId(cid);
+      let userEntry = { id: newId(), role: "user", text: text10 };
       const pending = { id: newId(), role: "ai", text: "", typing: true };
-      putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text: text10 }, pending]);
-      setSending(true);
+      const controller = new AbortController();
+      if (!beginExecution({ controller, source: "prompt" })) return;
+      putEntries(cid, (prev) => {
+        if (!editMessageId) return [...prev, userEntry, pending];
+        const branchPoint = prev.findIndex((entry2) => entry2.messageId === editMessageId);
+        return [...branchPoint < 0 ? prev : prev.slice(0, branchPoint), userEntry, pending];
+      });
+      setEditing(null);
       let entry = pending;
-      let receivedEvent = false;
       let completed = false;
       try {
-        for await (const event of conversation.stream(cid, text10)) {
-          receivedEvent = true;
+        for await (const event of conversation.stream(
+          cid,
+          text10,
+          controller.signal,
+          editMessageId
+        )) {
+          if (controller.signal.aborted && event.type !== "final") break;
+          if (event.type === "turn_started") {
+            userEntry = {
+              ...userEntry,
+              messageId: event.message_id,
+              runId: event.run_id
+            };
+            replaceEntry(cid, userEntry.id, userEntry);
+            continue;
+          }
           completed || (completed = event.type === "final");
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
+        }
+        if (controller.signal.aborted && !completed) {
+          replaceEntry(cid, pending.id, {
+            id: pending.id,
+            role: "ai",
+            text: "",
+            status: "cancelled"
+          });
+          return;
         }
         replaceEntry(cid, pending.id, { ...entry, typing: false });
         if (!entry.approval) {
           onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
         }
       } catch (error) {
+        if (controller.signal.aborted && !completed) {
+          replaceEntry(cid, pending.id, {
+            id: pending.id,
+            role: "ai",
+            text: "",
+            status: "cancelled"
+          });
+          return;
+        }
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
           setBudgetExceeded(true);
@@ -53544,18 +53794,25 @@ function AgentChatApp({
           onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
         } else if (entry.approval) {
           replaceEntry(cid, pending.id, { ...entry, typing: false });
-        } else if (is4xx || receivedEvent) {
+        } else {
           const message = is4xx ? error.message : GENERIC_ERROR;
           replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: message, error: true });
-        } else {
-          await sendWithoutStreaming(cid, text10, pending.id);
         }
       } finally {
-        setSending(false);
-        void refreshUsage(cid);
+        finishExecution(controller);
+        void refreshUsage(resolveConversationId(cid));
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming]
+    [
+      conversation,
+      beginExecution,
+      finishExecution,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry,
+      resolveConversationId
+    ]
   );
   const toggle = () => void (open ? closeChat() : openChat());
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(
@@ -53624,30 +53881,48 @@ function AgentChatApp({
                     ChatMessage,
                     {
                       entry,
-                      onApproval: (approval, decision) => void decideApproval(activeId, entry.id, approval, decision)
+                      onApproval: (approval, decision) => void decideApproval(activeId, entry, approval, decision),
+                      onCancelApproval: (approval) => void cancelApproval(activeId, entry.id, approval),
+                      onEdit: () => editMessage(entry),
+                      editable: canEdit
                     },
                     entry.id
                   ))
                 ] }) }),
-                /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(PromptInput, { onSubmit: (message) => void submit(message.text), children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
-                    PromptInputTextarea,
-                    {
-                      "aria-label": "Message",
-                      disabled: sending || budgetExceeded || awaitingApproval,
-                      inputRef,
-                      onSubmit: () => inputRef.current?.form?.requestSubmit(),
-                      placeholder: budgetExceeded ? "Context limit reached." : awaitingApproval ? "Respond to the approval request above." : "Message..."
-                    }
-                  ),
-                  /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(PromptInputFooter, { children: [
-                    /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "footer-start", children: [
-                      usage ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(BudgetMeter, { usage }) : null,
-                      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "prompt-hint", children: "Enter to send \xB7 Shift+Enter for a new line" })
-                    ] }),
-                    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(PromptInputSubmit, { disabled: sending || budgetExceeded || awaitingApproval })
-                  ] })
-                ] }),
+                /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(
+                  PromptInput,
+                  {
+                    submitEnabled: canSubmit,
+                    onSubmit: (message) => void submit(message.text, editing?.messageId),
+                    children: [
+                      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+                        PromptInputTextarea,
+                        {
+                          "aria-label": "Message",
+                          disabled: budgetExceeded || approvalBlocksComposer,
+                          inputRef,
+                          onSubmit: () => inputRef.current?.form?.requestSubmit(),
+                          placeholder: budgetExceeded ? "Context limit reached." : approvalBlocksComposer ? "Respond to the approval request above." : "Message..."
+                        }
+                      ),
+                      /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(PromptInputFooter, { children: [
+                        /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "footer-start", children: [
+                          usage ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(BudgetMeter, { usage }) : null,
+                          editing ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("button", { className: "edit-cancel", onClick: cancelEditing, type: "button", children: "Cancel edit" }) : null,
+                          /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "prompt-hint", children: "Enter to send \xB7 Shift+Enter for a new line" })
+                        ] }),
+                        /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+                          PromptInputSubmit,
+                          {
+                            disabled: !canSubmit && !canStop,
+                            running: canStop,
+                            onStop: stop
+                          }
+                        )
+                      ] })
+                    ]
+                  }
+                ),
                 /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "powered", children: "Powered by Extra" })
               ] })
             ]
@@ -53688,14 +53963,23 @@ function Launcher({
 }
 function ChatMessage({
   entry,
-  onApproval
+  onApproval,
+  onCancelApproval,
+  onEdit,
+  editable
 }) {
   const from = entry.role === "user" ? "user" : "assistant";
   if (entry.error) {
     return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from, children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "msg-error", role: "alert", children: entry.text }) });
   }
+  if (entry.status === "cancelled") {
+    return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from: "assistant", children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "msg-cancelled", role: "status", children: "Generation stopped" }) });
+  }
   if (entry.role === "user") {
-    return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Message, { from: "user", children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: entry.text }) });
+    return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Message, { from: "user", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: entry.text }),
+      editable && entry.messageId ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("div", { className: "msg-actions user-actions", children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("button", { "aria-label": "Edit message", className: "user-edit", onClick: onEdit, type: "button", children: "Edit" }) }) : null
+    ] });
   }
   const thinking = Boolean(entry.typing) && !entry.text.trim();
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Message, { from: "assistant", typing: thinking, children: [
@@ -53706,8 +53990,10 @@ function ChatMessage({
         {
           approval: entry.approval,
           error: entry.approvalError,
+          cancelling: Boolean(entry.approvalCancelling),
           submitting: Boolean(entry.approvalSubmitting),
-          onDecision: (decision) => onApproval(entry.approval, decision)
+          onDecision: (decision) => onApproval(entry.approval, decision),
+          onCancel: () => onCancelApproval(entry.approval)
         }
       ) : null,
       entry.text.trim() ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageContent, { children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(MessageResponse, { children: entry.text }) }) : null,
@@ -53718,51 +54004,72 @@ function ChatMessage({
 function ApprovalRequest({
   approval,
   submitting,
+  cancelling,
   error,
-  onDecision
+  onDecision,
+  onCancel
 }) {
-  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("section", { className: "approval-card", "aria-busy": submitting, "aria-label": "Tool approval request", children: [
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-title", children: "Approval required" }),
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-description", children: approval.description }),
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("p", { className: "approval-tool", children: [
-      "Tool: ",
-      approval.tool_name
-    ] }),
-    error ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-error", role: "alert", children: error }) : null,
-    /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "approval-actions", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
-        "button",
-        {
-          className: "approval-button primary",
-          disabled: submitting,
-          onClick: () => onDecision("allow_once"),
-          type: "button",
-          children: "Approve"
-        }
-      ),
-      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
-        "button",
-        {
-          className: "approval-button danger",
-          disabled: submitting,
-          onClick: () => onDecision("deny"),
-          type: "button",
-          children: "Deny"
-        }
-      ),
-      /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
-        "button",
-        {
-          className: "approval-button",
-          disabled: submitting,
-          onClick: () => onDecision("allow_for_session"),
-          type: "button",
-          children: "Approve for this session"
-        }
-      )
-    ] }),
-    submitting ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "approval-status", children: "Applying decision\u2026" }) : null
-  ] });
+  return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(
+    "section",
+    {
+      className: "approval-card",
+      "aria-busy": submitting || cancelling,
+      "aria-label": "Tool approval request",
+      children: [
+        /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-title", children: "Approval required" }),
+        /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-description", children: approval.description }),
+        /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("p", { className: "approval-tool", children: [
+          "Tool: ",
+          approval.tool_name
+        ] }),
+        error ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("p", { className: "approval-error", role: "alert", children: error }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("div", { className: "approval-actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+            "button",
+            {
+              className: "approval-button primary",
+              disabled: submitting || cancelling,
+              onClick: () => onDecision("allow_once"),
+              type: "button",
+              children: "Approve"
+            }
+          ),
+          /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+            "button",
+            {
+              className: "approval-button danger",
+              disabled: submitting || cancelling,
+              onClick: () => onDecision("deny"),
+              type: "button",
+              children: "Deny"
+            }
+          ),
+          /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+            "button",
+            {
+              className: "approval-button",
+              disabled: submitting || cancelling,
+              onClick: () => onDecision("allow_for_session"),
+              type: "button",
+              children: "Approve for this session"
+            }
+          ),
+          /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
+            "button",
+            {
+              className: "approval-button cancel-run",
+              disabled: cancelling,
+              onClick: onCancel,
+              type: "button",
+              children: "Cancel run"
+            }
+          )
+        ] }),
+        cancelling ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "approval-status", children: "Cancelling run\u2026" }) : null,
+        !cancelling && submitting ? /* @__PURE__ */ (0, import_jsx_runtime4.jsx)("span", { className: "approval-status", children: "Applying decision\u2026" }) : null
+      ]
+    }
+  );
 }
 function ThinkingDots() {
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)("span", { className: "thinking", "aria-hidden": true, children: [
@@ -54030,12 +54337,17 @@ function styles(config) {
     .msg pre code { background: none; padding: 0; white-space: pre-wrap; }
     .msg-actions { display: flex; gap: 4px; margin-top: 6px;
       opacity: 0; transition: opacity .15s ease; }
-    .msg.ai:hover .msg-actions, .msg-actions:focus-within { opacity: 1; }
+    .msg.ai:hover .msg-actions, .msg.user:hover .msg-actions, .msg-actions:focus-within { opacity: 1; }
     .msg-action { display: inline-flex; align-items: center; justify-content: center;
       width: 26px; height: 26px; border: 0; border-radius: 7px; background: transparent;
       color: #71717a; cursor: pointer; transition: background .12s, color .12s; }
     .msg-action:hover { background: #f4f4f5; color: #18181b; }
     .msg-action svg { width: 15px; height: 15px; animation: aui-icon-in .15s ease; }
+    .user-actions { justify-content: flex-end; margin-bottom: -4px; opacity: 1; }
+    .user-edit, .edit-cancel { border: 0; background: transparent; color: #71717a;
+      cursor: pointer; font: inherit; padding: 2px 4px; }
+    .user-edit:hover, .edit-cancel:hover { color: #18181b; text-decoration: underline; }
+    .msg-cancelled { color: #71717a; font-style: italic; }
     @keyframes aui-icon-in { from { opacity: 0; transform: scale(.75); } }
     .tool-list { margin-bottom: 10px; display: flex; flex-direction: column; gap: 8px; }
     .agent-meta { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; color: #71717a;
@@ -54077,6 +54389,8 @@ function styles(config) {
     .approval-button.primary:hover:not(:disabled) { opacity: .88; }
     .approval-button.danger { border-color: transparent; background: transparent; color: #71717a; }
     .approval-button.danger:hover:not(:disabled) { background: #f4f4f5; color: #18181b; }
+    .approval-button.cancel-run { border-color: #fca5a5; color: #b91c1c; }
+    .approval-button.cancel-run:hover:not(:disabled) { background: #fef2f2; }
     .approval-button:disabled { cursor: default; opacity: .55; }
     .approval-error { margin: 8px 0 0; color: #b91c1c; font-size: 12px; }
     .approval-status { display: block; margin-top: 8px; color: #71717a; font-size: 12px; }
@@ -54540,6 +54854,14 @@ lucide-react/dist/esm/icons/send.mjs:
    *)
 
 lucide-react/dist/esm/icons/square-pen.mjs:
+  (**
+   * @license lucide-react v1.22.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide-react/dist/esm/icons/square.mjs:
   (**
    * @license lucide-react v1.22.0 - ISC
    *

--- a/src/agent_manager/api/static/widget.test.mjs
+++ b/src/agent_manager/api/static/widget.test.mjs
@@ -211,6 +211,15 @@ function jsonResponse(body, ok = true, status = ok ? 200 : 500) {
   return { ok, status, json: async () => body };
 }
 
+function sseResponse(events) {
+  const body = [
+    ...events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}`),
+    "event: done\ndata: [DONE]",
+    "",
+  ].join("\n\n");
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
 async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 0));
   await Promise.resolve();
@@ -328,6 +337,15 @@ globalThis.fetch = async (url, options = {}) => {
   if (url.endsWith("/runs/run-1/approvals/approval-1/decision")) {
     return jsonResponse({ answer: "approved", status: "completed", pending_approval: null });
   }
+  if (url.endsWith("/runs/run-1/approvals/approval-1/decision/stream")) {
+    return sseResponse([
+      { type: "resume_started", run_id: "run-1" },
+      { type: "final", content: "approved" },
+    ]);
+  }
+  if (url.endsWith("/runs/run-1/approvals/approval-1/cancel")) {
+    return jsonResponse({ run_id: "run-1", status: "cancelled" });
+  }
   throw new Error(`unexpected fetch: ${url}`);
 };
 let client = new AgentChatClient("https://api.example", new TokenSource("https://api.example"));
@@ -350,6 +368,91 @@ assert.equal(
 );
 assert.equal(JSON.parse(fetchCalls[2].options.body).decision, "allow_for_session");
 assert.equal(approvalResponse.answer, "approved");
+const approvalEvents = [];
+for await (const event of client.streamApproval(
+  conversationId,
+  "run-1",
+  "approval-1",
+  "allow_once",
+)) {
+  approvalEvents.push(event);
+}
+assert.equal(
+  fetchCalls[3].url,
+  "https://api.example/conversations/conv-1/runs/run-1/approvals/approval-1/decision/stream",
+);
+assert.deepEqual(approvalEvents.map((event) => event.type), ["resume_started", "final"]);
+await client.cancelApproval(conversationId, "run-1", "approval-1");
+assert.equal(
+  fetchCalls[4].url,
+  "https://api.example/conversations/conv-1/runs/run-1/approvals/approval-1/cancel",
+);
+assert.equal(fetchCalls[4].options.method, "POST");
+
+{
+  const controller = new AbortController();
+  let receivedSignal;
+  globalThis.fetch = async (_url, options = {}) => {
+    receivedSignal = options.signal;
+    throw new DOMException("cancelled", "AbortError");
+  };
+  const streaming = client.streamMessage("conv-1", "stop", controller.signal);
+  controller.abort();
+  await assert.rejects(() => streaming.next(), { name: "AbortError" });
+  assert.equal(receivedSignal, controller.signal, "the stream signal reaches fetch unchanged");
+}
+
+{
+  let readerCancelled = false;
+  const encoded = new TextEncoder().encode(
+    'event: answer_delta\ndata: {"type":"answer_delta","content":"partial"}\n\n',
+  );
+  const reader = {
+    read: async () => ({ done: false, value: encoded }),
+    cancel: async () => {
+      readerCancelled = true;
+    },
+    releaseLock: () => {},
+  };
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    body: { getReader: () => reader },
+  });
+  const streaming = client.streamMessage("conv-1", "stop");
+  assert.equal((await streaming.next()).value.content, "partial");
+  await streaming.return();
+  assert.equal(readerCancelled, true, "abandoning iteration cancels the response body");
+}
+
+{
+  const encoded = new TextEncoder().encode(
+    'event: turn_started\r\ndata: {"type":"turn_started","run_id":"run-crlf","message_id":"msg-crlf"}\r\n\r\n' +
+      'event: final\r\ndata: {"type":"final","content":"done"}\r\n\r\n',
+  );
+  const reads = [
+    { done: false, value: encoded },
+    { done: true, value: undefined },
+  ];
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () => reads.shift(),
+        cancel: async () => {},
+        releaseLock: () => {},
+      }),
+    },
+  });
+  const events = [];
+  for await (const event of client.streamMessage("conv-1", "crlf")) events.push(event);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["turn_started", "final"],
+    "CRLF-delimited SSE frames are parsed independently",
+  );
+}
 
 resetPage();
 globalThis.fetch = async (url) => {

--- a/src/agent_manager/api/static/widget/api/AgentChatClient.ts
+++ b/src/agent_manager/api/static/widget/api/AgentChatClient.ts
@@ -85,10 +85,16 @@ export class AgentChatClient {
     return (await response.json()) as ChatMessage[];
   }
 
-  async sendMessage(conversationId: string, message: string): Promise<SendMessageResponse> {
+  async sendMessage(
+    conversationId: string,
+    message: string,
+    signal?: AbortSignal,
+    editMessageId?: string,
+  ): Promise<SendMessageResponse> {
     const response = await this.request(`/conversations/${conversationId}/messages`, {
       method: "POST",
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, edit_message_id: editMessageId }),
+      signal,
     });
 
     return parseRunResponse(await response.json());
@@ -110,6 +116,35 @@ export class AgentChatClient {
     return parseRunResponse(await response.json());
   }
 
+  async *streamApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+    decision: ApprovalDecision,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent> {
+    const response = await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/decision/stream`,
+      {
+        method: "POST",
+        body: JSON.stringify({ decision }),
+        signal,
+      },
+    );
+    yield* readSseResponse(response);
+  }
+
+  async cancelApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+  ): Promise<void> {
+    await this.request(
+      `/conversations/${conversationId}/runs/${encodeURIComponent(runId)}/approvals/${encodeURIComponent(approvalId)}/cancel`,
+      { method: "POST", body: "{}" },
+    );
+  }
+
   async getUsage(conversationId: string): Promise<TokenBudget> {
     const response = await this.request(`/conversations/${conversationId}/usage`);
     const data = await response.json();
@@ -121,37 +156,52 @@ export class AgentChatClient {
     };
   }
 
-  async *streamMessage(conversationId: string, message: string): AsyncGenerator<StreamEvent> {
+  async *streamMessage(
+    conversationId: string,
+    message: string,
+    signal?: AbortSignal,
+    editMessageId?: string,
+  ): AsyncGenerator<StreamEvent> {
     const response = await this.request(`/conversations/${conversationId}/messages/stream`, {
       method: "POST",
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, edit_message_id: editMessageId }),
+      signal,
     });
 
-    if (!response.body) {
-      throw new Error("Streaming response has no body");
-    }
+    yield* readSseResponse(response);
+  }
+}
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const frames = buffer.split(/\n\n/);
-        buffer = frames.pop() ?? "";
-        for (const frame of frames) {
-          const event = parseSseFrame(frame);
-          if (event) yield event;
-        }
+async function* readSseResponse(response: Response): AsyncGenerator<StreamEvent> {
+  if (!response.body) {
+    throw new Error("Streaming response has no body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split(/\r?\n\r?\n/);
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const event = parseSseFrame(frame);
+        if (event) yield event;
       }
-      buffer += decoder.decode();
-      const event = parseSseFrame(buffer);
-      if (event) yield event;
-    } finally {
-      reader.releaseLock();
     }
+    buffer += decoder.decode();
+    const event = parseSseFrame(buffer);
+    if (event) yield event;
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // An AbortSignal may already have cancelled the response body.
+    }
+    reader.releaseLock();
   }
 }
 

--- a/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
+++ b/src/agent_manager/api/static/widget/react/AgentChatApp.tsx
@@ -20,7 +20,6 @@ import type {
   ChatMessage,
   MessageEntry,
   PendingApproval,
-  SendMessageResponse,
   ThreadSummary,
   TokenBudget,
   ToolRecord,
@@ -62,26 +61,24 @@ const terminalApprovalMessage = (status: number): string => {
 
 const newId = randomId;
 
-const toEntry = (message: ChatMessage): MessageEntry => ({
-  id: newId(),
-  role: message.role === "user" ? "user" : "ai",
-  text: message.content,
-});
+const toEntries = (message: ChatMessage): MessageEntry[] => {
+  const entry: MessageEntry = {
+    id: newId(),
+    messageId: message.message_id,
+    runId: message.run_id ?? undefined,
+    role: message.role === "user" ? "user" : "ai",
+    text: message.content,
+  };
+  return message.role === "user" && message.status === "cancelled"
+    ? [entry, { id: newId(), role: "ai", text: "", status: "cancelled" }]
+    : [entry];
+};
 
-const applyRunResponse = (
-  entry: MessageEntry,
-  response: SendMessageResponse,
-): MessageEntry => ({
-  ...entry,
-  text: response.answer,
-  typing: false,
-  error: false,
-  route: response.visited ?? entry.route,
-  tools: response.used_tools ?? entry.tools,
-  approval: response.pending_approval ?? undefined,
-  approvalSubmitting: false,
-  approvalError: undefined,
-});
+interface ActiveExecution {
+  controller: AbortController;
+  runId?: string;
+  source: "prompt" | "approval";
+}
 
 export interface AgentChatAppProps {
   client: AgentChatClient;
@@ -101,29 +98,67 @@ export function AgentChatApp({
   const inline = config.mode === "inline";
   const [open, setOpen] = useState(inline);
   const [loaded, setLoaded] = useState(false);
-  const [sending, setSending] = useState(false);
+  const [activeExecution, setActiveExecution] = useState<ActiveExecution | null>(null);
   const [budgetExceeded, setBudgetExceeded] = useState(false);
   const [entriesById, setEntriesById] = useState<Record<string, MessageEntry[]>>({});
   const [usageById, setUsageById] = useState<Record<string, TokenBudget | null>>({});
   const [activeId, setActiveId] = useState("");
+  const [editing, setEditing] = useState<{ messageId: string; previousDraft: string } | null>(null);
   const entries = entriesById[activeId] ?? [];
   const usage = usageById[activeId] ?? null;
+  const isExecutionActive = activeExecution !== null;
   const awaitingApproval = entries.some((entry) => entry.approval !== undefined);
+  const approvalBlocksComposer = awaitingApproval && editing === null && !isExecutionActive;
+  const canEdit = true;
+  const canSubmit = !isExecutionActive && !budgetExceeded && !approvalBlocksComposer;
+  const canStop = isExecutionActive;
 
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [threadsOpen, setThreadsOpen] = useState(false);
   const launcherRef = useRef<HTMLButtonElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const approvalRequestsRef = useRef(new Set<string>());
+  const approvalCancellationRequestsRef = useRef(new Set<string>());
+  const activeExecutionRef = useRef<ActiveExecution | null>(null);
+  const replacementIdsRef = useRef(new Map<string, string>());
+
+  const resolveConversationId = useCallback((conversationId: string) => {
+    let resolved = conversationId;
+    while (replacementIdsRef.current.has(resolved)) {
+      resolved = replacementIdsRef.current.get(resolved) as string;
+    }
+    return resolved;
+  }, []);
 
   // A vanished conversation is replaced mid-turn; carry its messages onto the
   // id the turn actually ran under so the view does not go blank.
   const onReplaced = useCallback((staleId: string, freshId: string) => {
+    replacementIdsRef.current.set(staleId, freshId);
     setEntriesById(({ [staleId]: moved = [], ...rest }) => ({ ...rest, [freshId]: moved }));
     setActiveId((current) => (current === staleId ? freshId : current));
   }, []);
 
   const conversation = useConversation(client, config.endpoint, onReplaced);
+
+  useEffect(
+    () => () => {
+      activeExecutionRef.current?.controller.abort();
+    },
+    [],
+  );
+
+  const beginExecution = useCallback((execution: ActiveExecution): boolean => {
+    if (activeExecutionRef.current !== null) return false;
+    activeExecutionRef.current = execution;
+    setActiveExecution(execution);
+    return true;
+  }, []);
+
+  const finishExecution = useCallback((controller: AbortController) => {
+    if (activeExecutionRef.current?.controller !== controller) return;
+    activeExecutionRef.current = null;
+    setActiveExecution(null);
+  }, []);
 
   const refreshUsage = useCallback(
     async (cid: string) => {
@@ -142,7 +177,7 @@ export function AgentChatApp({
   const loadThread = useCallback(
     async (cid: string) => {
       const history = await conversation.loadHistory(cid);
-      putEntries(cid, () => history.map(toEntry));
+      putEntries(cid, () => history.flatMap(toEntries));
     },
     [conversation, putEntries],
   );
@@ -162,8 +197,8 @@ export function AgentChatApp({
   }, [inline, loadHistory]);
 
   useEffect(() => {
-    if (open && !awaitingApproval) inputRef.current?.focus({ preventScroll: true });
-  }, [open, loaded, sending, awaitingApproval]);
+    if (open && !approvalBlocksComposer) inputRef.current?.focus({ preventScroll: true });
+  }, [open, loaded, isExecutionActive, approvalBlocksComposer]);
 
   const openChat = useCallback(async () => {
     if (inline) return;
@@ -204,117 +239,277 @@ export function AgentChatApp({
   }, [conversation]);
 
   const replaceEntry = useCallback(
-    (cid: string, id: string, entry: MessageEntry) =>
-      putEntries(cid, (prev) => prev.map((current) => (current.id === id ? entry : current))),
-    [putEntries],
-  );
-
-
-  const sendWithoutStreaming = useCallback(
-    async (cid: string, text: string, entryId: string) => {
-      try {
-        const answer = await conversation.send(cid, text);
-        replaceEntry(
-          cid,
-          entryId,
-          applyRunResponse({ id: entryId, role: "ai", text: "" }, answer),
-        );
-        if (!answer.pending_approval) {
-          onAnswer({ visited: answer.visited ?? [], used_tools: answer.used_tools ?? [] });
-        }
-      } catch (error) {
-        const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
-        if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
-          setBudgetExceeded(true);
-        }
-        const errorMessage = is4xx ? error.message : GENERIC_ERROR;
-        replaceEntry(cid, entryId, { id: entryId, role: "ai", text: errorMessage, error: true });
-      }
+    (cid: string, id: string, entry: MessageEntry) => {
+      const resolvedId = resolveConversationId(cid);
+      putEntries(resolvedId, (prev) =>
+        prev.map((current) => (current.id === id ? entry : current)),
+      );
     },
-    [conversation, onAnswer, replaceEntry],
+    [putEntries, resolveConversationId],
   );
 
+  const stop = useCallback(() => {
+    activeExecution?.controller.abort();
+  }, [activeExecution]);
+
+  const editMessage = useCallback((entry: MessageEntry) => {
+    if (!entry.messageId || !inputRef.current) return;
+    setEditing({ messageId: entry.messageId, previousDraft: inputRef.current.value });
+    inputRef.current.value = entry.text;
+    inputRef.current.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    inputRef.current.focus({ preventScroll: true });
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    if (inputRef.current && editing) {
+      inputRef.current.value = editing.previousDraft;
+      inputRef.current.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      inputRef.current.focus({ preventScroll: true });
+    }
+    setEditing(null);
+  }, [editing]);
   const decideApproval = useCallback(
     async (
       cid: string,
-      entryId: string,
+      initialEntry: MessageEntry,
       approval: PendingApproval,
       decision: ApprovalDecision,
     ) => {
-      if (approvalRequestsRef.current.has(approval.approval_id)) return;
+      if (
+        approvalRequestsRef.current.has(approval.approval_id) ||
+        activeExecutionRef.current !== null
+      ) {
+        return;
+      }
+      const controller = new AbortController();
+      if (
+        !beginExecution({
+          controller,
+          runId: approval.run_id,
+          source: "approval",
+        })
+      ) {
+        return;
+      }
       approvalRequestsRef.current.add(approval.approval_id);
       putEntries(cid, (prev) =>
         prev.map((entry) =>
-          entry.id === entryId
+          entry.id === initialEntry.id
             ? { ...entry, approvalSubmitting: true, approvalError: undefined }
             : entry,
         ),
       );
+      let entry = initialEntry;
+      let completed = false;
+      let resumeStarted = false;
       try {
-        const result = await client.decideApproval(
+        for await (const event of conversation.streamApproval(
           cid,
           approval.run_id,
           approval.approval_id,
           decision,
-        );
-        putEntries(cid, (prev) =>
-          prev.map((entry) => (entry.id === entryId ? applyRunResponse(entry, result) : entry)),
-        );
-        if (!result.pending_approval) {
-          onAnswer({ visited: result.visited ?? [], used_tools: result.used_tools ?? [] });
+          controller.signal,
+        )) {
+          if (controller.signal.aborted && event.type !== "final") break;
+          resumeStarted ||= event.type === "resume_started";
+          completed ||= event.type === "final";
+          entry = reduceStreamEvent(entry, event);
+          replaceEntry(cid, initialEntry.id, entry);
+        }
+        if (controller.signal.aborted && !completed) {
+          if (!resumeStarted) {
+            await conversation
+              .cancelApproval(cid, approval.run_id, approval.approval_id)
+              .catch(() => {});
+          }
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: "",
+            status: "cancelled",
+          });
+          return;
+        }
+        replaceEntry(cid, initialEntry.id, { ...entry, typing: false });
+        if (completed && !entry.approval) {
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
         }
       } catch (error) {
+        if (controller.signal.aborted && !completed) {
+          if (!resumeStarted) {
+            await conversation
+              .cancelApproval(cid, approval.run_id, approval.approval_id)
+              .catch(() => {});
+          }
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: "",
+            status: "cancelled",
+          });
+          return;
+        }
+        if (completed) {
+          replaceEntry(cid, initialEntry.id, { ...entry, typing: false });
+          onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
+          return;
+        }
+        if (resumeStarted) {
+          replaceEntry(cid, initialEntry.id, {
+            id: initialEntry.id,
+            role: "ai",
+            text: GENERIC_ERROR,
+            error: true,
+          });
+          return;
+        }
         const terminal = isTerminalApprovalError(error);
         putEntries(cid, (prev) =>
           prev.map((entry) =>
-            entry.id === entryId
-              ? terminal
-                ? {
-                    ...entry,
-                    text: terminalApprovalMessage(error.status),
-                    error: true,
-                    approval: undefined,
-                    approvalSubmitting: false,
-                    approvalError: undefined,
-                  }
-                : {
-                    ...entry,
-                    approvalSubmitting: false,
-                    approvalError: GENERIC_ERROR,
-                  }
+            entry.id === initialEntry.id &&
+            entry.approval?.approval_id === approval.approval_id &&
+            !entry.approvalCancelling
+              ? {
+                  ...entry,
+                  ...(terminal
+                    ? {
+                        text: terminalApprovalMessage(error.status),
+                        error: true,
+                        approval: undefined,
+                      }
+                    : {}),
+                  approvalSubmitting: false,
+                  approvalError: terminal ? undefined : GENERIC_ERROR,
+                }
               : entry,
           ),
         );
       } finally {
         approvalRequestsRef.current.delete(approval.approval_id);
+        finishExecution(controller);
         void refreshUsage(cid);
       }
     },
-    [client, onAnswer, putEntries, refreshUsage],
+    [
+      beginExecution,
+      conversation,
+      finishExecution,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry,
+    ],
+  );
+
+  const cancelApproval = useCallback(
+    async (cid: string, entryId: string, approval: PendingApproval) => {
+      if (approvalCancellationRequestsRef.current.has(approval.approval_id)) return;
+      approvalCancellationRequestsRef.current.add(approval.approval_id);
+      putEntries(cid, (prev) =>
+        prev.map((entry) =>
+          entry.id === entryId
+            ? { ...entry, approvalCancelling: true, approvalError: undefined }
+            : entry,
+        ),
+      );
+      try {
+        await conversation.cancelApproval(cid, approval.run_id, approval.approval_id);
+        putEntries(cid, (prev) =>
+          prev.map((entry) =>
+            entry.id === entryId
+              ? { id: entry.id, role: "ai", text: "", status: "cancelled" }
+              : entry,
+          ),
+        );
+      } catch (error) {
+        const terminal = isTerminalApprovalError(error);
+        putEntries(cid, (prev) =>
+          prev.map((entry) =>
+            entry.id === entryId && entry.approval?.approval_id === approval.approval_id
+              ? {
+                  ...entry,
+                  ...(terminal
+                    ? {
+                        text: terminalApprovalMessage(error.status),
+                        error: true,
+                        approval: undefined,
+                      }
+                    : {}),
+                  approvalCancelling: false,
+                  approvalError: terminal ? undefined : GENERIC_ERROR,
+                }
+              : entry,
+          ),
+        );
+      } finally {
+        approvalCancellationRequestsRef.current.delete(approval.approval_id);
+        void refreshUsage(cid);
+      }
+    },
+    [conversation, putEntries, refreshUsage],
   );
 
   const submit = useCallback(
-    async (text: string) => {
+    async (text: string, editMessageId?: string) => {
+      if (activeExecutionRef.current !== null) return;
       const cid = await conversation.ensureId();
       setActiveId(cid);
+      let userEntry: MessageEntry = { id: newId(), role: "user", text };
       const pending: MessageEntry = { id: newId(), role: "ai", text: "", typing: true };
-      putEntries(cid, (prev) => [...prev, { id: newId(), role: "user", text }, pending]);
-      setSending(true);
+      const controller = new AbortController();
+      if (!beginExecution({ controller, source: "prompt" })) return;
+      putEntries(cid, (prev) => {
+        if (!editMessageId) return [...prev, userEntry, pending];
+        const branchPoint = prev.findIndex((entry) => entry.messageId === editMessageId);
+        return [...(branchPoint < 0 ? prev : prev.slice(0, branchPoint)), userEntry, pending];
+      });
+      setEditing(null);
       let entry = pending;
-      let receivedEvent = false;
       let completed = false;
       try {
-        for await (const event of conversation.stream(cid, text)) {
-          receivedEvent = true;
+        for await (const event of conversation.stream(
+          cid,
+          text,
+          controller.signal,
+          editMessageId,
+        )) {
+          if (controller.signal.aborted && event.type !== "final") break;
+          if (event.type === "turn_started") {
+            userEntry = {
+              ...userEntry,
+              messageId: event.message_id,
+              runId: event.run_id,
+            };
+            replaceEntry(cid, userEntry.id, userEntry);
+            continue;
+          }
           completed ||= event.type === "final";
           entry = reduceStreamEvent(entry, event);
           replaceEntry(cid, pending.id, entry);
+        }
+        if (controller.signal.aborted && !completed) {
+          replaceEntry(cid, pending.id, {
+            id: pending.id,
+            role: "ai",
+            text: "",
+            status: "cancelled",
+          });
+          return;
         }
         replaceEntry(cid, pending.id, { ...entry, typing: false });
         if (!entry.approval) {
           onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
         }
       } catch (error) {
+        if (controller.signal.aborted && !completed) {
+          replaceEntry(cid, pending.id, {
+            id: pending.id,
+            role: "ai",
+            text: "",
+            status: "cancelled",
+          });
+          return;
+        }
         const is4xx = error instanceof AgentChatHttpError && error.status >= 400 && error.status < 500;
         if (error instanceof AgentChatHttpError && error.errorType === "context_limit_exceeded") {
           setBudgetExceeded(true);
@@ -324,18 +519,25 @@ export function AgentChatApp({
           onAnswer({ visited: entry.route ?? [], used_tools: entry.tools ?? [] });
         } else if (entry.approval) {
           replaceEntry(cid, pending.id, { ...entry, typing: false });
-        } else if (is4xx || receivedEvent) {
+        } else {
           const message = is4xx ? error.message : GENERIC_ERROR;
           replaceEntry(cid, pending.id, { id: pending.id, role: "ai", text: message, error: true });
-        } else {
-          await sendWithoutStreaming(cid, text, pending.id);
         }
       } finally {
-        setSending(false);
-        void refreshUsage(cid);
+        finishExecution(controller);
+        void refreshUsage(resolveConversationId(cid));
       }
     },
-    [conversation, onAnswer, putEntries, refreshUsage, replaceEntry, sendWithoutStreaming],
+    [
+      conversation,
+      beginExecution,
+      finishExecution,
+      onAnswer,
+      putEntries,
+      refreshUsage,
+      replaceEntry,
+      resolveConversationId,
+    ],
   );
 
   const toggle = () => void (open ? closeChat() : openChat());
@@ -410,22 +612,30 @@ export function AgentChatApp({
                   key={entry.id}
                   entry={entry}
                   onApproval={(approval, decision) =>
-                    void decideApproval(activeId, entry.id, approval, decision)
+                    void decideApproval(activeId, entry, approval, decision)
                   }
+                  onCancelApproval={(approval) =>
+                    void cancelApproval(activeId, entry.id, approval)
+                  }
+                  onEdit={() => editMessage(entry)}
+                  editable={canEdit}
                 />
               ))}
             </ConversationContent>
           </Conversation>
-          <PromptInput onSubmit={(message) => void submit(message.text)}>
+          <PromptInput
+            submitEnabled={canSubmit}
+            onSubmit={(message) => void submit(message.text, editing?.messageId)}
+          >
             <PromptInputTextarea
               aria-label="Message"
-              disabled={sending || budgetExceeded || awaitingApproval}
+              disabled={budgetExceeded || approvalBlocksComposer}
               inputRef={inputRef}
               onSubmit={() => inputRef.current?.form?.requestSubmit()}
               placeholder={
                 budgetExceeded
                   ? "Context limit reached."
-                  : awaitingApproval
+                  : approvalBlocksComposer
                     ? "Respond to the approval request above."
                     : "Message..."
               }
@@ -433,9 +643,18 @@ export function AgentChatApp({
             <PromptInputFooter>
               <div className="footer-start">
                 {usage ? <BudgetMeter usage={usage} /> : null}
+                {editing ? (
+                  <button className="edit-cancel" onClick={cancelEditing} type="button">
+                    Cancel edit
+                  </button>
+                ) : null}
                 <span className="prompt-hint">Enter to send · Shift+Enter for a new line</span>
               </div>
-              <PromptInputSubmit disabled={sending || budgetExceeded || awaitingApproval} />
+              <PromptInputSubmit
+                disabled={!canSubmit && !canStop}
+                running={canStop}
+                onStop={stop}
+              />
             </PromptInputFooter>
           </PromptInput>
           <div className="powered">Powered by Extra</div>
@@ -481,9 +700,15 @@ function Launcher({
 function ChatMessage({
   entry,
   onApproval,
+  onCancelApproval,
+  onEdit,
+  editable,
 }: {
   entry: MessageEntry;
   onApproval: (approval: PendingApproval, decision: ApprovalDecision) => void;
+  onCancelApproval: (approval: PendingApproval) => void;
+  onEdit: () => void;
+  editable: boolean;
 }) {
   const from = entry.role === "user" ? "user" : "assistant";
 
@@ -497,10 +722,27 @@ function ChatMessage({
     );
   }
 
+  if (entry.status === "cancelled") {
+    return (
+      <Message from="assistant">
+        <div className="msg-cancelled" role="status">
+          Generation stopped
+        </div>
+      </Message>
+    );
+  }
+
   if (entry.role === "user") {
     return (
       <Message from="user">
         <MessageContent>{entry.text}</MessageContent>
+        {editable && entry.messageId ? (
+          <div className="msg-actions user-actions">
+            <button aria-label="Edit message" className="user-edit" onClick={onEdit} type="button">
+              Edit
+            </button>
+          </div>
+        ) : null}
       </Message>
     );
   }
@@ -518,8 +760,10 @@ function ChatMessage({
             <ApprovalRequest
               approval={entry.approval}
               error={entry.approvalError}
+              cancelling={Boolean(entry.approvalCancelling)}
               submitting={Boolean(entry.approvalSubmitting)}
               onDecision={(decision) => onApproval(entry.approval as PendingApproval, decision)}
+              onCancel={() => onCancelApproval(entry.approval as PendingApproval)}
             />
           ) : null}
           {entry.text.trim() ? (
@@ -537,16 +781,24 @@ function ChatMessage({
 function ApprovalRequest({
   approval,
   submitting,
+  cancelling,
   error,
   onDecision,
+  onCancel,
 }: {
   approval: PendingApproval;
   submitting: boolean;
+  cancelling: boolean;
   error?: string;
   onDecision: (decision: ApprovalDecision) => void;
+  onCancel: () => void;
 }) {
   return (
-    <section className="approval-card" aria-busy={submitting} aria-label="Tool approval request">
+    <section
+      className="approval-card"
+      aria-busy={submitting || cancelling}
+      aria-label="Tool approval request"
+    >
       <p className="approval-title">Approval required</p>
       <p className="approval-description">{approval.description}</p>
       <p className="approval-tool">Tool: {approval.tool_name}</p>
@@ -558,7 +810,7 @@ function ApprovalRequest({
       <div className="approval-actions">
         <button
           className="approval-button primary"
-          disabled={submitting}
+          disabled={submitting || cancelling}
           onClick={() => onDecision("allow_once")}
           type="button"
         >
@@ -566,7 +818,7 @@ function ApprovalRequest({
         </button>
         <button
           className="approval-button danger"
-          disabled={submitting}
+          disabled={submitting || cancelling}
           onClick={() => onDecision("deny")}
           type="button"
         >
@@ -574,14 +826,25 @@ function ApprovalRequest({
         </button>
         <button
           className="approval-button"
-          disabled={submitting}
+          disabled={submitting || cancelling}
           onClick={() => onDecision("allow_for_session")}
           type="button"
         >
           Approve for this session
         </button>
+        <button
+          className="approval-button cancel-run"
+          disabled={cancelling}
+          onClick={onCancel}
+          type="button"
+        >
+          Cancel run
+        </button>
       </div>
-      {submitting ? <span className="approval-status">Applying decision…</span> : null}
+      {cancelling ? <span className="approval-status">Cancelling run…</span> : null}
+      {!cancelling && submitting ? (
+        <span className="approval-status">Applying decision…</span>
+      ) : null}
     </section>
   );
 }

--- a/src/agent_manager/api/static/widget/react/shadcnAiElements.tsx
+++ b/src/agent_manager/api/static/widget/react/shadcnAiElements.tsx
@@ -1,4 +1,11 @@
-import { CheckCircleIcon, CircleIcon, SendIcon, WrenchIcon, XCircleIcon } from "lucide-react";
+import {
+  CheckCircleIcon,
+  CircleIcon,
+  SendIcon,
+  SquareIcon,
+  WrenchIcon,
+  XCircleIcon,
+} from "lucide-react";
 import type {
   ComponentProps,
   FormEvent,
@@ -78,12 +85,15 @@ export interface PromptInputMessage {
 export function PromptInput({
   children,
   className,
+  submitEnabled = true,
   onSubmit,
 }: PropsWithChildren<{
   className?: string;
+  submitEnabled?: boolean;
   onSubmit: (message: PromptInputMessage) => void;
 }>) {
   function submit(form: HTMLFormElement) {
+    if (!submitEnabled) return;
     const input = form.elements.namedItem("message") as HTMLTextAreaElement | null;
     const text = input?.value.trim() ?? "";
     if (!text) return;
@@ -148,10 +158,24 @@ export function PromptInputFooter({ children }: PropsWithChildren) {
   return <div className="prompt-footer">{children}</div>;
 }
 
-export function PromptInputSubmit({ disabled }: { disabled: boolean }) {
+export function PromptInputSubmit({
+  disabled,
+  running = false,
+  onStop,
+}: {
+  disabled: boolean;
+  running?: boolean;
+  onStop?: () => void;
+}) {
   return (
-    <button aria-label="Send message" className="send" disabled={disabled} type="submit">
-      <SendIcon aria-hidden="true" />
+    <button
+      aria-label={running ? "Stop generating" : "Send message"}
+      className="send"
+      disabled={disabled}
+      onClick={running ? onStop : undefined}
+      type={running ? "button" : "submit"}
+    >
+      {running ? <SquareIcon aria-hidden="true" /> : <SendIcon aria-hidden="true" />}
     </button>
   );
 }

--- a/src/agent_manager/api/static/widget/react/streamReducer.ts
+++ b/src/agent_manager/api/static/widget/react/streamReducer.ts
@@ -8,6 +8,16 @@ const TOOL_STATUS: Record<string, string> = {
 
 export function reduceStreamEvent(entry: MessageEntry, event: StreamEvent): MessageEntry {
   switch (event.type) {
+    case "turn_started":
+      return entry;
+    case "resume_started":
+      return {
+        ...entry,
+        typing: true,
+        approval: undefined,
+        approvalSubmitting: false,
+        approvalError: undefined,
+      };
     case "answer_delta":
       return { ...entry, text: entry.text + (event.content ?? "") };
     case "route":

--- a/src/agent_manager/api/static/widget/react/useConversation.ts
+++ b/src/agent_manager/api/static/widget/react/useConversation.ts
@@ -7,6 +7,7 @@ import {
   setStoredConversationId,
 } from "../storage/conversationStorage";
 import type {
+  ApprovalDecision,
   ChatMessage,
   TokenBudget,
   SendMessageResponse,
@@ -23,8 +24,32 @@ import type {
 export interface Conversation {
   peekId(): string | null;
   ensureId(): Promise<string>;
-  send(conversationId: string, text: string): Promise<SendMessageResponse>;
-  stream(conversationId: string, text: string): AsyncGenerator<StreamEvent>;
+  send(
+    conversationId: string,
+    text: string,
+    signal?: AbortSignal,
+    editMessageId?: string,
+  ): Promise<SendMessageResponse>;
+  stream(
+    conversationId: string,
+    text: string,
+    signal?: AbortSignal,
+    editMessageId?: string,
+  ): AsyncGenerator<StreamEvent>;
+  decideApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+    decision: ApprovalDecision,
+  ): Promise<SendMessageResponse>;
+  streamApproval(
+    conversationId: string,
+    runId: string,
+    approvalId: string,
+    decision: ApprovalDecision,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent>;
+  cancelApproval(conversationId: string, runId: string, approvalId: string): Promise<void>;
   loadHistory(conversationId: string): Promise<ChatMessage[]>;
   loadUsage(conversationId: string): Promise<TokenBudget | null>;
   listThreads(): Promise<ThreadSummary[]>;
@@ -70,29 +95,69 @@ export function useConversation(
   );
 
   const send = useCallback(
-    async (conversationId: string, text: string) => {
+    async (
+      conversationId: string,
+      text: string,
+      signal?: AbortSignal,
+      editMessageId?: string,
+    ) => {
       try {
-        return await client.sendMessage(conversationId, text);
+        return await client.sendMessage(conversationId, text, signal, editMessageId);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        return client.sendMessage(await replace(conversationId), text);
+        // A replacement conversation cannot contain a message id from the
+        // vanished one. Preserve the edited text, but make it the fresh root.
+        return client.sendMessage(await replace(conversationId), text, signal);
       }
     },
     [client, replace],
   );
 
   const stream = useCallback(
-    async function* (conversationId: string, text: string): AsyncGenerator<StreamEvent> {
+    async function* (
+      conversationId: string,
+      text: string,
+      signal?: AbortSignal,
+      editMessageId?: string,
+    ): AsyncGenerator<StreamEvent> {
       try {
-        yield* client.streamMessage(conversationId, text);
+        yield* client.streamMessage(conversationId, text, signal, editMessageId);
       } catch (error) {
         if (!isUnusableConversation(error)) throw error;
-        yield* client.streamMessage(await replace(conversationId), text);
+        // The old branch no longer exists server-side, so retrying its edit id
+        // against the newly created conversation would deterministically 404.
+        yield* client.streamMessage(await replace(conversationId), text, signal);
       }
     },
     [client, replace],
   );
 
+  const decideApproval = useCallback(
+    (
+      conversationId: string,
+      runId: string,
+      approvalId: string,
+      decision: ApprovalDecision,
+    ) => client.decideApproval(conversationId, runId, approvalId, decision),
+    [client],
+  );
+
+  const streamApproval = useCallback(
+    (
+      conversationId: string,
+      runId: string,
+      approvalId: string,
+      decision: ApprovalDecision,
+      signal?: AbortSignal,
+    ) => client.streamApproval(conversationId, runId, approvalId, decision, signal),
+    [client],
+  );
+
+  const cancelApproval = useCallback(
+    (conversationId: string, runId: string, approvalId: string) =>
+      client.cancelApproval(conversationId, runId, approvalId),
+    [client],
+  );
   const loadHistory = useCallback(
     async (conversationId: string) => {
       try {
@@ -136,6 +201,9 @@ export function useConversation(
       ensureId,
       send,
       stream,
+      decideApproval,
+      streamApproval,
+      cancelApproval,
       loadHistory,
       loadUsage,
       listThreads,
@@ -147,6 +215,9 @@ export function useConversation(
       ensureId,
       send,
       stream,
+      decideApproval,
+      streamApproval,
+      cancelApproval,
       loadHistory,
       loadUsage,
       listThreads,

--- a/src/agent_manager/api/static/widget/styles/styles.ts
+++ b/src/agent_manager/api/static/widget/styles/styles.ts
@@ -113,12 +113,17 @@ export function styles(config: AgentChatConfig): string {
     .msg pre code { background: none; padding: 0; white-space: pre-wrap; }
     .msg-actions { display: flex; gap: 4px; margin-top: 6px;
       opacity: 0; transition: opacity .15s ease; }
-    .msg.ai:hover .msg-actions, .msg-actions:focus-within { opacity: 1; }
+    .msg.ai:hover .msg-actions, .msg.user:hover .msg-actions, .msg-actions:focus-within { opacity: 1; }
     .msg-action { display: inline-flex; align-items: center; justify-content: center;
       width: 26px; height: 26px; border: 0; border-radius: 7px; background: transparent;
       color: #71717a; cursor: pointer; transition: background .12s, color .12s; }
     .msg-action:hover { background: #f4f4f5; color: #18181b; }
     .msg-action svg { width: 15px; height: 15px; animation: aui-icon-in .15s ease; }
+    .user-actions { justify-content: flex-end; margin-bottom: -4px; opacity: 1; }
+    .user-edit, .edit-cancel { border: 0; background: transparent; color: #71717a;
+      cursor: pointer; font: inherit; padding: 2px 4px; }
+    .user-edit:hover, .edit-cancel:hover { color: #18181b; text-decoration: underline; }
+    .msg-cancelled { color: #71717a; font-style: italic; }
     @keyframes aui-icon-in { from { opacity: 0; transform: scale(.75); } }
     .tool-list { margin-bottom: 10px; display: flex; flex-direction: column; gap: 8px; }
     .agent-meta { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; color: #71717a;
@@ -160,6 +165,8 @@ export function styles(config: AgentChatConfig): string {
     .approval-button.primary:hover:not(:disabled) { opacity: .88; }
     .approval-button.danger { border-color: transparent; background: transparent; color: #71717a; }
     .approval-button.danger:hover:not(:disabled) { background: #f4f4f5; color: #18181b; }
+    .approval-button.cancel-run { border-color: #fca5a5; color: #b91c1c; }
+    .approval-button.cancel-run:hover:not(:disabled) { background: #fef2f2; }
     .approval-button:disabled { cursor: default; opacity: .55; }
     .approval-error { margin: 8px 0 0; color: #b91c1c; font-size: 12px; }
     .approval-status { display: block; margin-top: 8px; color: #71717a; font-size: 12px; }

--- a/src/agent_manager/api/static/widget/types.ts
+++ b/src/agent_manager/api/static/widget/types.ts
@@ -32,8 +32,11 @@ export interface ThreadSummary {
 }
 
 export interface ChatMessage {
+  message_id: string;
+  run_id?: string | null;
   role: ChatRole;
   content: string;
+  status: string;
   created_at?: string;
 }
 
@@ -49,14 +52,18 @@ export interface TokenBudget {
 
 export interface MessageEntry {
   id: string;
+  messageId?: string;
+  runId?: string;
   role: "user" | "ai";
   text: string;
+  status?: "cancelled";
   typing?: boolean;
   error?: boolean;
   route?: string[];
   tools?: ToolRecord[];
   approval?: PendingApproval;
   approvalSubmitting?: boolean;
+  approvalCancelling?: boolean;
   approvalError?: string;
 }
 
@@ -94,6 +101,8 @@ export interface SendMessageResponse {
 export interface StreamEvent {
   type:
     | "route"
+    | "turn_started"
+    | "resume_started"
     | "answer_delta"
     | "tool_started"
     | "tool_succeeded"
@@ -111,6 +120,7 @@ export interface StreamEvent {
   system_name?: string;
   used_tools?: ToolRecord[];
   run_id?: string;
+  message_id?: string;
   approval_id?: string;
   agent_id?: string;
   description?: string;

--- a/src/agent_manager/application/__init__.py
+++ b/src/agent_manager/application/__init__.py
@@ -3,7 +3,9 @@
 from agent_manager.application.service import (
     ConversationAccessDenied,
     ConversationAlreadyExists,
+    ConversationBranchConflict,
     ConversationLinkRefused,
+    ConversationMessageNotFound,
     ConversationNotFound,
     ConversationService,
     ConversationTokenBudgetExceeded,
@@ -13,7 +15,9 @@ from agent_manager.application.service import (
 __all__ = [
     "ConversationAccessDenied",
     "ConversationAlreadyExists",
+    "ConversationBranchConflict",
     "ConversationLinkRefused",
+    "ConversationMessageNotFound",
     "ConversationNotFound",
     "ConversationService",
     "ConversationTokenBudgetExceeded",

--- a/src/agent_manager/application/service.py
+++ b/src/agent_manager/application/service.py
@@ -6,16 +6,28 @@ Both the engine transport and the database backend can change with no edits here
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
+import logging
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import cast
 
 from agent_engine.approvals.decision import ApprovalDecision
-from agent_engine.approvals.errors import ApprovalAlreadyProcessed
-from agent_engine.engine.engine import ApprovalEngine, Engine
+from agent_engine.approvals.errors import ApprovalAlreadyProcessed, RunNotFound
+from agent_engine.approvals.models import RunRecord, RunStatus
+from agent_engine.engine.engine import (
+    ApprovalCancellationEngine,
+    ApprovalEngine,
+    ApprovalStreamingEngine,
+    Engine,
+    RunStatusEngine,
+)
 from agent_engine.engine.types import ChatMessage, RunResult
+from agent_engine.runs.repository import RunRepository
 from agent_engine.runtime.hooks import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
 from agent_engine.runtime.tool_models import ToolUsageRecord
@@ -23,13 +35,14 @@ from agent_manager.application.context import build_history
 from agent_manager.domain import (
     ConversationMessage,
     ConversationSession,
-    Message,
     Principal,
     Repository,
     Role,
     TokenBudgetUsage,
     thread_title,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ConversationNotFound(Exception):
@@ -52,12 +65,21 @@ class ConversationLinkRefused(Exception):
     """Raised when a visitor's conversations cannot be handed to the caller."""
 
 
+class ConversationMessageNotFound(Exception):
+    """Raised when an edit target is not on the conversation's active branch."""
+
+
+class ConversationBranchConflict(Exception):
+    """Raised when another turn moved the branch head before this append."""
+
+
 @dataclass(frozen=True)
 class PreparedConversationTurn:
     """A persisted user turn plus the prior structured model context."""
 
     session_id: str
     run_id: str
+    message_id: str
     user_id: str
     message: str
     history: tuple[ChatMessage, ...]
@@ -75,6 +97,7 @@ class ConversationService:
         snapshot_ttl_seconds: int | None = 86_400,
         system_name: str | None = None,
         config_path: str | None = None,
+        run_repository: RunRepository | None = None,
     ) -> None:
         self._engine = engine
         self._repository = repository
@@ -84,6 +107,7 @@ class ConversationService:
         self._snapshot_ttl_seconds = snapshot_ttl_seconds
         self._system_name = system_name
         self._config_path = config_path
+        self._run_repository = run_repository
 
     async def create(self, principal: Principal, *, session_id: str | None = None) -> str:
         """Create a conversation, or return the caller's own existing one.
@@ -116,9 +140,12 @@ class ConversationService:
         await self._register(principal)
         return await self._repository.link_anonymous_user(visitor.user_id, principal.user_id)
 
-    async def history(self, conversation_id: str, principal: Principal) -> list[Message]:
+    async def history(
+        self, conversation_id: str, principal: Principal
+    ) -> list[ConversationMessage]:
         await self._authorize(conversation_id, principal)
-        return await self._repository.list_messages(conversation_id)
+        messages = await self._repository.list_conversation_messages(conversation_id)
+        return await self._with_run_statuses(messages)
 
     async def usage(self, conversation_id: str, principal: Principal) -> TokenBudgetUsage:
         await self._authorize(conversation_id, principal)
@@ -130,17 +157,33 @@ class ConversationService:
     ) -> list[ConversationSession]:
         return await self._repository.list_sessions(principal.user_id, limit=limit)
 
-    async def send(self, conversation_id: str, text: str, principal: Principal) -> RunResult:
-        turn = await self.prepare_turn(conversation_id, text, principal)
-        result = await self._engine.run(
-            turn.message,
-            history=turn.history,
-            context=RunContext(
-                run_id=turn.run_id,
-                conversation_id=turn.session_id,
-                user_id=turn.user_id,
-            ),
+    async def send(
+        self,
+        conversation_id: str,
+        text: str,
+        principal: Principal,
+        *,
+        edit_message_id: str | None = None,
+    ) -> RunResult:
+        turn = await self.prepare_turn(
+            conversation_id, text, principal, edit_message_id=edit_message_id
         )
+        try:
+            result = await self._engine.run(
+                turn.message,
+                history=turn.history,
+                context=RunContext(
+                    run_id=turn.run_id,
+                    conversation_id=turn.session_id,
+                    user_id=turn.user_id,
+                ),
+            )
+        except asyncio.CancelledError:
+            await self.cancel_turn(turn)
+            raise
+        except Exception:
+            await self.fail_turn(turn)
+            raise
         if result.pending_approval is None:
             await self.complete_turn(turn, result)
         return result
@@ -150,6 +193,8 @@ class ConversationService:
         conversation_id: str,
         text: str,
         principal: Principal,
+        *,
+        edit_message_id: str | None = None,
     ) -> PreparedConversationTurn:
         """Persist a user message and return its isolated prior model context."""
         await self._authorize(conversation_id, principal)
@@ -162,31 +207,76 @@ class ConversationService:
                 raise ConversationTokenBudgetExceeded(conversation_id)
 
         # Load prior history before saving the new message, or it gets inlined twice.
-        prior_context = await self._repository.get_context(
-            conversation_id,
-            max_messages=self._window,
-            max_chars=self._max_chars,
-        )
-        if not prior_context.messages:
-            await self._repository.rename_session(conversation_id, thread_title(text))
+        session = await self._require(conversation_id)
+        expected_head = session.head_message_id
+        parent_message_id = expected_head
+        if edit_message_id is None:
+            prior_context = await self._repository.get_context(
+                conversation_id,
+                max_messages=self._window,
+                max_chars=self._max_chars,
+            )
+        else:
+            branch = await self._repository.list_conversation_messages(conversation_id)
+            target = next(
+                (
+                    message
+                    for message in branch
+                    if message.message_id == edit_message_id and message.role == Role.USER
+                ),
+                None,
+            )
+            if target is None:
+                raise ConversationMessageNotFound(edit_message_id)
+            parent_message_id = target.parent_message_id
+            prior_context = await self._repository.get_context_at(
+                conversation_id,
+                parent_message_id,
+                max_messages=self._window,
+                max_chars=self._max_chars,
+            )
         run_id = uuid.uuid4().hex
+        message_id = uuid.uuid4().hex
         now = datetime.now(UTC)
-        await self._repository.append_message(
-            ConversationMessage(
-                message_id=uuid.uuid4().hex,
-                session_id=conversation_id,
-                run_id=run_id,
-                user_id=user_id,
-                role=Role.USER,
-                content=text,
-                created_at=now,
-            ),
-            snapshot_ttl_seconds=self._snapshot_ttl_seconds,
-        )
+        await self._register_run(run_id)
+        try:
+            appended = await self._repository.append_message_if_head(
+                ConversationMessage(
+                    message_id=message_id,
+                    session_id=conversation_id,
+                    run_id=run_id,
+                    user_id=user_id,
+                    role=Role.USER,
+                    content=text,
+                    created_at=now,
+                    parent_message_id=parent_message_id,
+                    status="running",
+                ),
+                expected_head,
+                snapshot_ttl_seconds=self._snapshot_ttl_seconds,
+            )
+        except BaseException:
+            await self._transition_run(run_id, RunStatus.CANCELLED)
+            raise
+        if not appended:
+            await self._transition_run(run_id, RunStatus.CANCELLED)
+            raise ConversationBranchConflict(conversation_id)
+        if not prior_context.messages:
+            try:
+                await self._repository.rename_session(conversation_id, thread_title(text))
+            except Exception:
+                # The user message and run are already durable. A cosmetic
+                # title failure must not orphan an accepted turn.
+                logger.warning(
+                    "conversation title update failed",
+                    extra={"conversation_id": conversation_id},
+                    exc_info=True,
+                )
 
         return PreparedConversationTurn(
             session_id=conversation_id,
             run_id=run_id,
+            message_id=message_id,
             user_id=user_id,
             message=text,
             history=build_history(prior_context.messages, self._window),
@@ -204,6 +294,7 @@ class ConversationService:
             session_id=turn.session_id,
             run_id=turn.run_id,
             user_id=turn.user_id,
+            parent_message_id=turn.message_id,
             content=result.answer,
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
@@ -241,10 +332,12 @@ class ConversationService:
                 raise
             result = recovered
         if result.pending_approval is None:
+            parent_message_id = await self._user_message_id_for_run(session.session_id, run_id)
             await self._persist_assistant_turn(
                 session_id=session.session_id,
                 run_id=run_id,
                 user_id=session.user_id,
+                parent_message_id=parent_message_id,
                 content=result.answer,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
@@ -253,38 +346,149 @@ class ConversationService:
             )
         return result
 
-    async def stream(
-        self, conversation_id: str, text: str, principal: Principal
-    ) -> AsyncIterator[RunStreamEvent]:
-        turn = await self.prepare_turn(conversation_id, text, principal)
+    async def cancel_pending_approval(
+        self,
+        conversation_id: str,
+        run_id: str,
+        approval_id: str,
+        principal: Principal,
+    ) -> None:
+        """Terminally cancel a pending approval owned by this conversation."""
+        session = await self._authorize(conversation_id, principal)
+        engine = self._require_approval_cancellation_engine()
+        await engine.cancel_pending_approval(
+            run_id,
+            approval_id,
+            caller_user_id=session.user_id,
+            caller_session_id=session.session_id,
+        )
 
-        final: RunStreamEvent | None = None
+    async def stream_approval(
+        self,
+        conversation_id: str,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision,
+        principal: Principal,
+    ) -> AsyncIterator[RunStreamEvent]:
+        """Authorize and return an owned stream for the same suspended run."""
+        session = await self._authorize(conversation_id, principal)
+        engine = self._require_approval_streaming_engine()
+        parent_message_id = await self._user_message_id_for_run(session.session_id, run_id)
+
+        async def events() -> AsyncIterator[RunStreamEvent]:
+            engine_stream = engine.resume_stream(
+                run_id,
+                approval_id,
+                decision,
+                caller_user_id=session.user_id,
+                caller_session_id=session.session_id,
+            )
+            try:
+                async for event in engine_stream:
+                    if event.type == "final":
+                        await self._persist_assistant_turn(
+                            session_id=session.session_id,
+                            run_id=run_id,
+                            user_id=session.user_id,
+                            parent_message_id=parent_message_id,
+                            content=event.content or "",
+                            input_tokens=event.input_tokens,
+                            output_tokens=event.output_tokens,
+                            visited=event.route or (),
+                            used_tools=event.used_tools,
+                        )
+                    yield event
+            finally:
+                if isinstance(engine_stream, AsyncGenerator):
+                    await engine_stream.aclose()
+
+        return events()
+
+    async def stream(
+        self,
+        conversation_id: str,
+        text: str,
+        principal: Principal,
+        *,
+        edit_message_id: str | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        turn = await self.prepare_turn(
+            conversation_id, text, principal, edit_message_id=edit_message_id
+        )
+
+        stream = self.stream_turn(turn)
+        suspended = False
+        exhausted = False
         try:
-            async for event in self._engine.stream(
-                turn.message,
-                history=turn.history,
-                context=RunContext(
-                    run_id=turn.run_id,
-                    conversation_id=turn.session_id,
-                    user_id=turn.user_id,
-                ),
-            ):
+            async for event in stream:
+                suspended = suspended or event.type == "pending_approval"
+                yield event
+            exhausted = True
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await self.fail_turn(turn)
+            raise
+        finally:
+            try:
+                await cast(AsyncGenerator[RunStreamEvent, None], stream).aclose()
+            finally:
+                if not exhausted and not suspended:
+                    await self.cancel_turn(turn)
+
+    async def cancel_turn(self, turn: PreparedConversationTurn) -> None:
+        """Atomically cancel a prepared or executing run when its owner leaves."""
+        await self._transition_run(turn.run_id, RunStatus.CANCELLED)
+
+    async def fail_turn(self, turn: PreparedConversationTurn) -> None:
+        """Fail a prepared run when execution raises before the engine records it."""
+        await self._transition_run(turn.run_id, RunStatus.FAILED)
+
+    async def stream_turn(self, turn: PreparedConversationTurn) -> AsyncIterator[RunStreamEvent]:
+        """Execute one already-persisted turn under its request-owned stream."""
+
+        engine_stream = self._engine.stream(
+            turn.message,
+            history=turn.history,
+            context=RunContext(
+                run_id=turn.run_id,
+                conversation_id=turn.session_id,
+                user_id=turn.user_id,
+            ),
+        )
+        try:
+            async for event in engine_stream:
                 if event.type == "final":
-                    final = event
+                    await self._persist_stream_final(turn, event)
 
                 yield event
         finally:
-            if final is not None:
-                await self._persist_assistant_turn(
-                    session_id=turn.session_id,
-                    run_id=turn.run_id,
-                    user_id=turn.user_id,
-                    content=final.content or "",
-                    input_tokens=final.input_tokens,
-                    output_tokens=final.output_tokens,
-                    visited=final.route or (),
-                    used_tools=final.used_tools,
-                )
+            if isinstance(engine_stream, AsyncGenerator):
+                await engine_stream.aclose()
+
+    async def _persist_stream_final(
+        self, turn: PreparedConversationTurn, final: RunStreamEvent
+    ) -> None:
+        """Finish persistence before exposing a terminal answer downstream."""
+        persistence = asyncio.create_task(
+            self._persist_assistant_turn(
+                session_id=turn.session_id,
+                run_id=turn.run_id,
+                user_id=turn.user_id,
+                parent_message_id=turn.message_id,
+                content=final.content or "",
+                input_tokens=final.input_tokens,
+                output_tokens=final.output_tokens,
+                visited=final.route or (),
+                used_tools=final.used_tools,
+            )
+        )
+        try:
+            await asyncio.shield(persistence)
+        except asyncio.CancelledError:
+            await persistence
+            raise
 
     async def _persist_assistant_turn(
         self,
@@ -292,6 +496,7 @@ class ConversationService:
         session_id: str,
         run_id: str,
         user_id: str | None,
+        parent_message_id: str | None,
         content: str,
         input_tokens: int | None,
         output_tokens: int | None,
@@ -312,6 +517,8 @@ class ConversationService:
                 role=Role.ASSISTANT,
                 content=content,
                 created_at=datetime.now(UTC),
+                parent_message_id=parent_message_id,
+                status="completed",
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 metadata={
@@ -321,6 +528,56 @@ class ConversationService:
             ),
             snapshot_ttl_seconds=self._snapshot_ttl_seconds,
         )
+
+    async def _user_message_id_for_run(self, session_id: str, run_id: str) -> str | None:
+        message = await self._repository.get_user_message_for_run(session_id, run_id)
+        return message.message_id if message is not None else None
+
+    async def _with_run_statuses(
+        self, messages: list[ConversationMessage]
+    ) -> list[ConversationMessage]:
+        completed = {
+            message.run_id
+            for message in messages
+            if message.role == Role.ASSISTANT and message.run_id is not None
+        }
+        statuses: dict[str, str] = {}
+        if self._run_repository is not None:
+            for run_id in {message.run_id for message in messages if message.run_id is not None}:
+                record = await self._run_repository.get(run_id)
+                if record is not None:
+                    statuses[run_id] = record.status.value
+        elif isinstance(self._engine, RunStatusEngine):
+            for run_id in {message.run_id for message in messages if message.run_id is not None}:
+                with suppress(RunNotFound):
+                    statuses[run_id] = await self._engine.get_run_status(run_id)
+        return [
+            dataclasses.replace(
+                message,
+                status=statuses.get(
+                    message.run_id or "",
+                    "completed" if message.run_id in completed else message.status,
+                ),
+            )
+            for message in messages
+        ]
+
+    async def _register_run(self, run_id: str) -> None:
+        if self._run_repository is None:
+            return
+        created = await self._run_repository.create_if_absent(
+            RunRecord(
+                run_id=run_id,
+                thread_id=run_id,
+                system_name=self._system_name or "",
+            )
+        )
+        if not created:
+            raise RuntimeError(f"generated run id already exists: {run_id}")
+
+    async def _transition_run(self, run_id: str, target: RunStatus) -> None:
+        if self._run_repository is not None:
+            await self._run_repository.transition_if_allowed(run_id, target)
 
     async def _register(self, principal: Principal) -> None:
         await self._repository.upsert_user(
@@ -332,6 +589,16 @@ class ConversationService:
     def _require_approval_engine(self) -> ApprovalEngine:
         if not isinstance(self._engine, ApprovalEngine):
             raise RuntimeError("the configured engine does not support approval resume")
+        return self._engine
+
+    def _require_approval_cancellation_engine(self) -> ApprovalCancellationEngine:
+        if not isinstance(self._engine, ApprovalCancellationEngine):
+            raise RuntimeError("the configured engine does not support approval cancellation")
+        return self._engine
+
+    def _require_approval_streaming_engine(self) -> ApprovalStreamingEngine:
+        if not isinstance(self._engine, ApprovalStreamingEngine):
+            raise RuntimeError("the configured engine does not support approval streaming")
         return self._engine
 
     async def _require(self, conversation_id: str) -> ConversationSession:

--- a/src/agent_manager/application/service.py
+++ b/src/agent_manager/application/service.py
@@ -553,14 +553,13 @@ class ConversationService:
             for message in messages
             if message.role == Role.ASSISTANT and message.run_id is not None
         }
+        run_ids = {message.run_id for message in messages if message.run_id is not None}
         statuses: dict[str, str] = {}
         if self._run_repository is not None:
-            for run_id in {message.run_id for message in messages if message.run_id is not None}:
-                record = await self._run_repository.get(run_id)
-                if record is not None:
-                    statuses[run_id] = record.status.value
+            records = await self._run_repository.get_many(run_ids)
+            statuses = {run_id: record.status.value for run_id, record in records.items()}
         elif isinstance(self._engine, RunStatusEngine):
-            for run_id in {message.run_id for message in messages if message.run_id is not None}:
+            for run_id in run_ids:
                 with suppress(RunNotFound):
                     statuses[run_id] = await self._engine.get_run_status(run_id)
         return [

--- a/src/agent_manager/application/service.py
+++ b/src/agent_manager/application/service.py
@@ -10,11 +10,11 @@ import asyncio
 import dataclasses
 import logging
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Coroutine, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from agent_engine.approvals.decision import ApprovalDecision
 from agent_engine.approvals.errors import ApprovalAlreadyProcessed, RunNotFound
@@ -387,16 +387,18 @@ class ConversationService:
             try:
                 async for event in engine_stream:
                     if event.type == "final":
-                        await self._persist_assistant_turn(
-                            session_id=session.session_id,
-                            run_id=run_id,
-                            user_id=session.user_id,
-                            parent_message_id=parent_message_id,
-                            content=event.content or "",
-                            input_tokens=event.input_tokens,
-                            output_tokens=event.output_tokens,
-                            visited=event.route or (),
-                            used_tools=event.used_tools,
+                        await self._persist_durably(
+                            self._persist_assistant_turn(
+                                session_id=session.session_id,
+                                run_id=run_id,
+                                user_id=session.user_id,
+                                parent_message_id=parent_message_id,
+                                content=event.content or "",
+                                input_tokens=event.input_tokens,
+                                output_tokens=event.output_tokens,
+                                visited=event.route or (),
+                                used_tools=event.used_tools,
+                            )
                         )
                     yield event
             finally:
@@ -429,6 +431,8 @@ class ConversationService:
             raise
         except Exception:
             await self.fail_turn(turn)
+            # The run is already terminal; `finally` must not try to cancel it.
+            exhausted = True
             raise
         finally:
             try:
@@ -471,7 +475,7 @@ class ConversationService:
         self, turn: PreparedConversationTurn, final: RunStreamEvent
     ) -> None:
         """Finish persistence before exposing a terminal answer downstream."""
-        persistence = asyncio.create_task(
+        await self._persist_durably(
             self._persist_assistant_turn(
                 session_id=turn.session_id,
                 run_id=turn.run_id,
@@ -484,10 +488,18 @@ class ConversationService:
                 used_tools=final.used_tools,
             )
         )
+
+    async def _persist_durably(self, persistence: Coroutine[Any, Any, None]) -> None:
+        """Complete one write even if the awaiting task is cancelled.
+
+        Every path that exposes a terminal answer goes through here: an abort
+        landing on the await must not leave a run terminal with no message.
+        """
+        task = asyncio.create_task(persistence)
         try:
-            await asyncio.shield(persistence)
+            await asyncio.shield(task)
         except asyncio.CancelledError:
-            await persistence
+            await task
             raise
 
     async def _persist_assistant_turn(

--- a/src/agent_manager/composition.py
+++ b/src/agent_manager/composition.py
@@ -14,6 +14,8 @@ from agent_engine.approvals.session_store import (
     InMemorySessionApprovalRepository,
     SessionApprovalRepository,
 )
+from agent_engine.runs.in_memory import InMemoryRunRepository
+from agent_engine.runs.repository import RunRepository
 from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
 from agent_engine.tool_usage.repository import ToolUsageRepository
 from agent_manager.config import AuthMode, Settings
@@ -28,6 +30,8 @@ from agent_manager.infrastructure.auth.resolver import (
 )
 from agent_manager.infrastructure.auth.tokens import TokenPolicy, TokenVerifier
 from agent_manager.infrastructure.persistence.database import create_db_engine, session_factory
+from agent_manager.infrastructure.persistence.memory_repository import MemoryRepository
+from agent_manager.infrastructure.persistence.run_repository import SqlRunRepository
 from agent_manager.infrastructure.persistence.sql_repository import SqlRepository
 
 logger = logging.getLogger(__name__)
@@ -41,6 +45,7 @@ class ApplicationRepositories:
     conversations: Repository
     session_approvals: SessionApprovalRepository
     tool_usage: ToolUsageRepository
+    runs: RunRepository
 
 
 def build_session_approval_repository() -> SessionApprovalRepository:
@@ -120,13 +125,27 @@ async def application_repositories(
     settings: Settings,
 ) -> AsyncIterator[ApplicationRepositories]:
     """Own application repositories for one complete process lifespan."""
-    db_engine = create_db_engine(settings.effective_database_url)
+    database_url = settings.effective_database_url
+    session_approvals = build_session_approval_repository()
+    tool_usage = build_tool_usage_repository()
+    if settings.uses_process_memory:
+        yield ApplicationRepositories(
+            conversations=MemoryRepository(),
+            session_approvals=session_approvals,
+            tool_usage=tool_usage,
+            runs=InMemoryRunRepository(),
+        )
+        return
+
+    assert database_url is not None
+    db_engine = create_db_engine(database_url)
     sessions = session_factory(db_engine)
     try:
         yield ApplicationRepositories(
             conversations=SqlRepository(sessions),
-            session_approvals=build_session_approval_repository(),
-            tool_usage=build_tool_usage_repository(),
+            session_approvals=session_approvals,
+            tool_usage=tool_usage,
+            runs=SqlRunRepository(sessions),
         )
     finally:
         await db_engine.dispose()

--- a/src/agent_manager/composition.py
+++ b/src/agent_manager/composition.py
@@ -137,7 +137,6 @@ async def application_repositories(
         )
         return
 
-    assert database_url is not None
     db_engine = create_db_engine(database_url)
     sessions = session_factory(db_engine)
     try:

--- a/src/agent_manager/config.py
+++ b/src/agent_manager/config.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import os
 import warnings
+from collections.abc import Mapping
 from enum import StrEnum
 from typing import Annotated, Any, Literal, NamedTuple
+from urllib.parse import parse_qs, urlsplit
 
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 
 ONE_HOUR_SECONDS = 3_600
 THIRTY_DAYS_SECONDS = 2_592_000
@@ -91,14 +95,43 @@ def normalize_database_url(url: str, backend: str) -> str:
     return url
 
 
+def _query_mode(query: Mapping[str, Any]) -> str | None:
+    value = query.get("mode")
+    if isinstance(value, list | tuple):
+        return str(value[0]) if value else None
+    return None if value is None else str(value)
+
+
+def _is_in_memory_sqlite(url: str) -> bool:
+    """Whether ``url`` names a SQLite database that lives only in process memory.
+
+    Parsed rather than substring-matched, so an on-disk path containing
+    ``:memory:`` keeps its persistence.
+    """
+    try:
+        parsed = make_url(url)
+    except ArgumentError:
+        return False
+    if parsed.get_backend_name() != "sqlite":
+        return False
+    database = parsed.database
+    if not database or database == ":memory:":
+        return True
+    if _query_mode(parsed.query) == "memory":
+        return True
+    if database.startswith("file:"):
+        # A SQLite URI filename carries its own query, e.g. `file:x?mode=memory`.
+        uri = urlsplit(database)
+        return uri.path == ":memory:" or _query_mode(parse_qs(uri.query)) == "memory"
+    return False
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     extra_db_backend: Literal["sqlite", "postgres"] = "sqlite"
     extra_db_url: str | None = None
-    # Persistence is opt-in. Without either URL the manager uses its process-local
-    # repository adapters and never opens a database connection.
-    database_url: str | None = None
+    database_url: str = "sqlite+aiosqlite:///chat.db"
     context_window: int = 10
     context_max_chars: int | None = None
     context_max_tokens: int | None = None
@@ -176,11 +209,10 @@ class Settings(BaseSettings):
         return cls(_env_file=None, **values)  # type: ignore[call-arg]
 
     @property
-    def effective_database_url(self) -> str | None:
-        url = self.extra_db_url or self.database_url
-        return normalize_database_url(url, self.extra_db_backend) if url else None
+    def effective_database_url(self) -> str:
+        return normalize_database_url(self.extra_db_url or self.database_url, self.extra_db_backend)
 
     @property
     def uses_process_memory(self) -> bool:
-        url = self.effective_database_url
-        return url is None or ":memory:" in url
+        """True only for a SQLite URL that names no on-disk database."""
+        return _is_in_memory_sqlite(self.effective_database_url)

--- a/src/agent_manager/config.py
+++ b/src/agent_manager/config.py
@@ -39,7 +39,9 @@ class Settings(BaseSettings):
 
     agent_db_backend: Literal["sqlite", "postgres"] = "sqlite"
     agent_db_url: str | None = None
-    database_url: str = "sqlite+aiosqlite:///chat.db"
+    # Persistence is opt-in. Without either URL the manager uses its process-local
+    # repository adapters and never opens a database connection.
+    database_url: str | None = None
     context_window: int = 10
     context_max_chars: int | None = None
     context_max_tokens: int | None = None
@@ -88,5 +90,11 @@ class Settings(BaseSettings):
         return cls(_env_file=None, **values)  # type: ignore[call-arg]
 
     @property
-    def effective_database_url(self) -> str:
-        return normalize_database_url(self.agent_db_url or self.database_url, self.agent_db_backend)
+    def effective_database_url(self) -> str | None:
+        url = self.agent_db_url or self.database_url
+        return normalize_database_url(url, self.agent_db_backend) if url else None
+
+    @property
+    def uses_process_memory(self) -> bool:
+        url = self.effective_database_url
+        return url is None or ":memory:" in url

--- a/src/agent_manager/domain/models.py
+++ b/src/agent_manager/domain/models.py
@@ -48,6 +48,7 @@ class ConversationSession:
     system_name: str | None = None
     config_path: str | None = None
     title: str | None = None
+    head_message_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/src/agent_manager/domain/repository.py
+++ b/src/agent_manager/domain/repository.py
@@ -87,7 +87,37 @@ class Repository(ABC):
         *,
         snapshot_ttl_seconds: int | None = None,
     ) -> bool:
-        """Atomically append by ``message_id`` and report whether it was created."""
+        """Atomically append by ``message_id`` and report whether it was created.
+
+        A message whose parent is no longer the selected head is retained on
+        that inactive branch without changing the conversation's active head.
+        """
+        ...
+
+    @abstractmethod
+    async def append_message_if_head(
+        self,
+        message: ConversationMessage,
+        expected_head_message_id: str | None,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        """Append and select ``message`` only if the active branch head matches.
+
+        The comparison and append are one atomic repository operation. A false
+        result writes nothing and lets the application reject concurrent turns
+        or edits without producing a detached execution.
+        """
+        ...
+
+    @abstractmethod
+    async def get_message(self, message_id: str) -> ConversationMessage | None: ...
+
+    @abstractmethod
+    async def get_user_message_for_run(
+        self, session_id: str, run_id: str
+    ) -> ConversationMessage | None:
+        """Find the run's user message across active and inactive branches."""
         ...
 
     @abstractmethod
@@ -113,6 +143,18 @@ class Repository(ABC):
         max_messages: int | None = None,
         max_chars: int | None = None,
     ) -> ConversationContext: ...
+
+    @abstractmethod
+    async def get_context_at(
+        self,
+        session_id: str,
+        head_message_id: str | None,
+        *,
+        max_messages: int | None = None,
+        max_chars: int | None = None,
+    ) -> ConversationContext:
+        """Build context from one immutable ancestry path; ``None`` is empty."""
+        ...
 
     @abstractmethod
     async def get_token_usage(self, conversation_id: str) -> int:

--- a/src/agent_manager/infrastructure/persistence/database.py
+++ b/src/agent_manager/infrastructure/persistence/database.py
@@ -24,11 +24,17 @@ def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
-def upgrade_database() -> None:
-    """Bring the configured database to the latest schema via Alembic."""
+def upgrade_database() -> bool:
+    """Upgrade explicit persistent storage; do nothing for process memory."""
+    from agent_manager.config import Settings
+
+    if Settings().uses_process_memory:
+        return False
+
     from alembic import command
     from alembic.config import Config
 
     cfg = Config(str(_MIGRATIONS / "alembic.ini"))
     cfg.set_main_option("script_location", str(_MIGRATIONS))
     command.upgrade(cfg, "head")
+    return True

--- a/src/agent_manager/infrastructure/persistence/memory_repository.py
+++ b/src/agent_manager/infrastructure/persistence/memory_repository.py
@@ -230,7 +230,9 @@ class MemoryRepository(Repository):
             self._messages.get(session_id, []),
             session.head_message_id if session is not None else None,
         )
-        return list(msgs[-limit:] if limit is not None else msgs)
+        if limit is None:
+            return list(msgs)
+        return list(msgs[-limit:]) if limit > 0 else []
 
     async def list_messages(self, conversation_id: str, limit: int | None = None) -> list[Message]:
         msgs = await self.list_conversation_messages(conversation_id, limit)

--- a/src/agent_manager/infrastructure/persistence/memory_repository.py
+++ b/src/agent_manager/infrastructure/persistence/memory_repository.py
@@ -96,6 +96,7 @@ class MemoryRepository(Repository):
             system_name=system_name,
             config_path=config_path,
             title=title,
+            head_message_id=None,
             metadata=dict(metadata or {}),
             created_at=now,
             updated_at=now,
@@ -132,19 +133,15 @@ class MemoryRepository(Repository):
     ) -> ConversationSnapshot:
         if message.session_id not in self._sessions:
             await self.create_session(message.session_id, user_id=message.user_id)
-        self._messages.setdefault(message.session_id, []).append(message)
         session = self._sessions[message.session_id]
-        self._sessions[message.session_id] = ConversationSession(
-            session_id=session.session_id,
-            user_id=session.user_id,
-            system_name=session.system_name,
-            config_path=session.config_path,
-            title=session.title,
-            metadata=session.metadata,
-            created_at=session.created_at,
+        if message.parent_message_id is None and session.head_message_id is not None:
+            message = replace(message, parent_message_id=session.head_message_id)
+        self._messages.setdefault(message.session_id, []).append(message)
+        self._sessions[message.session_id] = replace(
+            session,
+            head_message_id=message.message_id,
             updated_at=message.created_at,
             last_message_at=message.created_at,
-            expires_at=session.expires_at,
         )
         snapshot = self._build_snapshot(message.session_id, snapshot_ttl_seconds)
         self._snapshots[message.session_id] = snapshot
@@ -162,8 +159,57 @@ class MemoryRepository(Repository):
             for existing in self._messages.get(message.session_id, [])
         ):
             return False
+        session = self._sessions.get(message.session_id)
+        if session is not None and session.head_message_id != message.parent_message_id:
+            self._messages.setdefault(message.session_id, []).append(message)
+            return True
         await self.append_message(message, snapshot_ttl_seconds=snapshot_ttl_seconds)
         return True
+
+    async def append_message_if_head(
+        self,
+        message: ConversationMessage,
+        expected_head_message_id: str | None,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        session = self._sessions.get(message.session_id)
+        if session is None or session.head_message_id != expected_head_message_id:
+            return False
+        self._messages.setdefault(message.session_id, []).append(message)
+        self._sessions[message.session_id] = replace(
+            session,
+            head_message_id=message.message_id,
+            updated_at=message.created_at,
+            last_message_at=message.created_at,
+        )
+        self._snapshots[message.session_id] = self._build_snapshot(
+            message.session_id, snapshot_ttl_seconds
+        )
+        return True
+
+    async def get_message(self, message_id: str) -> ConversationMessage | None:
+        return next(
+            (
+                message
+                for messages in self._messages.values()
+                for message in messages
+                if message.message_id == message_id
+            ),
+            None,
+        )
+
+    async def get_user_message_for_run(
+        self, session_id: str, run_id: str
+    ) -> ConversationMessage | None:
+        return next(
+            (
+                message
+                for message in self._messages.get(session_id, [])
+                if message.run_id == run_id and message.role == Role.USER
+            ),
+            None,
+        )
 
     async def add_message(self, conversation_id: str, role: Role, content: str) -> None:
         await self.append_message(
@@ -179,7 +225,11 @@ class MemoryRepository(Repository):
     async def list_conversation_messages(
         self, session_id: str, limit: int | None = None
     ) -> list[ConversationMessage]:
-        msgs = self._messages.get(session_id, [])
+        session = self._sessions.get(session_id)
+        msgs = _branch_messages(
+            self._messages.get(session_id, []),
+            session.head_message_id if session is not None else None,
+        )
         return list(msgs[-limit:] if limit is not None else msgs)
 
     async def list_messages(self, conversation_id: str, limit: int | None = None) -> list[Message]:
@@ -216,14 +266,34 @@ class MemoryRepository(Repository):
         if snapshot is None:
             snapshot = await self.rebuild_snapshot(session_id)
             source = "rebuilt"
-        messages = await self.list_messages(session_id)
-        messages = _bound_messages(messages, max_messages=max_messages, max_chars=max_chars)
+        active_messages = await self.list_messages(session_id)
+        messages = _bound_messages(active_messages, max_messages=max_messages, max_chars=max_chars)
         return ConversationContext(
             session_id=session_id,
             messages=messages,
-            message_count=len(self._messages.get(session_id, [])),
+            message_count=len(active_messages),
             source=source if snapshot is not None else "cold",
             snapshot=snapshot,
+        )
+
+    async def get_context_at(
+        self,
+        session_id: str,
+        head_message_id: str | None,
+        *,
+        max_messages: int | None = None,
+        max_chars: int | None = None,
+    ) -> ConversationContext:
+        messages = _branch_messages(self._messages.get(session_id, []), head_message_id)
+        context = [
+            Message(role=m.role, content=m.content, created_at=m.created_at) for m in messages
+        ]
+        bounded = _bound_messages(context, max_messages=max_messages, max_chars=max_chars)
+        return ConversationContext(
+            session_id=session_id,
+            messages=bounded,
+            message_count=len(messages),
+            source="branch",
         )
 
     async def delete_expired_snapshots(self, now: datetime) -> int:
@@ -242,7 +312,8 @@ class MemoryRepository(Repository):
         from datetime import timedelta
 
         now = datetime.now(UTC)
-        messages = self._messages.get(session_id, [])
+        session = self._sessions[session_id]
+        messages = _branch_messages(self._messages.get(session_id, []), session.head_message_id)
         last = messages[-1] if messages else None
         conversation_json: dict[str, Any] = {
             "messages": [
@@ -258,7 +329,6 @@ class MemoryRepository(Repository):
                 for msg in messages
             ]
         }
-        session = self._sessions[session_id]
         expires_at = (
             now + timedelta(seconds=snapshot_ttl_seconds)
             if snapshot_ttl_seconds is not None
@@ -274,6 +344,22 @@ class MemoryRepository(Repository):
             updated_at=now,
             expires_at=expires_at,
         )
+
+
+def _branch_messages(
+    messages: list[ConversationMessage], head_message_id: str | None
+) -> list[ConversationMessage]:
+    """Return the selected immutable root-to-head ancestry path."""
+    if head_message_id is None:
+        return []
+    by_id = {message.message_id: message for message in messages}
+    path: list[ConversationMessage] = []
+    cursor = by_id.get(head_message_id)
+    while cursor is not None:
+        path.append(cursor)
+        cursor = by_id.get(cursor.parent_message_id) if cursor.parent_message_id else None
+    path.reverse()
+    return path
 
 
 def _bound_messages(

--- a/src/agent_manager/infrastructure/persistence/migrations/alembic.ini
+++ b/src/agent_manager/infrastructure/persistence/migrations/alembic.ini
@@ -1,5 +1,5 @@
-# Alembic config for agent_manager. The database URL is injected from
-# DATABASE_URL in env.py, never hard-coded here.
+# Alembic config for agent_manager. An explicit AGENT_DB_URL or DATABASE_URL is
+# injected in env.py; process-memory mode does not run migrations.
 [alembic]
 script_location = .
 prepend_sys_path = .

--- a/src/agent_manager/infrastructure/persistence/migrations/env.py
+++ b/src/agent_manager/infrastructure/persistence/migrations/env.py
@@ -17,10 +17,9 @@ from agent_manager.config import Settings
 
 config = context.config
 settings = Settings()
-database_url = settings.effective_database_url
-if settings.uses_process_memory or database_url is None:
-    raise RuntimeError("Set EXTRA_DB_URL or DATABASE_URL before running Alembic migrations")
-config.set_main_option("sqlalchemy.url", database_url)
+if settings.uses_process_memory:
+    raise RuntimeError("Set EXTRA_DB_URL or DATABASE_URL to a persistent database before migrating")
+config.set_main_option("sqlalchemy.url", settings.effective_database_url)
 
 if config.config_file_name is not None:
     # Do not silence already-configured application loggers when a migration

--- a/src/agent_manager/infrastructure/persistence/migrations/env.py
+++ b/src/agent_manager/infrastructure/persistence/migrations/env.py
@@ -1,5 +1,4 @@
-"""Alembic environment (async). Schema target is the SQLModel metadata; the URL
-comes from DATABASE_URL so migrations hit the same database the app uses."""
+"""Alembic environment for explicitly configured persistent storage."""
 
 from __future__ import annotations
 
@@ -18,7 +17,10 @@ from agent_manager.config import Settings
 
 config = context.config
 settings = Settings()
-config.set_main_option("sqlalchemy.url", settings.effective_database_url)
+database_url = settings.effective_database_url
+if settings.uses_process_memory or database_url is None:
+    raise RuntimeError("Set AGENT_DB_URL or DATABASE_URL before running Alembic migrations")
+config.set_main_option("sqlalchemy.url", database_url)
 
 if config.config_file_name is not None:
     # Do not silence already-configured application loggers when a migration

--- a/src/agent_manager/infrastructure/persistence/migrations/versions/0002_conversation_persistence.py
+++ b/src/agent_manager/infrastructure/persistence/migrations/versions/0002_conversation_persistence.py
@@ -1,4 +1,4 @@
-"""conversation users, sessions, cold messages, and hot snapshots
+"""conversation users, sessions, messages, snapshots, and durable runs
 
 Revision ID: 0002
 Revises: 0001
@@ -41,6 +41,7 @@ def upgrade() -> None:
         sa.Column("system_name", sa.String(length=256), nullable=True),
         sa.Column("config_path", sa.String(length=1024), nullable=True),
         sa.Column("title", sa.String(length=512), nullable=True),
+        sa.Column("head_message_id", sa.String(length=64), nullable=True),
         sa.Column("metadata_json", sa.JSON(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
@@ -115,8 +116,24 @@ def upgrade() -> None:
         ["expires_at"],
     )
 
+    op.create_table(
+        "agent_runs",
+        sa.Column("run_id", sa.String(length=64), primary_key=True),
+        sa.Column("thread_id", sa.String(length=64), nullable=False),
+        sa.Column("system_name", sa.String(length=256), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.Float(), nullable=False),
+        sa.Column("updated_at", sa.Float(), nullable=False),
+    )
+    op.create_index("ix_agent_runs_status", "agent_runs", ["status"])
+
 
 def downgrade() -> None:
+    op.drop_index("ix_agent_runs_status", table_name="agent_runs")
+    op.drop_table("agent_runs")
+
     op.drop_index("ix_conversation_snapshots_expires_at", table_name="conversation_snapshots")
     op.drop_index("ix_conversation_snapshots_user_id", table_name="conversation_snapshots")
     op.drop_table("conversation_snapshots")

--- a/src/agent_manager/infrastructure/persistence/run_repository.py
+++ b/src/agent_manager/infrastructure/persistence/run_repository.py
@@ -1,0 +1,102 @@
+"""SQL adapter for authoritative engine run lifecycle state."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from sqlalchemy import func, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlmodel import col
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from agent_engine.approvals.models import RunRecord, RunStatus, can_transition_run
+from agent_engine.runs.repository import RunRepository
+from agent_manager.infrastructure.persistence.tables import RunRecordRow
+
+
+class SqlRunRepository(RunRepository):
+    """Durable, atomically transitioned run records for manager deployments."""
+
+    def __init__(self, sessions: async_sessionmaker[AsyncSession]) -> None:
+        self._sessions = sessions
+
+    async def create_if_absent(self, record: RunRecord) -> bool:
+        async with self._sessions() as session, session.begin():
+            if await session.get(RunRecordRow, record.run_id) is not None:
+                return False
+            try:
+                async with session.begin_nested():
+                    session.add(_row(record))
+            except IntegrityError:
+                return False
+        return True
+
+    async def get(self, run_id: str) -> RunRecord | None:
+        async with self._sessions() as session:
+            row = await session.get(RunRecordRow, run_id)
+        return _record(row) if row is not None else None
+
+    async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
+        sources = frozenset(status for status in RunStatus if can_transition_run(status, target))
+        if not sources:
+            return False
+        async with self._sessions() as session, session.begin():
+            changed = await session.exec(
+                update(RunRecordRow)
+                .where(
+                    col(RunRecordRow.run_id) == run_id,
+                    col(RunRecordRow.status).in_([status.value for status in sources]),
+                )
+                .values(status=target.value, updated_at=time.time())
+            )
+        return int(_rowcount(changed)) == 1
+
+    async def add_token_usage(
+        self,
+        run_id: str,
+        *,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> RunRecord | None:
+        values: dict[str, object] = {"updated_at": time.time()}
+        if input_tokens is not None:
+            values["input_tokens"] = func.coalesce(RunRecordRow.input_tokens, 0) + input_tokens
+        if output_tokens is not None:
+            values["output_tokens"] = func.coalesce(RunRecordRow.output_tokens, 0) + output_tokens
+        async with self._sessions() as session, session.begin():
+            await session.exec(
+                update(RunRecordRow).where(col(RunRecordRow.run_id) == run_id).values(**values)
+            )
+        return await self.get(run_id)
+
+
+def _rowcount(result: Any) -> int:
+    return int(result.rowcount)
+
+
+def _row(record: RunRecord) -> RunRecordRow:
+    return RunRecordRow(
+        run_id=record.run_id,
+        thread_id=record.thread_id,
+        system_name=record.system_name,
+        status=record.status.value,
+        input_tokens=record.input_tokens,
+        output_tokens=record.output_tokens,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+def _record(row: RunRecordRow) -> RunRecord:
+    return RunRecord(
+        run_id=row.run_id,
+        thread_id=row.thread_id,
+        system_name=row.system_name,
+        status=RunStatus(row.status),
+        input_tokens=row.input_tokens,
+        output_tokens=row.output_tokens,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )

--- a/src/agent_manager/infrastructure/persistence/run_repository.py
+++ b/src/agent_manager/infrastructure/persistence/run_repository.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Collection
 from typing import Any
 
 from sqlalchemy import func, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
-from sqlmodel import col
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from agent_engine.approvals.models import RunRecord, RunStatus, can_transition_run
@@ -37,6 +38,18 @@ class SqlRunRepository(RunRepository):
         async with self._sessions() as session:
             row = await session.get(RunRecordRow, run_id)
         return _record(row) if row is not None else None
+
+    async def get_many(self, run_ids: Collection[str]) -> dict[str, RunRecord]:
+        """Resolve every requested id in one statement."""
+        wanted = set(run_ids)
+        if not wanted:
+            return {}
+        async with self._sessions() as session:
+            result = await session.exec(
+                select(RunRecordRow).where(col(RunRecordRow.run_id).in_(wanted))
+            )
+            rows = result.all()
+        return {row.run_id: _record(row) for row in rows}
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
         sources = frozenset(status for status in RunStatus if can_transition_run(status, target))

--- a/src/agent_manager/infrastructure/persistence/sql_repository.py
+++ b/src/agent_manager/infrastructure/persistence/sql_repository.py
@@ -11,9 +11,10 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import delete, update
+from sqlalchemy import delete, literal, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.orm import aliased
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -324,9 +325,7 @@ class SqlRepository(Repository):
         self, session_id: str, limit: int | None = None
     ) -> list[ConversationMessage]:
         async with self._sessions() as session:
-            rows = await self._active_message_rows(session, session_id)
-        if limit is not None:
-            rows = rows[-limit:]
+            rows = await self._active_message_rows(session, session_id, limit)
         return [_message(row) for row in rows]
 
     async def list_messages(self, conversation_id: str, limit: int | None = None) -> list[Message]:
@@ -384,8 +383,7 @@ class SqlRepository(Repository):
         max_chars: int | None = None,
     ) -> ConversationContext:
         async with self._sessions() as session:
-            rows = await self._message_rows(session, session_id, None)
-        branch = _branch_rows(rows, head_message_id)
+            branch = await self._branch_message_rows(session, session_id, head_message_id)
         messages = [
             Message(role=Role(row.role), content=row.content, created_at=row.created_at)
             for row in branch
@@ -470,13 +468,52 @@ class SqlRepository(Repository):
         return list(result.all())
 
     async def _active_message_rows(
-        self, session: AsyncSession, session_id: str
+        self, session: AsyncSession, session_id: str, limit: int | None = None
     ) -> list[ConversationMessageRow]:
         session_row = await session.get(ConversationSessionRow, session_id)
         if session_row is None:
             return []
-        rows = await self._message_rows(session, session_id, None)
-        return _branch_rows(rows, session_row.head_message_id)
+        return await self._branch_message_rows(
+            session, session_id, session_row.head_message_id, limit
+        )
+
+    async def _branch_message_rows(
+        self,
+        session: AsyncSession,
+        session_id: str,
+        head_message_id: str | None,
+        limit: int | None = None,
+    ) -> list[ConversationMessageRow]:
+        """Return one branch, oldest first, walking `parent_message_id` in SQL.
+
+        A recursive CTE keeps both the traversal and the limit in the database:
+        history reads the tail of the active branch, never every message the
+        conversation has stored.
+        """
+        if head_message_id is None or (limit is not None and limit <= 0):
+            return []
+        head = (
+            select(ConversationMessageRow, literal(0).label("depth"))
+            .where(
+                col(ConversationMessageRow.session_id) == session_id,
+                col(ConversationMessageRow.message_id) == head_message_id,
+            )
+            .cte("branch", recursive=True)
+        )
+        parent = aliased(ConversationMessageRow, name="parent_message")
+        ancestors = select(parent, (head.c.depth + 1).label("depth")).where(
+            col(parent.session_id) == session_id,
+            col(parent.message_id) == head.c.parent_message_id,
+        )
+        if limit is not None:
+            ancestors = ancestors.where(head.c.depth < limit - 1)
+        branch = head.union_all(ancestors)
+        result = await session.exec(
+            select(ConversationMessageRow)
+            .join(branch, col(ConversationMessageRow.message_id) == branch.c.message_id)
+            .order_by(branch.c.depth.desc())
+        )
+        return list(result.all())
 
 
 def _rows_affected(result: Any) -> int:
@@ -614,21 +651,6 @@ def _bound_messages(
         if total >= max_chars:
             break
     return list(reversed(kept))
-
-
-def _branch_rows(
-    rows: list[ConversationMessageRow], head_message_id: str | None
-) -> list[ConversationMessageRow]:
-    if head_message_id is None:
-        return []
-    by_id = {row.message_id: row for row in rows}
-    path: list[ConversationMessageRow] = []
-    cursor = by_id.get(head_message_id)
-    while cursor is not None:
-        path.append(cursor)
-        cursor = by_id.get(cursor.parent_message_id) if cursor.parent_message_id else None
-    path.reverse()
-    return path
 
 
 def _utc(value: datetime | None) -> datetime | None:

--- a/src/agent_manager/infrastructure/persistence/sql_repository.py
+++ b/src/agent_manager/infrastructure/persistence/sql_repository.py
@@ -7,6 +7,7 @@ layer depends only on the repository port, so backend details stay here.
 from __future__ import annotations
 
 import uuid
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -123,6 +124,7 @@ class SqlRepository(Repository):
                 system_name=system_name,
                 config_path=config_path,
                 title=title,
+                head_message_id=None,
                 metadata_json=dict(metadata or {}),
                 created_at=now,
                 updated_at=now,
@@ -193,6 +195,7 @@ class SqlRepository(Repository):
                 session_row = ConversationSessionRow(
                     session_id=message.session_id,
                     user_id=message.user_id,
+                    head_message_id=message.message_id,
                     created_at=message.created_at,
                     updated_at=message.created_at,
                     last_message_at=message.created_at,
@@ -201,8 +204,11 @@ class SqlRepository(Repository):
                 session.add(session_row)
             else:
                 # No user_id here: writing a message never claims a conversation.
+                if message.parent_message_id is None and session_row.head_message_id is not None:
+                    message = replace(message, parent_message_id=session_row.head_message_id)
                 session_row.updated_at = message.created_at
                 session_row.last_message_at = message.created_at
+                session_row.head_message_id = message.message_id
 
             session.add(_message_row(message))
             await session.flush()
@@ -218,12 +224,38 @@ class SqlRepository(Repository):
         *,
         snapshot_ttl_seconds: int | None = None,
     ) -> bool:
-        """Use the message primary key as the adapter's atomic idempotency boundary."""
+        """Append once, retaining stale-branch children without selecting them."""
         try:
-            await self.append_message(
-                message,
-                snapshot_ttl_seconds=snapshot_ttl_seconds,
-            )
+            async with self._sessions() as session, session.begin():
+                if await session.get(ConversationMessageRow, message.message_id) is not None:
+                    return False
+                session_row = await session.get(ConversationSessionRow, message.session_id)
+                if session_row is None:
+                    session_row = ConversationSessionRow(
+                        session_id=message.session_id,
+                        user_id=message.user_id,
+                        head_message_id=message.message_id,
+                        created_at=message.created_at,
+                        updated_at=message.created_at,
+                        last_message_at=message.created_at,
+                        metadata_json={},
+                    )
+                    session.add(session_row)
+                    activate = True
+                else:
+                    activate = session_row.head_message_id == message.parent_message_id
+                    if activate:
+                        session_row.head_message_id = message.message_id
+                        session_row.updated_at = message.created_at
+                        session_row.last_message_at = message.created_at
+                async with session.begin_nested():
+                    session.add(_message_row(message))
+                if activate:
+                    await self._rebuild_snapshot_in_session(
+                        session,
+                        message.session_id,
+                        snapshot_ttl_seconds=snapshot_ttl_seconds,
+                    )
         except IntegrityError:
             async with self._sessions() as session:
                 existing = await session.get(ConversationMessageRow, message.message_id)
@@ -232,11 +264,69 @@ class SqlRepository(Repository):
             return False
         return True
 
+    async def append_message_if_head(
+        self,
+        message: ConversationMessage,
+        expected_head_message_id: str | None,
+        *,
+        snapshot_ttl_seconds: int | None = None,
+    ) -> bool:
+        async with self._sessions() as session, session.begin():
+            head = col(ConversationSessionRow.head_message_id)
+            expected = (
+                head.is_(None)
+                if expected_head_message_id is None
+                else head == expected_head_message_id
+            )
+            changed = await session.exec(
+                update(ConversationSessionRow)
+                .where(
+                    col(ConversationSessionRow.session_id) == message.session_id,
+                    expected,
+                )
+                .values(
+                    head_message_id=message.message_id,
+                    updated_at=message.created_at,
+                    last_message_at=message.created_at,
+                )
+            )
+            if _rows_affected(changed) == 0:
+                return False
+            session.add(_message_row(message))
+            await session.flush()
+            await self._rebuild_snapshot_in_session(
+                session,
+                message.session_id,
+                snapshot_ttl_seconds=snapshot_ttl_seconds,
+            )
+        return True
+
+    async def get_message(self, message_id: str) -> ConversationMessage | None:
+        async with self._sessions() as session:
+            row = await session.get(ConversationMessageRow, message_id)
+        return _message(row) if row is not None else None
+
+    async def get_user_message_for_run(
+        self, session_id: str, run_id: str
+    ) -> ConversationMessage | None:
+        async with self._sessions() as session:
+            result = await session.exec(
+                select(ConversationMessageRow).where(
+                    col(ConversationMessageRow.session_id) == session_id,
+                    col(ConversationMessageRow.run_id) == run_id,
+                    col(ConversationMessageRow.role) == Role.USER.value,
+                )
+            )
+            row = result.first()
+        return _message(row) if row is not None else None
+
     async def list_conversation_messages(
         self, session_id: str, limit: int | None = None
     ) -> list[ConversationMessage]:
         async with self._sessions() as session:
-            rows = await self._message_rows(session, session_id, limit)
+            rows = await self._active_message_rows(session, session_id)
+        if limit is not None:
+            rows = rows[-limit:]
         return [_message(row) for row in rows]
 
     async def list_messages(self, conversation_id: str, limit: int | None = None) -> list[Message]:
@@ -285,6 +375,29 @@ class SqlRepository(Repository):
             snapshot=snapshot,
         )
 
+    async def get_context_at(
+        self,
+        session_id: str,
+        head_message_id: str | None,
+        *,
+        max_messages: int | None = None,
+        max_chars: int | None = None,
+    ) -> ConversationContext:
+        async with self._sessions() as session:
+            rows = await self._message_rows(session, session_id, None)
+        branch = _branch_rows(rows, head_message_id)
+        messages = [
+            Message(role=Role(row.role), content=row.content, created_at=row.created_at)
+            for row in branch
+        ]
+        bounded = _bound_messages(messages, max_messages=max_messages, max_chars=max_chars)
+        return ConversationContext(
+            session_id=session_id,
+            messages=bounded,
+            message_count=len(branch),
+            source="branch",
+        )
+
     async def delete_expired_snapshots(self, now: datetime) -> int:
         async with self._sessions() as session, session.begin():
             expires_at = col(ConversationSnapshotRow.expires_at)
@@ -305,7 +418,7 @@ class SqlRepository(Repository):
         session_row = await session.get(ConversationSessionRow, session_id)
         if session_row is None:
             return None
-        rows = await self._message_rows(session, session_id, None)
+        rows = await self._active_message_rows(session, session_id)
         now = datetime.now(UTC)
         last = rows[-1] if rows else None
         expires_at = (
@@ -342,11 +455,28 @@ class SqlRepository(Repository):
     ) -> list[ConversationMessageRow]:
         stmt = select(ConversationMessageRow).where(ConversationMessageRow.session_id == session_id)
         if limit is not None:
-            recent = stmt.order_by(col(ConversationMessageRow.created_at).desc()).limit(limit)
+            recent = stmt.order_by(
+                col(ConversationMessageRow.created_at).desc(),
+                col(ConversationMessageRow.message_id).desc(),
+            ).limit(limit)
             result = await session.exec(recent)
             return list(reversed(result.all()))
-        result = await session.exec(stmt.order_by(col(ConversationMessageRow.created_at)))
+        result = await session.exec(
+            stmt.order_by(
+                col(ConversationMessageRow.created_at),
+                col(ConversationMessageRow.message_id),
+            )
+        )
         return list(result.all())
+
+    async def _active_message_rows(
+        self, session: AsyncSession, session_id: str
+    ) -> list[ConversationMessageRow]:
+        session_row = await session.get(ConversationSessionRow, session_id)
+        if session_row is None:
+            return []
+        rows = await self._message_rows(session, session_id, None)
+        return _branch_rows(rows, session_row.head_message_id)
 
 
 def _rows_affected(result: Any) -> int:
@@ -375,6 +505,7 @@ def _session(row: ConversationSessionRow) -> ConversationSession:
         system_name=row.system_name,
         config_path=row.config_path,
         title=row.title,
+        head_message_id=row.head_message_id,
         metadata=dict(row.metadata_json or {}),
         created_at=_utc(row.created_at),
         updated_at=_utc(row.updated_at),
@@ -483,6 +614,21 @@ def _bound_messages(
         if total >= max_chars:
             break
     return list(reversed(kept))
+
+
+def _branch_rows(
+    rows: list[ConversationMessageRow], head_message_id: str | None
+) -> list[ConversationMessageRow]:
+    if head_message_id is None:
+        return []
+    by_id = {row.message_id: row for row in rows}
+    path: list[ConversationMessageRow] = []
+    cursor = by_id.get(head_message_id)
+    while cursor is not None:
+        path.append(cursor)
+        cursor = by_id.get(cursor.parent_message_id) if cursor.parent_message_id else None
+    path.reverse()
+    return path
 
 
 def _utc(value: datetime | None) -> datetime | None:

--- a/src/agent_manager/infrastructure/persistence/tables.py
+++ b/src/agent_manager/infrastructure/persistence/tables.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Column, DateTime, Index, Integer, Text
+from sqlalchemy import JSON, Column, DateTime, Float, Index, Integer, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -39,6 +39,7 @@ class ConversationSessionRow(SQLModel, table=True):
     system_name: str | None = Field(default=None, max_length=256)
     config_path: str | None = Field(default=None, max_length=1024)
     title: str | None = Field(default=None, max_length=512)
+    head_message_id: str | None = Field(default=None, max_length=64)
     metadata_json: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
@@ -96,3 +97,18 @@ class ConversationSnapshotRow(SQLModel, table=True):
     expires_at: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), index=True)
     )
+
+
+class RunRecordRow(SQLModel, table=True):
+    """Durable adapter row for the engine's existing RunRepository contract."""
+
+    __tablename__ = "agent_runs"
+
+    run_id: str = Field(primary_key=True, max_length=64)
+    thread_id: str = Field(max_length=64)
+    system_name: str = Field(max_length=256)
+    status: str = Field(max_length=32, index=True)
+    input_tokens: int | None = Field(default=None, sa_column=Column(Integer))
+    output_tokens: int | None = Field(default=None, sa_column=Column(Integer))
+    created_at: float = Field(sa_column=Column(Float, nullable=False))
+    updated_at: float = Field(sa_column=Column(Float, nullable=False))

--- a/src/agentctl/main.py
+++ b/src/agentctl/main.py
@@ -94,7 +94,7 @@ def generate(config: str) -> None:
     default=None,
     help="Stable conversation session id. Generated and printed if omitted.",
 )
-@click.option("--user-id", default=None, help="Optional user id for persisted local runs.")
+@click.option("--user-id", default=None, help="Optional user id for conversation runs.")
 def run(
     config: str,
     message: str,
@@ -157,6 +157,8 @@ async def _run_async(
             LangGraphEngine(
                 base_dir,
                 session_approval_repository=repositories.session_approvals,
+                tool_usage_repository=repositories.tool_usage,
+                run_repository=repositories.runs,
             ) as engine,
         ):
             await engine.build(spec)
@@ -169,6 +171,7 @@ async def _run_async(
                 snapshot_ttl_seconds=settings.snapshot_ttl_seconds,
                 system_name=spec.meta.name,
                 config_path=str(Path(config).resolve()),
+                run_repository=repositories.runs,
             )
             await service.create(caller, session_id=effective_session_id)
             if stream:

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -793,6 +793,113 @@ async def test_closing_approval_stream_cancels_same_run_without_partial_assistan
     assert [(message.role, message.content) for message in messages] == [(Role.USER, "send it")]
 
 
+class _MidStreamFailureEngine(Engine):
+    async def build(self, _spec: object) -> None: ...
+
+    async def run(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> RunResult:
+        raise RuntimeError("private run failure")
+
+    async def stream(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        yield RunStreamEvent(type="answer_delta", content="partial")
+        raise RuntimeError("private stream failure")
+
+
+async def test_failed_stream_stays_failed_and_is_not_also_cancelled() -> None:
+    """`fail_turn` is the terminal outcome; the cleanup path must not chase it with a cancel."""
+
+    class TransitionRecordingRunRepository(InMemoryRunRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.targets: list[RunStatus] = []
+
+        async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:
+            self.targets.append(target)
+            return await super().transition_if_allowed(run_id, target)
+
+    runs = TransitionRecordingRunRepository()
+    service = ConversationService(
+        _MidStreamFailureEngine(), MemoryRepository(), run_repository=runs
+    )
+    principal = Principal.external("owner")
+    cid = await service.create(principal, session_id="session-1")
+
+    response = await stream_message(cid, SendMessageRequest(message="hello"), service, principal)
+    body = cast(AsyncGenerator[str, None], response.body_iterator)
+    frames = [frame async for frame in body]
+
+    assert any('"type": "error"' in frame for frame in frames)
+    run_id = json.loads(frames[0].split("data: ", 1)[1])["run_id"]
+    record = await runs.get(run_id)
+    assert record is not None and record.status == RunStatus.FAILED
+    assert RunStatus.CANCELLED not in runs.targets
+
+
+async def test_resume_stream_persists_final_when_its_consumer_is_cancelled_mid_write() -> None:
+    """An abort landing on the resume write must not leave a terminal run unanswered."""
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    class BlockingAssistantWriteRepository(MemoryRepository):
+        async def append_message_if_absent(
+            self,
+            message: ConversationMessage,
+            *,
+            snapshot_ttl_seconds: int | None = None,
+        ) -> bool:
+            if message.role is Role.ASSISTANT:
+                write_started.set()
+                await release_write.wait()
+            return await super().append_message_if_absent(
+                message, snapshot_ttl_seconds=snapshot_ttl_seconds
+            )
+
+    runs = InMemoryRunRepository()
+    engine = _ApprovalRecordingEngine(runs)
+    repository = BlockingAssistantWriteRepository()
+    service = ConversationService(engine, repository, run_repository=runs)
+    principal = Principal.external("owner")
+    cid = await service.create(principal, session_id="session-1")
+    pending = await service.send(cid, "send it", principal)
+    assert pending.pending_approval is not None
+
+    events = await service.stream_approval(
+        cid,
+        pending.pending_approval.run_id,
+        pending.pending_approval.approval_id,
+        ApprovalDecision.ALLOW_ONCE,
+        principal,
+    )
+
+    async def consume() -> None:
+        async for _event in events:
+            pass
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.wait_for(write_started.wait(), timeout=1)
+    consumer.cancel()
+    release_write.set()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+    messages = await service.history(cid, principal)
+    assert [(message.role, message.content) for message in messages] == [
+        (Role.USER, "send it"),
+        (Role.ASSISTANT, "sent"),
+    ]
+
+
 async def test_resuming_approval_after_edit_keeps_answer_on_original_branch() -> None:
     engine = _ApprovalRecordingEngine()
     repository = MemoryRepository()

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
-from collections.abc import AsyncIterator, Sequence
+import json
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
 
 from agent_engine.approvals.decision import ApprovalDecision
 from agent_engine.approvals.errors import ApprovalAlreadyProcessed, ApprovalNotFound
+from agent_engine.approvals.models import RunStatus
 from agent_engine.engine.engine import Engine
 from agent_engine.engine.types import ChatMessage, PendingApproval, RunResult
+from agent_engine.runs.in_memory import InMemoryRunRepository
 from agent_engine.runtime.hooks.models import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
 from agent_engine.runtime.tool_models import ToolUsageRecord
+from agent_manager.api.routes import stream_approval_decision, stream_message
+from agent_manager.api.schemas import ApprovalDecisionRequest, SendMessageRequest
 from agent_manager.application import ConversationService
 from agent_manager.config import AuthMode
 from agent_manager.domain import (
@@ -35,12 +43,14 @@ from tests.agent_manager.conftest import (
 
 
 class _ApprovalRecordingEngine(RecordingEngine):
-    def __init__(self) -> None:
+    def __init__(self, run_repository: InMemoryRunRepository | None = None) -> None:
         super().__init__()
+        self.run_repository = run_repository
         self.pending: PendingApproval | None = None
         self.resume_calls: list[
             tuple[str, str, ApprovalDecision | str, str | None, str | None]
         ] = []
+        self.cancel_calls: list[tuple[str, str, str | None, str | None]] = []
         self.completed_results: dict[str, RunResult] = {}
 
     def _pending_result(self, context: RunContext | None) -> RunResult:
@@ -129,6 +139,38 @@ class _ApprovalRecordingEngine(RecordingEngine):
         )
         self.completed_results[run_id] = result
         return result
+
+    async def resume_stream(
+        self,
+        run_id: str,
+        approval_id: str,
+        decision: ApprovalDecision | str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        self.resume_calls.append((run_id, approval_id, decision, caller_user_id, caller_session_id))
+        answer = "The tool request was denied." if decision == ApprovalDecision.DENY else "sent"
+        yield RunStreamEvent(type="resume_started", run_id=run_id)
+        yield RunStreamEvent(
+            type="final",
+            content=answer,
+            route=("writer",),
+            input_tokens=5,
+            output_tokens=2,
+        )
+
+    async def cancel_pending_approval(
+        self,
+        run_id: str,
+        approval_id: str,
+        *,
+        caller_user_id: str | None = None,
+        caller_session_id: str | None = None,
+    ) -> None:
+        self.cancel_calls.append((run_id, approval_id, caller_user_id, caller_session_id))
+        if self.run_repository is not None:
+            await self.run_repository.transition_if_allowed(run_id, RunStatus.CANCELLED)
 
 
 @pytest.fixture
@@ -460,15 +502,69 @@ def test_stream_surfaces_sse_events_and_persists_final_answer(client: TestClient
 
     assert response.status_code == 200
     assert "text/event-stream" in response.headers["content-type"]
+    assert 'event: turn_started\ndata: {"type": "turn_started", "run_id":' in text
+    assert '"message_id":' in text
     assert 'event: answer_delta\ndata: {"type": "answer_delta", "content": "x"}' in text
     assert 'event: final\ndata: {"type": "final", "content": "answer:hello"' in text
     assert "event: done\ndata: [DONE]" in text
-
     messages = client.get(f"/conversations/{cid}/messages").json()
     assert [(m["role"], m["content"]) for m in messages] == [
         ("user", "hello"),
         ("assistant", "answer:hello"),
     ]
+
+
+async def test_closing_after_turn_started_cancels_a_run_before_engine_iteration() -> None:
+    engine = RecordingEngine()
+    runs = InMemoryRunRepository()
+    service = ConversationService(engine, MemoryRepository(), run_repository=runs)
+    principal = Principal.external("early-stop")
+    cid = await service.create(principal)
+    response = await stream_message(
+        cid,
+        SendMessageRequest(message="stop immediately"),
+        service,
+        principal,
+    )
+    body = cast(AsyncGenerator[str, None], response.body_iterator)
+
+    started_frame = await body.__anext__()
+    started = json.loads(started_frame.split("data: ", 1)[1])
+    await body.aclose()
+
+    assert engine.contexts == []
+    record = await runs.get(started["run_id"])
+    assert record is not None and record.status == RunStatus.CANCELLED
+
+
+def test_edit_message_api_selects_a_new_immutable_branch() -> None:
+    engine = RecordingEngine()
+    repository = MemoryRepository()
+    client = TestClient(
+        build_test_app(ConversationService(engine, repository)),
+        headers=bearer("default-user"),
+    )
+    cid = client.post("/conversations").json()["conversation_id"]
+    client.post(f"/conversations/{cid}/messages", json={"message": "U1"})
+    client.post(f"/conversations/{cid}/messages", json={"message": "U2"})
+    before = client.get(f"/conversations/{cid}/messages").json()
+    u2 = next(message for message in before if message["content"] == "U2")
+
+    response = client.post(
+        f"/conversations/{cid}/messages",
+        json={"message": "U2 edited", "edit_message_id": u2["message_id"]},
+    )
+
+    assert response.status_code == 200
+    after = client.get(f"/conversations/{cid}/messages").json()
+    assert [message["content"] for message in after] == [
+        "U1",
+        "answer:U1",
+        "U2 edited",
+        "answer:U2 edited",
+    ]
+    assert [message.content for message in engine.histories[-1]] == ["U1", "answer:U1"]
+    assert u2["content"] == "U2"
 
 
 def test_stream_surfaces_pending_approval_details() -> None:
@@ -558,6 +654,131 @@ def test_conversation_approval_actions_resume_and_persist(
     assert client.get("/conversations/session-1/usage", headers=headers).json()["used_tokens"] == 7
 
 
+def test_conversation_approval_stream_resumes_same_run_and_persists() -> None:
+    engine = _ApprovalRecordingEngine()
+    repository = MemoryRepository()
+    client = TestClient(
+        build_test_app(ConversationService(engine, repository)),
+        headers=bearer("user-1"),
+    )
+    client.post("/conversations", json={"session_id": "session-1"})
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/decision/stream",
+        json={"decision": ApprovalDecision.ALLOW_ONCE.value},
+    )
+
+    assert response.status_code == 200
+    assert f'"type": "resume_started", "run_id": "{pending["run_id"]}"' in response.text
+    assert 'event: final\ndata: {"type": "final", "content": "sent"' in response.text
+    assert engine.resume_calls[0][0] == pending["run_id"]
+    messages = client.get("/conversations/session-1/messages").json()
+    assert [(message["role"], message["content"]) for message in messages] == [
+        ("user", "send it"),
+        ("assistant", "sent"),
+    ]
+
+
+async def test_closing_approval_stream_cancels_same_run_without_partial_assistant() -> None:
+    runs = InMemoryRunRepository()
+
+    class BlockingResumeEngine(_ApprovalRecordingEngine):
+        def __init__(self) -> None:
+            super().__init__(runs)
+            self.cancelled = asyncio.Event()
+
+        async def resume_stream(
+            self,
+            run_id: str,
+            approval_id: str,
+            decision: ApprovalDecision | str,
+            *,
+            caller_user_id: str | None = None,
+            caller_session_id: str | None = None,
+        ) -> AsyncIterator[RunStreamEvent]:
+            del approval_id, decision, caller_user_id, caller_session_id
+            await runs.transition_if_allowed(run_id, RunStatus.RESUMING)
+            await runs.transition_if_allowed(run_id, RunStatus.RUNNING)
+            try:
+                yield RunStreamEvent(type="resume_started", run_id=run_id)
+                yield RunStreamEvent(type="answer_delta", content="partial")
+                await asyncio.Event().wait()
+            finally:
+                await runs.transition_if_allowed(run_id, RunStatus.CANCELLED)
+                self.cancelled.set()
+
+    engine = BlockingResumeEngine()
+    repository = MemoryRepository()
+    service = ConversationService(engine, repository, run_repository=runs)
+    principal = Principal.external("owner")
+    cid = await service.create(principal, session_id="session-1")
+    pending = await service.send(cid, "send it", principal)
+    assert pending.pending_approval is not None
+    await runs.transition_if_allowed(pending.pending_approval.run_id, RunStatus.PENDING_APPROVAL)
+
+    response = await stream_approval_decision(
+        cid,
+        pending.pending_approval.run_id,
+        pending.pending_approval.approval_id,
+        ApprovalDecisionRequest(decision=ApprovalDecision.ALLOW_ONCE),
+        service,
+        principal,
+    )
+    body = cast(AsyncGenerator[str, None], response.body_iterator)
+    started = await body.__anext__()
+    partial = await body.__anext__()
+    assert '"type": "resume_started"' in started
+    assert '"content": "partial"' in partial
+
+    await body.aclose()
+    await asyncio.wait_for(engine.cancelled.wait(), timeout=1)
+
+    record = await runs.get(pending.pending_approval.run_id)
+    assert record is not None and record.status == RunStatus.CANCELLED
+    messages = await service.history(cid, principal)
+    assert [(message.role, message.content) for message in messages] == [(Role.USER, "send it")]
+
+
+async def test_resuming_approval_after_edit_keeps_answer_on_original_branch() -> None:
+    engine = _ApprovalRecordingEngine()
+    repository = MemoryRepository()
+    service = ConversationService(engine, repository)
+    principal = Principal.external("user-1")
+    cid = await service.create(principal, session_id="session-1")
+    original_result = await service.send(cid, "send original", principal)
+    assert original_result.pending_approval is not None
+    original_user = (await service.history(cid, principal))[0]
+
+    await service.send(
+        cid,
+        "send edited",
+        principal,
+        edit_message_id=original_user.message_id,
+    )
+    await service.decide_approval(
+        cid,
+        original_result.pending_approval.run_id,
+        original_result.pending_approval.approval_id,
+        ApprovalDecision.ALLOW_ONCE,
+        principal,
+    )
+
+    active = await service.history(cid, principal)
+    assert [message.content for message in active] == ["send edited"]
+    assistant_id = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"agent-manager:{cid}:{original_result.pending_approval.run_id}:assistant",
+    ).hex
+    inactive_answer = await repository.get_message(assistant_id)
+    assert inactive_answer is not None
+    assert inactive_answer.parent_message_id == original_user.message_id
+
+
 def test_conversation_approval_refuses_a_different_caller() -> None:
     engine = _ApprovalRecordingEngine()
     app = build_test_app(ConversationService(engine, MemoryRepository()))
@@ -583,6 +804,100 @@ def test_conversation_approval_refuses_a_different_caller() -> None:
 
     assert response.status_code == 403
     assert engine.resume_calls == []
+
+
+def test_conversation_owner_can_cancel_pending_approval() -> None:
+    runs = InMemoryRunRepository()
+    engine = _ApprovalRecordingEngine(runs)
+    app = build_test_app(ConversationService(engine, MemoryRepository(), run_repository=runs))
+    client = TestClient(app)
+    headers = bearer("owner")
+    client.post(
+        "/conversations",
+        json={"session_id": "session-1"},
+        headers=headers,
+    )
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+        headers=headers,
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/cancel",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"run_id": pending["run_id"], "status": "cancelled"}
+    assert engine.cancel_calls == [
+        (
+            pending["run_id"],
+            "approval-1",
+            Principal.external("owner").user_id,
+            "session-1",
+        )
+    ]
+    messages = client.get("/conversations/session-1/messages", headers=headers).json()
+    assert [(message["role"], message["status"]) for message in messages] == [("user", "cancelled")]
+
+
+def test_conversation_intruder_cannot_cancel_pending_approval() -> None:
+    engine = _ApprovalRecordingEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app)
+    owner = bearer("owner")
+    client.post(
+        "/conversations",
+        json={"session_id": "session-1"},
+        headers=owner,
+    )
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+        headers=owner,
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/cancel",
+        headers=bearer("intruder"),
+    )
+
+    assert response.status_code == 403
+    assert engine.cancel_calls == []
+
+
+def test_cancel_pending_approval_returns_conflict_when_decision_already_won() -> None:
+    class AlreadyClaimedCancellationEngine(_ApprovalRecordingEngine):
+        async def cancel_pending_approval(
+            self,
+            run_id: str,
+            approval_id: str,
+            *,
+            caller_user_id: str | None = None,
+            caller_session_id: str | None = None,
+        ) -> None:
+            del run_id, caller_user_id, caller_session_id
+            raise ApprovalAlreadyProcessed(approval_id, "resuming")
+
+    engine = AlreadyClaimedCancellationEngine()
+    app = build_test_app(ConversationService(engine, MemoryRepository()))
+    client = TestClient(app, headers=bearer("owner"))
+    client.post("/conversations", json={"session_id": "session-1"})
+    pending = client.post(
+        "/conversations/session-1/messages",
+        json={"message": "send it"},
+    ).json()["pending_approval"]
+
+    response = client.post(
+        f"/conversations/session-1/runs/{pending['run_id']}"
+        f"/approvals/{pending['approval_id']}/cancel"
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "approval already processed"}
 
 
 def test_conversation_approval_sanitizes_engine_failure(

--- a/tests/agent_manager/test_config.py
+++ b/tests/agent_manager/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from agent_manager.config import Settings, normalize_database_url
 
 
-def test_default_storage_is_process_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_database_is_persistent_sqlite_file(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXTRA_DB_BACKEND", raising=False)
     monkeypatch.delenv("EXTRA_DB_URL", raising=False)
     monkeypatch.delenv("AGENT_DB_BACKEND", raising=False)
@@ -16,9 +16,8 @@ def test_default_storage_is_process_memory(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert settings.extra_db_backend == "sqlite"
     assert settings.extra_db_url is None
-    assert settings.database_url is None
-    assert settings.effective_database_url is None
-    assert settings.uses_process_memory is True
+    assert settings.effective_database_url == "sqlite+aiosqlite:///chat.db"
+    assert settings.uses_process_memory is False
     assert settings.context_max_tokens is None
 
 
@@ -29,10 +28,37 @@ def test_explicit_legacy_database_url_selects_sql_storage() -> None:
     assert settings.uses_process_memory is False
 
 
-def test_explicit_in_memory_sqlite_url_still_selects_process_memory() -> None:
+def test_explicit_in_memory_sqlite_url_selects_process_memory() -> None:
     settings = Settings.from_values(database_url="sqlite+aiosqlite:///:memory:")
 
     assert settings.uses_process_memory is True
+
+
+def test_sqlite_url_without_a_database_selects_process_memory() -> None:
+    assert Settings.from_values(database_url="sqlite+aiosqlite://").uses_process_memory is True
+
+
+def test_shared_cache_memory_uri_selects_process_memory() -> None:
+    settings = Settings.from_values(
+        database_url="sqlite+aiosqlite:///file:chat?mode=memory&cache=shared&uri=true"
+    )
+
+    assert settings.uses_process_memory is True
+
+
+def test_on_disk_path_containing_memory_marker_stays_persistent() -> None:
+    """A substring test would drop persistence for this perfectly valid path."""
+    settings = Settings.from_values(database_url="sqlite+aiosqlite:////var/lib/:memory:/chat.db")
+
+    assert settings.uses_process_memory is False
+
+
+def test_postgres_is_never_process_memory() -> None:
+    settings = Settings.from_values(
+        extra_db_backend="postgres", extra_db_url="postgresql://u:p@localhost/:memory:"
+    )
+
+    assert settings.uses_process_memory is False
 
 
 def test_extra_db_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent_manager/test_config.py
+++ b/tests/agent_manager/test_config.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
-import pytest
-
 from agent_manager.config import Settings, normalize_database_url
 
 
-def test_default_database_is_persistent_sqlite_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("AGENT_DB_BACKEND", raising=False)
-    monkeypatch.delenv("AGENT_DB_URL", raising=False)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-
-    settings = Settings()
+def test_default_storage_is_process_memory() -> None:
+    settings = Settings.from_values()
 
     assert settings.agent_db_backend == "sqlite"
     assert settings.agent_db_url is None
-    assert settings.effective_database_url == "sqlite+aiosqlite:///chat.db"
+    assert settings.database_url is None
+    assert settings.effective_database_url is None
+    assert settings.uses_process_memory is True
     assert settings.context_max_tokens is None
+
+
+def test_explicit_legacy_database_url_selects_sql_storage() -> None:
+    settings = Settings.from_values(database_url="sqlite:///chat.db")
+
+    assert settings.effective_database_url == "sqlite+aiosqlite:///chat.db"
+    assert settings.uses_process_memory is False
+
+
+def test_explicit_in_memory_sqlite_url_still_selects_process_memory() -> None:
+    settings = Settings.from_values(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert settings.uses_process_memory is True
 
 
 def test_sqlite_url_normalizes_to_async_driver() -> None:

--- a/tests/agent_manager/test_database.py
+++ b/tests/agent_manager/test_database.py
@@ -1,0 +1,16 @@
+"""Database setup selects persistence only when explicitly configured."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_manager.config import Settings
+from agent_manager.infrastructure.persistence.database import upgrade_database
+
+
+def test_upgrade_is_a_noop_without_a_configured_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agent_manager.config.Settings", lambda: Settings.from_values())
+
+    assert upgrade_database() is False

--- a/tests/agent_manager/test_database.py
+++ b/tests/agent_manager/test_database.py
@@ -1,4 +1,4 @@
-"""Database setup selects persistence only when explicitly configured."""
+"""Database setup runs migrations only against a database that outlives the process."""
 
 from __future__ import annotations
 
@@ -8,9 +8,12 @@ from agent_manager.config import Settings
 from agent_manager.infrastructure.persistence.database import upgrade_database
 
 
-def test_upgrade_is_a_noop_without_a_configured_database(
+def test_upgrade_is_a_noop_for_an_in_memory_database(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("agent_manager.config.Settings", lambda: Settings.from_values())
+    monkeypatch.setattr(
+        "agent_manager.config.Settings",
+        lambda: Settings.from_values(database_url="sqlite+aiosqlite:///:memory:"),
+    )
 
     assert upgrade_database() is False

--- a/tests/agent_manager/test_repository_contract.py
+++ b/tests/agent_manager/test_repository_contract.py
@@ -214,6 +214,54 @@ async def test_limit_returns_most_recent_oldest_first(repo: Repository) -> None:
     for i in range(5):
         await repo.add_message(cid, Role.USER, f"m{i}")
     assert [m.content for m in await repo.list_messages(cid, limit=2)] == ["m3", "m4"]
+    assert await repo.list_messages(cid, limit=0) == []
+
+
+async def test_limit_counts_only_the_active_branch(repo: Repository) -> None:
+    """A limited read walks the selected ancestry, not whatever else the session stores."""
+    now = datetime.now(UTC)
+    await repo.create_session("branch", user_id="u1")
+    await repo.append_message_if_head(
+        ConversationMessage("root", "branch", Role.USER, "Q1", now), None
+    )
+    await repo.append_message_if_head(
+        ConversationMessage(
+            "answer",
+            "branch",
+            Role.ASSISTANT,
+            "A1",
+            now + timedelta(microseconds=1),
+            parent_message_id="root",
+        ),
+        "root",
+    )
+    await repo.append_message_if_head(
+        ConversationMessage(
+            "abandoned",
+            "branch",
+            Role.USER,
+            "Q2",
+            now + timedelta(microseconds=2),
+            parent_message_id="answer",
+        ),
+        "answer",
+    )
+    # Edit Q2: a sibling of `abandoned` becomes the head, leaving it stored but inactive.
+    await repo.append_message_if_head(
+        ConversationMessage(
+            "edited",
+            "branch",
+            Role.USER,
+            "Q2 edited",
+            now + timedelta(microseconds=3),
+            parent_message_id="answer",
+        ),
+        "abandoned",
+    )
+
+    limited = await repo.list_conversation_messages("branch", limit=2)
+
+    assert [message.message_id for message in limited] == ["answer", "edited"]
 
 
 async def test_same_turn_keeps_order(repo: Repository) -> None:

--- a/tests/agent_manager/test_repository_contract.py
+++ b/tests/agent_manager/test_repository_contract.py
@@ -143,6 +143,72 @@ async def test_append_message_if_absent_is_idempotent(repo: Repository) -> None:
     assert stored == [message]
 
 
+async def test_branch_head_selects_one_immutable_ancestry(repo: Repository) -> None:
+    await repo.create_session("branch")
+    now = datetime.now(UTC)
+    root = ConversationMessage("root", "branch", Role.USER, "U1", now)
+    answer = ConversationMessage(
+        "answer",
+        "branch",
+        Role.ASSISTANT,
+        "A1",
+        now + timedelta(microseconds=1),
+        parent_message_id="root",
+    )
+    original = ConversationMessage(
+        "original",
+        "branch",
+        Role.USER,
+        "U2",
+        now + timedelta(microseconds=2),
+        run_id="run-original",
+        parent_message_id="answer",
+    )
+    for message in (root, answer, original):
+        await repo.append_message(message)
+
+    edited = ConversationMessage(
+        "edited",
+        "branch",
+        Role.USER,
+        "U2 edited",
+        now + timedelta(microseconds=3),
+        parent_message_id="answer",
+    )
+    assert await repo.append_message_if_head(edited, "original") is True
+    assert (
+        await repo.append_message_if_head(
+            ConversationMessage("racer", "branch", Role.USER, "racer", now),
+            "original",
+        )
+        is False
+    )
+
+    assert [message.message_id for message in await repo.list_conversation_messages("branch")] == [
+        "root",
+        "answer",
+        "edited",
+    ]
+    assert await repo.get_message("original") == original
+    assert await repo.get_user_message_for_run("branch", "run-original") == original
+
+    late_original_answer = ConversationMessage(
+        "late-answer",
+        "branch",
+        Role.ASSISTANT,
+        "late A2",
+        now + timedelta(microseconds=4),
+        parent_message_id="original",
+    )
+    assert await repo.append_message_if_absent(late_original_answer) is True
+    assert [message.message_id for message in await repo.list_conversation_messages("branch")] == [
+        "root",
+        "answer",
+        "edited",
+    ]
+    assert await repo.get_message("late-answer") == late_original_answer
+
+
 async def test_limit_returns_most_recent_oldest_first(repo: Repository) -> None:
     cid = await repo.create_conversation()
     for i in range(5):

--- a/tests/agent_manager/test_run_repository.py
+++ b/tests/agent_manager/test_run_repository.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+
+from sqlmodel import SQLModel
+
+import agent_manager.infrastructure.persistence.tables  # noqa: F401
+from agent_engine.approvals.models import RunRecord, RunStatus
+from agent_manager.infrastructure.persistence.database import create_db_engine, session_factory
+from agent_manager.infrastructure.persistence.run_repository import SqlRunRepository
+
+
+async def test_sql_run_repository_persists_status_and_usage_atomically() -> None:
+    engine = create_db_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    repository = SqlRunRepository(session_factory(engine))
+    record = RunRecord("run-1", "run-1", "system")
+
+    assert await repository.create_if_absent(record) is True
+    assert await repository.create_if_absent(record) is False
+    assert await repository.add_token_usage("run-1", input_tokens=4, output_tokens=2) is not None
+    completed, cancelled = await asyncio.gather(
+        repository.transition_if_allowed("run-1", RunStatus.COMPLETED),
+        repository.transition_if_allowed("run-1", RunStatus.CANCELLED),
+    )
+
+    assert sum((completed, cancelled)) == 1
+    stored = await repository.get("run-1")
+    assert stored is not None
+    assert stored.status in {RunStatus.COMPLETED, RunStatus.CANCELLED}
+    assert (stored.input_tokens, stored.output_tokens) == (4, 2)
+    await engine.dispose()

--- a/tests/agent_manager/test_run_repository.py
+++ b/tests/agent_manager/test_run_repository.py
@@ -31,3 +31,20 @@ async def test_sql_run_repository_persists_status_and_usage_atomically() -> None
     assert stored.status in {RunStatus.COMPLETED, RunStatus.CANCELLED}
     assert (stored.input_tokens, stored.output_tokens) == (4, 2)
     await engine.dispose()
+
+
+async def test_sql_run_repository_reads_many_runs_in_one_statement() -> None:
+    engine = create_db_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    repository = SqlRunRepository(session_factory(engine))
+    for run_id in ("run-1", "run-2", "run-3"):
+        await repository.create_if_absent(RunRecord(run_id, run_id, "system"))
+    await repository.transition_if_allowed("run-2", RunStatus.COMPLETED)
+
+    found = await repository.get_many(["run-1", "run-2", "missing"])
+
+    assert set(found) == {"run-1", "run-2"}
+    assert found["run-2"].status is RunStatus.COMPLETED
+    assert await repository.get_many([]) == {}
+    await engine.dispose()

--- a/tests/agent_manager/test_service.py
+++ b/tests/agent_manager/test_service.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 
+from agent_engine.approvals.errors import RunNotFound
 from agent_engine.engine.types import ChatMessage, ChatRole
 from agent_engine.runtime.hooks.models import RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
@@ -43,6 +44,50 @@ class FinalThenCleanupErrorEngine(RecordingEngine):
         raise CleanupAfterFinalError("cleanup after final")
 
 
+class RenameFailingRepository(MemoryRepository):
+    async def rename_session(self, session_id: str, title: str) -> None:
+        del session_id, title
+        raise RuntimeError("title storage unavailable")
+
+
+class CancellableThenSuccessfulEngine(RecordingEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancelled = asyncio.Event()
+        self.stream_count = 0
+        self.statuses: dict[str, str] = {}
+
+    async def get_run_status(self, run_id: str) -> str:
+        try:
+            return self.statuses[run_id]
+        except KeyError:
+            raise RunNotFound(run_id) from None
+
+    async def stream(
+        self,
+        message: str,
+        *,
+        history: Sequence[ChatMessage] = (),
+        context: RunContext | None = None,
+    ) -> AsyncIterator[RunStreamEvent]:
+        self.prompts.append(message)
+        self.histories.append(tuple(history))
+        self.contexts.append(context)
+        assert context is not None and context.run_id is not None
+        self.statuses[context.run_id] = "running"
+        self.stream_count += 1
+        if self.stream_count > 1:
+            self.statuses[context.run_id] = "completed"
+            yield RunStreamEvent(type="final", content=f"answer:{message}", route=("agent",))
+            return
+        try:
+            yield RunStreamEvent(type="answer_delta", content="partial")
+            await asyncio.Event().wait()
+        finally:
+            self.statuses[context.run_id] = "cancelled"
+            self.cancelled.set()
+
+
 def _service(window: int = 10) -> tuple[ConversationService, RecordingEngine]:
     engine = RecordingEngine()
     return ConversationService(engine, MemoryRepository(), window=window), engine
@@ -58,6 +103,18 @@ async def test_send_persists_user_and_assistant_in_order() -> None:
         (Role.USER, "hello"),
         (Role.ASSISTANT, "answer:hello"),
     ]
+
+
+async def test_cosmetic_title_failure_does_not_orphan_an_accepted_turn() -> None:
+    repository = RenameFailingRepository()
+    service = ConversationService(RecordingEngine(), repository)
+    cid = await service.create(ALICE)
+
+    result = await service.send(cid, "hello", ALICE)
+
+    assert result.answer == "answer:hello"
+    messages = await service.history(cid, ALICE)
+    assert [message.content for message in messages] == ["hello", "answer:hello"]
 
 
 async def test_stream_persists_final_before_propagating_late_engine_failure() -> None:
@@ -84,13 +141,105 @@ async def test_stream_persists_final_when_consumer_closes_generator() -> None:
 
     final = await events.__anext__()
     assert final.type == "final"
-    await events.aclose()
-
     messages = await service.history(cid, ALICE)
     assert [(message.role, message.content) for message in messages] == [
         (Role.USER, "hello"),
         (Role.ASSISTANT, "persisted"),
     ]
+    await events.aclose()
+
+
+async def test_cancelled_stream_persists_no_partial_assistant_and_next_turn_succeeds() -> None:
+    repository = MemoryRepository()
+    engine = CancellableThenSuccessfulEngine()
+    service = ConversationService(engine, repository)
+    cid = await service.create(ALICE)
+    events = cast(AsyncGenerator[RunStreamEvent, None], service.stream(cid, "first", ALICE))
+
+    partial = await events.__anext__()
+    assert partial.content == "partial"
+    await events.aclose()
+    await asyncio.wait_for(engine.cancelled.wait(), timeout=1)
+
+    messages = await service.history(cid, ALICE)
+    assert [(message.role, message.content) for message in messages] == [(Role.USER, "first")]
+    assert messages[0].status == "cancelled"
+
+    assert [event.type async for event in service.stream(cid, "second", ALICE)] == ["final"]
+    messages = await service.history(cid, ALICE)
+    assert [(message.role, message.content) for message in messages] == [
+        (Role.USER, "first"),
+        (Role.USER, "second"),
+        (Role.ASSISTANT, "answer:second"),
+    ]
+    assert [message.content for message in engine.histories[-1]] == ["first"]
+    assert all(message.content != "Generation stopped" for message in engine.histories[-1])
+
+
+async def test_edit_creates_an_immutable_branch_with_only_ancestor_context() -> None:
+    repository = MemoryRepository()
+    engine = RecordingEngine()
+    service = ConversationService(engine, repository)
+    cid = await service.create(ALICE)
+    await service.send(cid, "U1", ALICE)
+    await service.send(cid, "U2", ALICE)
+    original = await service.history(cid, ALICE)
+    original_u2 = next(message for message in original if message.content == "U2")
+    original_a2 = next(message for message in original if message.content == "answer:U2")
+
+    await service.send(
+        cid,
+        "U2 edited",
+        ALICE,
+        edit_message_id=original_u2.message_id,
+    )
+
+    assert engine.histories[-1] == (
+        ChatMessage(ChatRole.USER, "U1"),
+        ChatMessage(ChatRole.ASSISTANT, "answer:U1"),
+    )
+    active = await service.history(cid, ALICE)
+    assert [message.content for message in active] == [
+        "U1",
+        "answer:U1",
+        "U2 edited",
+        "answer:U2 edited",
+    ]
+    stored_u2 = await repository.get_message(original_u2.message_id)
+    stored_a2 = await repository.get_message(original_a2.message_id)
+    assert stored_u2 is not None and stored_u2.content == "U2"
+    assert stored_a2 is not None and stored_a2.content == "answer:U2"
+    edited = next(message for message in active if message.content == "U2 edited")
+    assert edited.run_id != original_u2.run_id
+    assert edited.parent_message_id == original_u2.parent_message_id
+
+
+async def test_editing_root_starts_a_new_root_without_old_branch_context() -> None:
+    repository = MemoryRepository()
+    engine = RecordingEngine()
+    service = ConversationService(engine, repository)
+    cid = await service.create(ALICE)
+    await service.send(cid, "original root", ALICE)
+    original = await service.history(cid, ALICE)
+
+    await service.send(
+        cid,
+        "edited root",
+        ALICE,
+        edit_message_id=original[0].message_id,
+    )
+
+    assert engine.histories[-1] == ()
+    active = await service.history(cid, ALICE)
+    assert [message.content for message in active] == [
+        "edited root",
+        "answer:edited root",
+    ]
+    assert active[0].parent_message_id is None
+    stored_user = await repository.get_message(original[0].message_id)
+    stored_assistant = await repository.get_message(original[1].message_id)
+    assert stored_user is not None and stored_user.content == "original root"
+    assert stored_assistant is not None and stored_assistant.content == "answer:original root"
 
 
 async def test_prior_history_passed_to_engine_as_structured_messages() -> None:

--- a/tests/agent_manager/test_session_approval_composition.py
+++ b/tests/agent_manager/test_session_approval_composition.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from agent_engine.approvals.invocation import SessionApprovalKey
 from agent_engine.approvals.session_store import InMemorySessionApprovalRepository
-from agent_manager.composition import build_session_approval_repository
+from agent_engine.runs.in_memory import InMemoryRunRepository
+from agent_manager.composition import application_repositories, build_session_approval_repository
+from agent_manager.config import Settings
+from agent_manager.infrastructure.persistence.memory_repository import MemoryRepository
 
 
 def test_composition_builds_the_in_memory_adapter() -> None:
@@ -40,3 +45,19 @@ async def test_new_application_repository_starts_without_prior_grants() -> None:
 
     assert await first.is_allowed(key) is True
     assert await second.is_allowed(key) is False
+
+
+async def test_unconfigured_application_uses_only_process_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_sql_engine_is_created(_url: str) -> None:
+        raise AssertionError("unconfigured storage must not create a database engine")
+
+    monkeypatch.setattr(
+        "agent_manager.composition.create_db_engine",
+        fail_if_sql_engine_is_created,
+    )
+
+    async with application_repositories(Settings.from_values()) as repositories:
+        assert isinstance(repositories.conversations, MemoryRepository)
+        assert isinstance(repositories.runs, InMemoryRunRepository)

--- a/tests/agent_manager/test_session_approval_composition.py
+++ b/tests/agent_manager/test_session_approval_composition.py
@@ -47,17 +47,18 @@ async def test_new_application_repository_starts_without_prior_grants() -> None:
     assert await second.is_allowed(key) is False
 
 
-async def test_unconfigured_application_uses_only_process_memory(
+async def test_in_memory_database_url_uses_only_process_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fail_if_sql_engine_is_created(_url: str) -> None:
-        raise AssertionError("unconfigured storage must not create a database engine")
+        raise AssertionError("in-memory storage must not create a database engine")
 
     monkeypatch.setattr(
         "agent_manager.composition.create_db_engine",
         fail_if_sql_engine_is_created,
     )
+    settings = Settings.from_values(database_url="sqlite+aiosqlite:///:memory:")
 
-    async with application_repositories(Settings.from_values()) as repositories:
+    async with application_repositories(settings) as repositories:
         assert isinstance(repositories.conversations, MemoryRepository)
         assert isinstance(repositories.runs, InMemoryRunRepository)

--- a/tests/approvals/test_engine_hitl.py
+++ b/tests/approvals/test_engine_hitl.py
@@ -12,7 +12,8 @@ call executes without asking. There is no risk classification.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
 from typing import Any, cast
 
@@ -140,6 +141,69 @@ class ChainedApprovalModel(FakeChatModel):
         )
 
 
+class BlockingAfterToolModel(FakeChatModel):
+    """Block the post-tool model turn so streamed resume cancellation is observable."""
+
+    def __init__(
+        self,
+        tool_names: list[str] | None = None,
+        *,
+        blocked: asyncio.Event | None = None,
+        cancelled: asyncio.Event | None = None,
+    ) -> None:
+        super().__init__(tool_names)
+        self.blocked = blocked or asyncio.Event()
+        self.cancelled = cancelled or asyncio.Event()
+
+    def bind_tools(self, tools: list[Any]) -> BlockingAfterToolModel:
+        return BlockingAfterToolModel(
+            [tool.name for tool in tools],
+            blocked=self.blocked,
+            cancelled=self.cancelled,
+        )
+
+    async def ainvoke(self, messages: list[Any]) -> AIMessage:
+        if not any(isinstance(message, ToolMessage) for message in messages):
+            return self._respond(messages)
+        self.blocked.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+        raise AssertionError("unreachable")
+
+    async def astream(self, messages: list[Any]) -> AsyncIterator[AIMessage]:
+        yield await self.ainvoke(messages)
+
+
+class SequentialToolModel(FakeChatModel):
+    """Request each bound tool in order, producing two approval checkpoints."""
+
+    def bind_tools(self, tools: list[Any]) -> SequentialToolModel:
+        return SequentialToolModel([tool.name for tool in tools])
+
+    def _respond(self, messages: list[Any]) -> AIMessage:
+        completed = sum(isinstance(message, ToolMessage) for message in messages)
+        if completed < len(self._tool_names):
+            tool_name = self._tool_names[completed]
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    LCToolCall(
+                        name=tool_name,
+                        args={"message": tool_name},
+                        id=f"call-{completed + 1}",
+                    )
+                ],
+                usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+            )
+        return AIMessage(
+            content="both done",
+            usage_metadata={"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+        )
+
+
 def _factory(provider: str, name: str, temperature: float | None, **_: Any) -> BaseChatModel:
     return cast(BaseChatModel, FakeChatModel())
 
@@ -154,6 +218,12 @@ def _chained_factory(
     provider: str, name: str, temperature: float | None, **_: Any
 ) -> BaseChatModel:
     return cast(BaseChatModel, ChainedApprovalModel())
+
+
+def _sequential_factory(
+    provider: str, name: str, temperature: float | None, **_: Any
+) -> BaseChatModel:
+    return cast(BaseChatModel, SequentialToolModel())
 
 
 def _write_counting_tool(base_dir: Path, tool_id: str, counter: Path) -> None:
@@ -182,16 +252,17 @@ def _spec(tool_id: str, *, auto_mode: bool = False) -> SystemSpec:
 
 
 def _chained_spec() -> SystemSpec:
+    return _multi_tool_spec("send_email", "archive_email")
+
+
+def _multi_tool_spec(*tool_ids: str) -> SystemSpec:
     agent = AgentSpec(
         id="writer",
         name="writer",
         description="writer agent",
         model=_MODEL,
         prompts=BasePromptSet(),
-        tools=(
-            ToolSpec("send_email", "Send an email to the selected recipient."),
-            ToolSpec("archive_email", "Archive the email after sending it."),
-        ),
+        tools=tuple(ToolSpec(tool_id, f"{tool_id} description") for tool_id in tool_ids),
         auto_mode=False,
     )
     return SystemSpec(meta=SystemMeta(name="hitl"), defaults=None, graph=GraphNode(node=agent))
@@ -438,6 +509,205 @@ async def test_duplicate_resume_is_rejected_and_tool_runs_once(tmp_path: Path) -
             await engine.resume("run-5", approval_id, "allow once")
 
     assert _executions(counter) == 1  # no duplicate side effect
+
+
+async def test_cancel_pending_approval_is_terminal_and_never_executes_tool(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    _write_counting_tool(tmp_path, "send_email", counter)
+    async with await _engine(tmp_path) as engine:
+        await engine.build(_spec("send_email"))
+        pending = await engine.run(
+            "hi",
+            context=RunContext(
+                run_id="run-cancel-pending",
+                conversation_id="conversation-1",
+                user_id="owner",
+            ),
+        )
+        assert pending.pending_approval is not None
+
+        await engine.cancel_pending_approval(
+            "run-cancel-pending",
+            pending.pending_approval.approval_id,
+            caller_user_id="owner",
+            caller_session_id="conversation-1",
+        )
+
+        assert await engine.get_run_status("run-cancel-pending") == "cancelled"
+        assert await engine.get_pending_approval("run-cancel-pending") is None
+        with pytest.raises(ApprovalAlreadyProcessed):
+            await engine.resume(
+                "run-cancel-pending",
+                pending.pending_approval.approval_id,
+                "allow once",
+                caller_user_id="owner",
+                caller_session_id="conversation-1",
+            )
+
+    assert _executions(counter) == 0
+
+
+async def test_stopping_streamed_resume_cancels_same_run_and_real_graph_task(
+    tmp_path: Path,
+) -> None:
+    counter = tmp_path / "calls.log"
+    _write_counting_tool(tmp_path, "send_email", counter)
+    model = BlockingAfterToolModel()
+
+    def factory(*_: Any, **__: Any) -> BaseChatModel:
+        return cast(BaseChatModel, model)
+
+    async with LangGraphEngine(tmp_path, model_factory=factory) as engine:
+        await engine.build(_spec("send_email"))
+        pending = await engine.run(
+            "hi",
+            context=RunContext(
+                run_id="same-run",
+                conversation_id="conversation-1",
+                user_id="owner",
+            ),
+        )
+        assert pending.pending_approval is not None
+
+        events = cast(
+            AsyncGenerator[Any, None],
+            engine.resume_stream(
+                "same-run",
+                pending.pending_approval.approval_id,
+                "allow once",
+                caller_user_id="owner",
+                caller_session_id="conversation-1",
+            ),
+        )
+        started = await events.__anext__()
+        assert started.type == "resume_started"
+        assert started.run_id == "same-run"
+        assert await engine.get_run_status("same-run") == "running"
+        await asyncio.wait_for(model.blocked.wait(), timeout=1)
+
+        await events.aclose()
+        await asyncio.wait_for(model.cancelled.wait(), timeout=1)
+
+        assert await engine.get_run_status("same-run") == "cancelled"
+
+    assert _executions(counter) == 1
+
+
+async def test_stopping_resume_during_claim_activation_cannot_strand_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counter = tmp_path / "calls.log"
+    _write_counting_tool(tmp_path, "send_email", counter)
+    async with await _engine(tmp_path) as engine:
+        await engine.build(_spec("send_email"))
+        pending = await engine.run("hi", context=RunContext(run_id="activation-race"))
+        assert pending.pending_approval is not None
+        assert engine._lifecycle is not None
+
+        activation_entered = asyncio.Event()
+        release_activation = asyncio.Event()
+        original_activate = engine._lifecycle.activate_resume
+
+        async def delayed_activate(ctx: RunContext) -> None:
+            activation_entered.set()
+            await release_activation.wait()
+            await original_activate(ctx)
+
+        monkeypatch.setattr(engine._lifecycle, "activate_resume", delayed_activate)
+        events = cast(
+            AsyncGenerator[Any, None],
+            engine.resume_stream(
+                "activation-race",
+                pending.pending_approval.approval_id,
+                "allow once",
+            ),
+        )
+        first_event = asyncio.create_task(events.__anext__())
+        await asyncio.wait_for(activation_entered.wait(), timeout=1)
+
+        first_event.cancel()
+        await asyncio.sleep(0)
+        release_activation.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first_event
+        await events.aclose()
+
+        assert await engine.get_run_status("activation-race") == "cancelled"
+        assert await engine.get_pending_approval("activation-race") is None
+
+    assert _executions(counter) == 0
+
+
+async def test_completed_streamed_resume_wins_over_late_stop(tmp_path: Path) -> None:
+    counter = tmp_path / "calls.log"
+    _write_counting_tool(tmp_path, "send_email", counter)
+    async with await _engine(tmp_path) as engine:
+        await engine.build(_spec("send_email"))
+        pending = await engine.run("hi", context=RunContext(run_id="completed-resume"))
+        assert pending.pending_approval is not None
+        events = cast(
+            AsyncGenerator[Any, None],
+            engine.resume_stream(
+                "completed-resume",
+                pending.pending_approval.approval_id,
+                "allow once",
+            ),
+        )
+
+        streamed = [event async for event in events]
+        await events.aclose()
+
+        assert streamed[0].type == "resume_started"
+        assert streamed[-1].type == "final"
+        assert await engine.get_run_status("completed-resume") == "completed"
+
+    assert _executions(counter) == 1
+
+
+async def test_streamed_resume_supports_multiple_sequential_approvals_same_run(
+    tmp_path: Path,
+) -> None:
+    first_counter = tmp_path / "first.log"
+    second_counter = tmp_path / "second.log"
+    _write_counting_tool(tmp_path, "first_tool", first_counter)
+    _write_counting_tool(tmp_path, "second_tool", second_counter)
+    async with LangGraphEngine(tmp_path, model_factory=_sequential_factory) as engine:
+        await engine.build(_multi_tool_spec("first_tool", "second_tool"))
+        first = await engine.run("hi", context=RunContext(run_id="multi-approval"))
+        assert first.pending_approval is not None
+        assert first.pending_approval.tool_name == "first_tool"
+
+        first_resume = [
+            event
+            async for event in engine.resume_stream(
+                "multi-approval",
+                first.pending_approval.approval_id,
+                "allow once",
+            )
+        ]
+        second = next(event for event in first_resume if event.type == "pending_approval")
+        assert second.run_id == "multi-approval"
+        assert second.tool_name == "second_tool"
+        assert await engine.get_run_status("multi-approval") == "pending_approval"
+
+        second_resume = [
+            event
+            async for event in engine.resume_stream(
+                "multi-approval",
+                second.approval_id or "",
+                "allow once",
+            )
+        ]
+        assert second_resume[0].type == "resume_started"
+        assert second_resume[-1].type == "final"
+        assert second_resume[-1].content == "both done"
+        assert await engine.get_run_status("multi-approval") == "completed"
+
+    assert _executions(first_counter) == 1
+    assert _executions(second_counter) == 1
 
 
 async def test_invalid_decision_fails_closed_without_tool_execution(tmp_path: Path) -> None:

--- a/tests/approvals/test_manager.py
+++ b/tests/approvals/test_manager.py
@@ -141,6 +141,53 @@ async def test_second_claim_is_rejected() -> None:
         await mgr.claim(run_id="r1", approval_id="ap1")
 
 
+async def test_cancel_pending_rejects_approval_without_claiming_run() -> None:
+    mgr = _approval_manager()
+    await _pending(mgr, user="owner", auth_ref="session-1")
+
+    cancelled = await mgr.cancel_pending(
+        run_id="r1",
+        approval_id="ap1",
+        caller_user_id="owner",
+        caller_auth_ref="session-1",
+    )
+
+    assert cancelled.status == ApprovalStatus.REJECTED
+    assert (await mgr.get_run("r1")).status == RunStatus.PENDING_APPROVAL
+    with pytest.raises(ApprovalAlreadyProcessed):
+        await mgr.claim(
+            run_id="r1",
+            approval_id="ap1",
+            caller_user_id="owner",
+            caller_auth_ref="session-1",
+        )
+
+
+async def test_cancel_pending_loses_after_resume_claim() -> None:
+    mgr = _approval_manager()
+    await _pending(mgr)
+    await mgr.claim(run_id="r1", approval_id="ap1")
+
+    with pytest.raises(ApprovalAlreadyProcessed):
+        await mgr.cancel_pending(run_id="r1", approval_id="ap1")
+
+
+async def test_unauthorized_cancellation_leaves_approval_pending() -> None:
+    mgr = _approval_manager()
+    await _pending(mgr, user="owner", auth_ref="session-1")
+
+    with pytest.raises(UnauthorizedApprover):
+        await mgr.cancel_pending(
+            run_id="r1",
+            approval_id="ap1",
+            caller_user_id="intruder",
+            caller_auth_ref="session-1",
+        )
+
+    assert (await mgr.get_approval("r1", "ap1")).status == ApprovalStatus.PENDING
+    assert (await mgr.get_run("r1")).status == RunStatus.PENDING_APPROVAL
+
+
 async def test_claim_validates_run_membership() -> None:
     runs = InMemoryRunRepository()
     mgr = ApprovalManager(

--- a/tests/approvals/test_models.py
+++ b/tests/approvals/test_models.py
@@ -49,6 +49,11 @@ def test_in_flight_runs_can_be_cancelled() -> None:
     resuming.transition(RunStatus.CANCELLED)
     assert resuming.status == RunStatus.CANCELLED
 
+    pending = _run()
+    pending.status = RunStatus.PENDING_APPROVAL
+    pending.transition(RunStatus.CANCELLED)
+    assert pending.status == RunStatus.CANCELLED
+
 
 @pytest.mark.parametrize(
     "start,target",
@@ -58,7 +63,6 @@ def test_in_flight_runs_can_be_cancelled() -> None:
         (RunStatus.RUNNING, RunStatus.RESUMING),
         (RunStatus.CANCELLED, RunStatus.RUNNING),
         (RunStatus.CANCELLED, RunStatus.COMPLETED),
-        (RunStatus.PENDING_APPROVAL, RunStatus.CANCELLED),
     ],
 )
 def test_invalid_run_transitions_raise(start: RunStatus, target: RunStatus) -> None:

--- a/tests/approvals/test_repository.py
+++ b/tests/approvals/test_repository.py
@@ -49,6 +49,24 @@ async def test_claim_is_atomic_single_winner() -> None:
     assert sum(results) == 1  # exactly one caller wins the PENDING -> RESUMING move
 
 
+async def test_claim_and_cancel_have_exactly_one_winner() -> None:
+    repo = InMemoryApprovalRepository()
+    await repo.create(_approval())
+
+    async def transition(operation: str) -> str | None:
+        try:
+            if operation == "claim":
+                await repo.claim("ap1")
+            else:
+                await repo.reject_pending("ap1")
+            return operation
+        except InvalidStateTransition:
+            return None
+
+    winners = await asyncio.gather(transition("claim"), transition("cancel"))
+    assert len([winner for winner in winners if winner is not None]) == 1
+
+
 async def test_claim_missing_raises() -> None:
     repo = InMemoryApprovalRepository()
     with pytest.raises(ApprovalNotFound):

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -129,11 +129,20 @@ async function mockConversationApi(
 
 async function mockApprovalApi(
   page: Page,
-  options: { decisionStatus?: number; decisionDetail?: string } = {},
+  options: {
+    decisionStatus?: number;
+    decisionDetail?: string;
+    failDecision?: boolean;
+    decisionDelayMs?: number;
+    blockResume?: boolean;
+  } = {},
 ) {
   const decisions: string[] = [];
+  const cancellations: string[] = [];
+  const editTargets: Array<string | null> = [];
   let streamCount = 0;
   let sessionApproved = false;
+  let cancelled = false;
 
   await page.route("**/conversations", async (route) => {
     const body =
@@ -145,11 +154,18 @@ async function mockApprovalApi(
 
   await page.route("**/conversations/*/messages/stream", async (route: Route) => {
     streamCount += 1;
+    const request = JSON.parse(route.request().postData() || "{}") as {
+      edit_message_id?: string;
+    };
+    editTargets.push(request.edit_message_id ?? null);
+    const runId = `run-${streamCount}`;
+    const messageId = `user-${streamCount}`;
     if (sessionApproved) {
       await route.fulfill({
         status: 200,
         contentType: "text/event-stream",
         body: [
+          `event: turn_started\ndata: ${JSON.stringify({ type: "turn_started", run_id: runId, message_id: messageId })}`,
           `event: final\ndata: ${JSON.stringify({ type: "final", content: "Session approval reused", route: ["writer"], used_tools: [] })}`,
           "event: done\ndata: [DONE]",
           "",
@@ -157,11 +173,11 @@ async function mockApprovalApi(
       });
       return;
     }
-    const runId = `run-${streamCount}`;
     await route.fulfill({
       status: 200,
       contentType: "text/event-stream",
       body: [
+        `event: turn_started\ndata: ${JSON.stringify({ type: "turn_started", run_id: runId, message_id: messageId })}`,
         `event: pending_approval\ndata: ${JSON.stringify({
           type: "pending_approval",
           route: ["writer"],
@@ -179,31 +195,53 @@ async function mockApprovalApi(
     });
   });
 
-  await page.route(/\/conversations\/[^/]+\/runs\/[^/]+\/approvals\/[^/]+\/decision$/, async (route) => {
-    const body = JSON.parse(route.request().postData() || "{}") as { decision?: string };
-    decisions.push(body.decision || "");
-    sessionApproved ||= body.decision === "allow_for_session";
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    if (options.decisionStatus) {
+  if (!options.blockResume) {
+    await page.route(/\/conversations\/[^/]+\/runs\/[^/]+\/approvals\/[^/]+\/decision\/stream$/, async (route) => {
+      const body = JSON.parse(route.request().postData() || "{}") as { decision?: string };
+      decisions.push(body.decision || "");
+      await new Promise((resolve) => setTimeout(resolve, options.decisionDelayMs ?? 25));
+      if (cancelled) {
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "approval already processed" }),
+        });
+        return;
+      }
+      sessionApproved ||= body.decision === "allow_for_session";
+      if (options.failDecision || options.decisionStatus) {
+        await route.fulfill({
+          status: options.decisionStatus ?? 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            detail: options.decisionDetail ?? "private approval failure",
+          }),
+        });
+        return;
+      }
+      const answer =
+        body.decision === "deny" ? "The tool request was denied." : "The tool completed.";
       await route.fulfill({
-        status: options.decisionStatus,
-        contentType: "application/json",
-        body: JSON.stringify({ detail: options.decisionDetail ?? "private approval failure" }),
+        status: 200,
+        contentType: "text/event-stream",
+        body: [
+          `event: resume_started\ndata: ${JSON.stringify({ type: "resume_started", run_id: `run-${streamCount}` })}`,
+          `event: final\ndata: ${JSON.stringify({ type: "final", content: answer, route: ["writer"], used_tools: [] })}`,
+          "event: done\ndata: [DONE]",
+          "",
+        ].join("\n\n"),
       });
-      return;
-    }
+    });
+  }
+
+  await page.route(/\/conversations\/[^/]+\/runs\/[^/]+\/approvals\/[^/]+\/cancel$/, async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    cancellations.push(path);
+    cancelled = true;
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({
-        answer:
-          body.decision === "deny" ? "The tool request was denied." : "The tool completed.",
-        visited: ["writer"],
-        used_tools: [],
-        status: "completed",
-        run_id: null,
-        pending_approval: null,
-      }),
+      body: JSON.stringify({ run_id: `run-${streamCount}`, status: "cancelled" }),
     });
   });
 
@@ -219,7 +257,7 @@ async function mockApprovalApi(
     });
   });
 
-  return { decisions, getStreamCount: () => streamCount };
+  return { decisions, cancellations, editTargets, getStreamCount: () => streamCount };
 }
 
 async function mockConversationApiWithStaleConversation(page: Page, staleStatus = 404) {
@@ -380,6 +418,18 @@ async function shadowClickText(page: Page, selector: string, text: string, index
       targets.find((node) => node.textContent?.includes(text))?.click();
     },
     { selector, text },
+  );
+}
+
+async function shadowClickUserAction(page: Page, text: string, label: string) {
+  const handle = await widget(page);
+  await handle.evaluate(
+    (element, { text, label }) => {
+      const messages = Array.from(element.shadowRoot?.querySelectorAll<HTMLElement>(".msg.user") ?? []);
+      const message = messages.find((node) => node.querySelector(".message-content")?.textContent === text);
+      message?.querySelector<HTMLElement>(`[aria-label="${label}"]`)?.click();
+    },
+    { text, label },
   );
 }
 
@@ -545,6 +595,169 @@ test("sending a message calls backend, renders assistant answer, stores conversa
   expect(calls).toContain("GET /conversations/conv-smoke/messages");
 });
 
+test("Stop cancels the active stream while preserving the next draft", async ({ page }) => {
+  const calls = await mockConversationApi(page);
+  let streamCount = 0;
+  let releaseFirst!: () => void;
+  const firstReleased = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
+    streamCount += 1;
+    if (streamCount === 1) {
+      await firstReleased;
+      try {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: [
+            `event: final\ndata: ${JSON.stringify({ type: "final", content: "late answer", route: [], used_tools: [] })}`,
+            "event: done\ndata: [DONE]",
+            "",
+          ].join("\n\n"),
+        });
+      } catch {
+        // The browser already abandoned the intercepted request.
+      }
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: "next answer", route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "first prompt");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => streamCount).toBe(1);
+  await expect.poll(() => shadowAttribute(page, ".send", "aria-label")).toBe("Stop generating");
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+
+  await shadowFill(page, ".input", "next draft");
+  await page.keyboard.press("Enter");
+  expect(streamCount).toBe(1);
+  await expect.poll(() => shadowValue(page, ".input")).toBe("next draft");
+
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowAttribute(page, ".send", "aria-label")).toBe("Send message");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("next draft");
+  await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
+  await expect.poll(() => shadowText(page, ".msg-cancelled")).toBe("Generation stopped");
+  expect(await shadowText(page, ".messages")).not.toContain("Something went wrong");
+  expect(calls).not.toContain("POST /conversations/conv-smoke/messages");
+
+  releaseFirst();
+  await page.waitForTimeout(50);
+  expect(await shadowText(page, ".messages")).not.toContain("late answer");
+
+  await shadowClick(page, ".send");
+  await expect.poll(() => streamCount).toBe(2);
+  await expect.poll(() => shadowText(page, ".messages")).toContain("next answer");
+});
+
+test("editing a user message creates a new visible branch and can be cancelled", async ({ page }) => {
+  await mockConversationApi(page);
+  await page.addInitScript(
+    ([key, value]) => localStorage.setItem(key, value),
+    [CONVERSATION_KEY, "conv-edit"],
+  );
+  const original = [
+    { message_id: "u1", run_id: "r1", role: "user", content: "U1", status: "completed", created_at: "2026-01-01T00:00:00Z" },
+    { message_id: "a1", run_id: "r1", role: "assistant", content: "A1", status: "completed", created_at: "2026-01-01T00:00:01Z" },
+    { message_id: "u2", run_id: "r2", role: "user", content: "U2", status: "completed", created_at: "2026-01-01T00:00:02Z" },
+    { message_id: "a2", run_id: "r2", role: "assistant", content: "A2", status: "completed", created_at: "2026-01-01T00:00:03Z" },
+  ];
+  let active = [...original];
+  let editTarget = "";
+  await page.route("**/conversations/conv-edit/messages", async (route: Route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(active) });
+  });
+  await page.route("**/conversations/conv-edit/messages/stream", async (route: Route) => {
+    const body = JSON.parse(route.request().postData() || "{}") as {
+      message: string;
+      edit_message_id?: string;
+    };
+    editTarget = body.edit_message_id || "";
+    active = [
+      ...original.slice(0, 2),
+      { message_id: "u2-edited", run_id: "r3", role: "user", content: body.message, status: "completed", created_at: "2026-01-01T00:00:04Z" },
+      { message_id: "a2-edited", run_id: "r3", role: "assistant", content: "A2 edited", status: "completed", created_at: "2026-01-01T00:00:05Z" },
+    ];
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: turn_started\ndata: ${JSON.stringify({ type: "turn_started", run_id: "r3", message_id: "u2-edited" })}`,
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: "A2 edited", route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("A2");
+  await expect.poll(() => shadowComputedStyle(page, ".user-actions", "opacity")).toBe("1");
+  await shadowFill(page, ".input", "draft in progress");
+
+  await shadowClickUserAction(page, "U2", "Edit message");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("U2");
+  await shadowClick(page, ".edit-cancel");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("draft in progress");
+  expect(await shadowText(page, ".messages")).toContain("A2");
+
+  await shadowClickUserAction(page, "U2", "Edit message");
+  await shadowFill(page, ".input", "U2 edited");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => editTarget).toBe("u2");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("U2 edited");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("A2 edited");
+  expect(await shadowText(page, ".messages")).not.toContain("A2A2 edited");
+  expect(original.map((message) => message.content)).toEqual(["U1", "A1", "U2", "A2"]);
+});
+
+test("cancelled history renders lifecycle state without persisted assistant text", async ({ page }) => {
+  await mockConversationApi(page);
+  await page.addInitScript(
+    ([key, value]) => localStorage.setItem(key, value),
+    [CONVERSATION_KEY, "conv-cancelled"],
+  );
+  await page.route("**/conversations/conv-cancelled/messages", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          message_id: "cancelled-user",
+          run_id: "cancelled-run",
+          role: "user",
+          content: "Explain RocksDB",
+          status: "cancelled",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await expect.poll(() => shadowText(page, ".msg-cancelled")).toBe("Generation stopped");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Explain RocksDB");
+  await expect.poll(() => shadowExists(page, '[aria-label="Edit message"]')).toBe(true);
+  await expect.poll(() => shadowComputedStyle(page, ".user-actions", "opacity")).toBe("1");
+});
+
 test("tool activity shows the tool name without its internal provider", async ({ page }) => {
   await mockConversationApi(page, {
     usedTools: [{ name: "search_docs", provider: "mcp", status: "succeeded" }],
@@ -601,6 +814,60 @@ for (const action of [
   });
 }
 
+test("a pending approval can be cancelled even while a decision is applying", async ({ page }) => {
+  const approval = await mockApprovalApi(page, { decisionDelayMs: 500 });
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "send the email");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => shadowText(page, ".approval-actions")).toContain("Cancel run");
+  await shadowClickText(page, ".approval-button", "Approve");
+  await expect.poll(() => shadowText(page, ".approval-status")).toBe("Applying decision…");
+  await shadowClickText(page, ".approval-button", "Cancel run");
+
+  await expect.poll(() => approval.cancellations).toHaveLength(1);
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+  await expect.poll(() => shadowText(page, ".msg-cancelled")).toBe("Generation stopped");
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+  expect(approval.decisions).toEqual(["allow_once"]);
+});
+
+test("resumed approval keeps draft and Edit available and Stop cancels it", async ({ page }) => {
+  const approval = await mockApprovalApi(page, { blockResume: true });
+  const nonStreamingDecisions: string[] = [];
+  page.on("request", (request) => {
+    if (/\/approvals\/[^/]+\/decision$/.test(new URL(request.url()).pathname)) {
+      nonStreamingDecisions.push(request.url());
+    }
+  });
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "send the email");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+
+  await shadowClickText(page, ".approval-button", "Approve");
+  await expect.poll(() => shadowAttribute(page, ".send", "aria-label")).toBe("Stop generating");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+  await expect.poll(() => shadowExists(page, '[aria-label="Edit message"]')).toBe(true);
+
+  await shadowFill(page, ".input", "next prompt draft");
+  await shadowClickUserAction(page, "send the email", "Edit message");
+  await shadowFill(page, ".input", "edited prompt draft");
+  await page.keyboard.press("Enter");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("edited prompt draft");
+  expect(approval.getStreamCount()).toBe(1);
+
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowText(page, ".msg-cancelled")).toBe("Generation stopped");
+  await expect.poll(() => shadowAttribute(page, ".send", "aria-label")).toBe("Send message");
+  await expect.poll(() => shadowValue(page, ".input")).toBe("edited prompt draft");
+  expect(await shadowText(page, ".messages")).not.toContain("Something went wrong");
+  expect(nonStreamingDecisions).toEqual([]);
+});
+
 test("session approval prevents another prompt for the same session tool", async ({ page }) => {
   const approval = await mockApprovalApi(page);
   await page.goto("/widget-demo.html");
@@ -619,6 +886,26 @@ test("session approval prevents another prompt for the same session tool", async
   await expect.poll(() => approval.getStreamCount()).toBe(2);
   expect(approval.decisions).toEqual(["allow_for_session"]);
   await expect.poll(() => shadowExists(page, ".approval-card")).toBe(false);
+});
+
+test("editing a pending-approval prompt creates a branch without resuming it", async ({ page }) => {
+  const approval = await mockApprovalApi(page);
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await shadowFill(page, ".input", "original request");
+  await shadowClick(page, ".send");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
+
+  await shadowClickUserAction(page, "original request", "Edit message");
+  await expect.poll(() => shadowExists(page, ".input:disabled")).toBe(false);
+  await shadowFill(page, ".input", "revised request");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => approval.getStreamCount()).toBe(2);
+  expect(approval.editTargets).toEqual([null, "user-1"]);
+  expect(approval.decisions).toEqual([]);
+  await expect.poll(() => shadowText(page, ".messages")).toContain("revised request");
+  await expect.poll(() => shadowExists(page, ".approval-card")).toBe(true);
 });
 
 test("a failed approval decision restores the controls without leaking details", async ({ page }) => {
@@ -688,13 +975,14 @@ test("Shift+Enter inserts a newline and Enter sends", async ({ page }) => {
 });
 
 test("backend error renders a user-friendly message", async ({ page }) => {
-  await mockConversationApi(page, { failSend: true });
+  const calls = await mockConversationApi(page, { failSend: true });
   await page.goto("/widget-demo.html");
   await shadowClick(page, ".launcher");
   await shadowFill(page, ".input", "please fail");
   await shadowClick(page, ".send");
 
   await expect.poll(() => shadowText(page, ".messages")).toContain("Something went wrong. Please try again.");
+  expect(calls).not.toContain("POST /conversations/conv-smoke/messages");
 });
 
 test("budget meter shows cumulative token usage against the budget after a turn", async ({ page }) => {
@@ -825,9 +1113,7 @@ test("thinking dots persist when switching away from an in-flight thread and bac
   await expect.poll(() => shadowExists(page, ".thinking")).toBe(false);
 });
 
-test("a turn stays on its own conversation when the user switches threads mid-request", async ({
-  page,
-}) => {
+test("a failed stream is not replayed after switching threads", async ({ page }) => {
   let release!: () => void;
   const pending = new Promise<void>((resolve) => {
     release = resolve;
@@ -848,9 +1134,8 @@ test("a turn stays on its own conversation when the user switches threads mid-re
       body: JSON.stringify({ used_tokens: 0, max_tokens: null, percent: 0, severity: "normal" }),
     });
   });
-  // Hold the stream open until the user has switched away, then fail it: the
-  // widget retries the turn without streaming, and that retry must still go to
-  // the conversation the turn started in.
+  // Hold the stream open until the user has switched away, then fail it. The
+  // mutation must not be replayed because delivery failure is ambiguous.
   await page.route("**/conversations/conv-smoke/messages/stream", async (route: Route) => {
     await pending;
     await route.fulfill({
@@ -876,11 +1161,17 @@ test("a turn stays on its own conversation when the user switches threads mid-re
 
   release();
 
-  await expect.poll(() => calls).toContain("POST /conversations/conv-smoke/messages");
-  expect(calls).not.toContain("POST /conversations/conv-other/messages");
   await expect
     .poll(() => usageCalls[usageCalls.length - 1])
     .toBe("/conversations/conv-smoke/usage");
+  expect(calls).not.toContain("POST /conversations/conv-smoke/messages");
+  expect(calls).not.toContain("POST /conversations/conv-other/messages");
+
+  await shadowClick(page, '.header-btn[aria-label="Conversations"]');
+  await shadowClickText(page, ".thread-item", "Current chat");
+  await expect.poll(() => shadowText(page, ".messages")).toContain(
+    "Something went wrong. Please try again.",
+  );
 });
 
 async function mockConversationApiWithTokenBudgetExceeded(page: Page) {
@@ -1001,6 +1292,101 @@ test("stale stored conversation is replaced before sending to the agent", async 
   expect(calls).toContain("GET /conversations/conv-stale/messages");
   expect(calls).toContain("POST /conversations");
   expect(calls).toContain("POST /conversations/conv-fresh/messages/stream");
+});
+
+test("editing after an in-memory restart starts a fresh root instead of reusing a stale message id", async ({
+  page,
+}) => {
+  await pinVisitorPass(page);
+  await page.addInitScript(
+    ([key, value]) => localStorage.setItem(key, value),
+    [CONVERSATION_KEY, "conv-stale-edit"],
+  );
+  let restarted = false;
+  const streamBodies: Array<{ message?: string; edit_message_id?: string }> = [];
+  const usageConversationIds: string[] = [];
+
+  await page.route("**/conversations", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ conversation_id: "conv-fresh-edit", session_id: "conv-fresh-edit" }),
+    });
+  });
+  await page.route("**/conversations/*/messages", async (route: Route) => {
+    const conversationId = new URL(route.request().url()).pathname.split("/")[2];
+    if (conversationId === "conv-stale-edit" && !restarted) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            message_id: "stale-user-message",
+            run_id: "stale-run",
+            role: "user",
+            content: "original text",
+            status: "completed",
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ]),
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+  });
+  await page.route("**/conversations/*/messages/stream", async (route: Route) => {
+    const conversationId = new URL(route.request().url()).pathname.split("/")[2];
+    const body = JSON.parse(route.request().postData() || "{}") as {
+      message?: string;
+      edit_message_id?: string;
+    };
+    streamBodies.push(body);
+    if (conversationId === "conv-stale-edit") {
+      await route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+      return;
+    }
+    if (body.edit_message_id) {
+      await route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        `event: turn_started\ndata: ${JSON.stringify({ type: "turn_started", run_id: "fresh-run", message_id: "fresh-user-message" })}`,
+        `event: final\ndata: ${JSON.stringify({ type: "final", content: "Recovered edited answer", route: [], used_tools: [] })}`,
+        "event: done\ndata: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+  await page.route("**/conversations/*/usage", async (route: Route) => {
+    usageConversationIds.push(new URL(route.request().url()).pathname.split("/")[2] || "");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ used_tokens: 0, max_tokens: null, percent: 0, severity: "normal" }),
+    });
+  });
+
+  await page.goto("/widget-demo.html");
+  await shadowClick(page, ".launcher");
+  await expect.poll(() => shadowText(page, ".messages")).toContain("original text");
+  restarted = true;
+
+  await shadowClickUserAction(page, "original text", "Edit message");
+  await shadowFill(page, ".input", "edited after restart");
+  await shadowClick(page, ".send");
+
+  await expect.poll(() => shadowText(page, ".messages")).toContain("Recovered edited answer");
+  expect(streamBodies).toEqual([
+    { message: "edited after restart", edit_message_id: "stale-user-message" },
+    { message: "edited after restart" },
+  ]);
+  await expect.poll(() => usageConversationIds[usageConversationIds.length - 1]).toBe("conv-fresh-edit");
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), CONVERSATION_KEY))
+    .toBe("conv-fresh-edit");
 });
 
 test("script-only auto-mount creates one configured widget", async ({ page }) => {

--- a/tests/e2e/widget_static_app.py
+++ b/tests/e2e/widget_static_app.py
@@ -2,10 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 
 from agent_manager.api.web import mount_web
 from agent_manager.config import Settings
 
 app = FastAPI()
 mount_web(app, Settings())
+
+
+@app.post("/conversations/{conversation_id}/runs/{run_id}/approvals/{approval_id}/decision/stream")
+async def blocking_approval_resume(
+    conversation_id: str,
+    run_id: str,
+    approval_id: str,
+) -> StreamingResponse:
+    """Test-only stream that stays active until Playwright aborts it."""
+    del conversation_id, approval_id
+
+    async def events():
+        started = json.dumps({"type": "resume_started", "run_id": run_id})
+        yield f"event: resume_started\ndata: {started}\n\n"
+        partial = json.dumps({"type": "answer_delta", "content": "partial"})
+        yield f"event: answer_delta\ndata: {partial}\n\n"
+        await asyncio.Event().wait()
+
+    return StreamingResponse(events(), media_type="text/event-stream")

--- a/tests/engine/test_run_lifecycle.py
+++ b/tests/engine/test_run_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,9 @@ class RegistrationSpy(RunRepository):
         return True
 
     async def get(self, run_id: str) -> RunRecord | None:
+        raise AssertionError("RunLifecycle must not read before registration")
+
+    async def get_many(self, run_ids: Collection[str]) -> dict[str, RunRecord]:
         raise AssertionError("RunLifecycle must not read before registration")
 
     async def transition_if_allowed(self, run_id: str, target: RunStatus) -> bool:

--- a/tests/engine/test_run_lifecycle.py
+++ b/tests/engine/test_run_lifecycle.py
@@ -45,6 +45,11 @@ class RegistrationSpy(RunRepository):
         raise AssertionError("RunLifecycle must not record engine-owned usage")
 
 
+class RunIdReplacingHookManager(HookManager):
+    async def run_run_start(self, context: RunContext) -> RunContext:
+        return context.replace(run_id="replaced-run")
+
+
 async def test_begin_delegates_registration_as_one_repository_operation() -> None:
     repository = RegistrationSpy()
     lifecycle = RunLifecycle(
@@ -63,6 +68,20 @@ async def test_begin_delegates_registration_as_one_repository_operation() -> Non
     await lifecycle.cancel(context)
 
     assert repository.transitions == [("run-1", RunStatus.CANCELLED)]
+
+
+async def test_begin_rejects_hook_replacement_of_authoritative_run_id() -> None:
+    repository = RegistrationSpy()
+    lifecycle = RunLifecycle(
+        system_name="system",
+        hook_manager=RunIdReplacingHookManager(),
+        run_repository=repository,
+    )
+
+    with pytest.raises(ValueError, match=r"cannot replace.*run_id"):
+        await lifecycle.begin(RunContext(run_id="run-1"))
+
+    assert repository.registered == []
 
 
 async def test_begin_does_not_reset_an_existing_run() -> None:

--- a/tests/engine/test_stream_lifecycle.py
+++ b/tests/engine/test_stream_lifecycle.py
@@ -97,7 +97,10 @@ class BlockingModel:
         return AIMessage(content="first second")
 
     async def astream(self, messages: list[Any]) -> AsyncIterator[AIMessageChunk]:
-        yield AIMessageChunk(content="first")
+        yield AIMessageChunk(
+            content="first",
+            usage_metadata={"input_tokens": 4, "output_tokens": 1, "total_tokens": 5},
+        )
         await self.released.wait()
         self.resumed = True
         yield AIMessageChunk(content=" second")
@@ -242,6 +245,24 @@ async def test_stream_channel_preserves_producer_exception_type() -> None:
     assert raised.value is failure
 
 
+async def test_terminal_event_waits_for_lifecycle_finalization_before_delivery() -> None:
+    channel = StreamChannel()
+    terminal = channel.publish_terminal(RunStreamEvent(type="final", content="done"))
+    events = cast(AsyncGenerator[RunStreamEvent, None], channel.events())
+
+    async def receive() -> RunStreamEvent:
+        return await events.__anext__()
+
+    next_event = asyncio.create_task(receive())
+
+    await terminal.accepted.wait()
+    assert next_event.done() is False
+    terminal.finalized.set()
+
+    assert await next_event == RunStreamEvent(type="final", content="done")
+    await events.aclose()
+
+
 async def test_graph_failure_reaches_the_consumer_and_fails_the_run(tmp_path: Path) -> None:
     async with LangGraphEngine(tmp_path, model_factory=_broken_factory) as engine:
         await engine.build(
@@ -335,11 +356,16 @@ async def test_context_vars_are_restored_when_the_consumer_walks_away(tmp_path: 
 
 async def test_abandoned_stream_stops_the_graph_and_cancels_the_run(tmp_path: Path) -> None:
     model = BlockingModel()
+    runs = InMemoryRunRepository()
 
     def factory(*_: Any, **__: Any) -> BaseChatModel:
         return cast(BaseChatModel, cast(object, model))
 
-    async with LangGraphEngine(tmp_path, model_factory=factory) as engine:
+    async with LangGraphEngine(
+        tmp_path,
+        model_factory=factory,
+        run_repository=runs,
+    ) as engine:
         await engine.build(_spec())
         events = cast(
             AsyncGenerator[RunStreamEvent, None],
@@ -355,3 +381,6 @@ async def test_abandoned_stream_stops_the_graph_and_cancels_the_run(tmp_path: Pa
 
         assert model.resumed is False
         assert await engine.get_run_status("run-abandoned") == "cancelled"
+        stored = await runs.get("run-abandoned")
+        assert stored is not None
+        assert (stored.input_tokens, stored.output_tokens) == (4, 1)

--- a/tests/runs/test_repository.py
+++ b/tests/runs/test_repository.py
@@ -57,6 +57,17 @@ async def test_run_repository_registers_new_run(run_repository: RunRepository) -
     assert await run_repository.get("r1") == record
 
 
+async def test_run_repository_resolves_many_ids_at_once(run_repository: RunRepository) -> None:
+    await run_repository.create_if_absent(_run("r1"))
+    await run_repository.create_if_absent(_run("r2", status=RunStatus.COMPLETED))
+
+    found = await run_repository.get_many(["r1", "r2", "unknown"])
+
+    assert set(found) == {"r1", "r2"}
+    assert found["r2"].status is RunStatus.COMPLETED
+    assert await run_repository.get_many([]) == {}
+
+
 async def test_run_repository_accumulates_reported_token_usage(
     run_repository: RunRepository,
 ) -> None:


### PR DESCRIPTION
Cancel / interrupt support and immutable conversation branches
Summary

A conversation is now an immutable message tree with an explicitly selected active branch, and every turn — new, resumed, or suspended on an approval — can be interrupted with an authoritative, persisted outcome.

Previously messages were one append-only list (the schema already carried an unused parent_message_id). Cancelling a run left its user message behind but the history API could not project the run's real state, so the widget erased all evidence of the stopped turn. Editing an earlier message could not safely mutate that row or reuse its descendants, since every later answer was produced from the original content. The browser also received no response until the engine emitted its first event, which made "stop before the first token" depend on cancelling an ordinary request handler instead of a response-owned stream.

Design and rationale: docs/adr/0002-conversation-lifecycle-and-immutable-branches.md.

What changed

Immutable message tree

ConversationMessage.parent_message_id links a message to its predecessor; ConversationSession.head_message_id selects the active root-to-leaf path.
A normal turn appends at the head. An edit appends a new user message at the edited message's parent and atomically selects it as the new head — existing descendants stay stored and unchanged.
A late assistant result is stored on its original branch, and selects itself only if its parent is still the active head.
Model context and the history API traverse only the selected ancestry. No separate branch_id: the leaf message already identifies a branch.

Cancellation lifecycle

The manager prepares and persists the turn before returning the streaming response; the first SSE frame is turn_started, carrying the authoritative run_id and message_id. Graph execution is owned by the response generator, so a disconnect at any point terminalizes the run.
The run is registered before turn_started, so disconnecting before engine iteration can no longer leave a run stuck in running.
A terminal engine event is acknowledged before the run becomes COMPLETED, and the assistant message is persisted before that event reaches HTTP — a disconnect racing acknowledgement cancels the run rather than dropping a queued final answer.
New turns and resumed turns share one engine-owned graph-task cancellation path. Resume keeps the original run_id and moves PENDING_APPROVAL → RESUMING → RUNNING before emitting work.
A suspended approval stays resumable after its SSE response ends; the owner can terminalize it explicitly. Cancellation competes atomically with the approval claim, so exactly one of cancel/resume wins.
The synthetic UI label Generation stopped is never persisted or sent to the engine.

Contract / API

History items expose message_id, run_id, and status.
Send and stream requests accept an optional edit_message_id.
New manager-owned turn_started stream event.
New POST .../runs/{run_id}/approvals/{approval_id}/cancel — cancellation is a lifecycle transition, not an approval decision and not DENY.
New POST .../approvals/{approval_id}/decision/stream; its resume_started event carries the original run_id, and disconnecting it cancels the graph task.
Sessions gain head_message_id; manager persistence gains durable run records via a SQL RunRepository adapter injected into both the engine and the conversation service.
Failed or disconnected stream mutations are never auto-replayed over the non-streaming endpoint — without a client idempotency key, a delivery failure cannot prove the original request changed no state.

Persistence / composition

With no database URL configured the manager composes process-local conversation and run repositories and opens no SQL connection. AGENT_DB_URL or DATABASE_URL opts into SQL persistence and Alembic.
No new migration revision: no database environment exists yet, so the existing fresh-database baseline revision was updated in place.

Widget

Stop control for an in-flight turn, message editing that branches, cancelled turns rendered from persisted run state, and resume controls that stay available while an approval is still active.
Known limits
External side effects completed before cancellation are not rolled back.
If the approval claim wins the race, /cancel returns a conflict.
Token budget stays cumulative across executed branches — editing does not refund model/tool work already consumed.
Usage reported by a provider only after a cancelled request cannot be counted exactly.
Without a configured database URL, history and run state are lost on restart.
Tests
Repository contract tests run ancestry/head behavior against both the memory and SQL adapters.
Service tests assert the exact model context after edit and after cancel.
API and browser (Playwright) tests cover lifecycle projection, edit identity, immutable downstream replacement, cancellation display, and reload.
New coverage in tests/approvals/ for cancel-vs-claim races and streamed resume.