### PR TITLE
feat(auth): carry the caller's own credential through to plugin code

### DIFF
--- a/docs/MCP_AND_TOOLS.md
+++ b/docs/MCP_AND_TOOLS.md
@@ -410,8 +410,9 @@ For the MVP:
 - hide local-vs-MCP origin by presenting both as LangChain tools, while tracking
   the origin in the tool-usage records (✅ implemented);
 - bind discovered MCP tools into LangGraph/LangChain tool-calling (✅ implemented);
-- pass trusted request context through `ctx` into tool calls (⏳ planned —
-  resolvers receive `ctx`, tools do not yet);
+- reach the run's context from a tool via `current_run_context` (✅ implemented —
+  a context variable rather than a `ctx` parameter, so tool signatures stay
+  exactly what the model sees);
 - redact secrets from traces (⏳ planned, task 0011);
 - keep prompt wording out of the enforcement path.
 

--- a/docs/SIDECAR_CONTEXT_AUTH.md
+++ b/docs/SIDECAR_CONTEXT_AUTH.md
@@ -27,7 +27,41 @@ Content-Type: application/json
 
 For each request, the runtime builds `ctx` from headers and request data. Plugin
 methods receive `ctx`; client code decides how to interpret tokens, user ids,
-tenant ids, roles, and permissions.
+tenant ids, roles, and permissions. Tools are not passed `ctx` as an argument —
+that would put it in the schema the model sees — and read it from
+`agent_engine.runtime.hooks.current_run_context` instead.
+
+---
+
+## Credentials Are Accepted, Facts Are Derived
+
+`Authorization` reaches `ctx.auth_context.inbound_access_token` and is forwarded
+to plugin code without being verified here. That is deliberate, and the split it
+rests on is the one rule to keep in mind:
+
+- **A credential is self-securing.** Forge it and the system that owns it answers
+  401. Nothing can reach through this engine that it could not already reach
+  directly, so taking one from the caller costs nothing.
+- **A fact is not.** `{"role": "admin"}` works the moment anything trusts it.
+
+So a credential may be accepted from the caller; a user id, a role, or a tenant
+must be *derived* — a resolver calls the owning system with the credential and
+uses what comes back. Nothing else about the caller is accepted over the wire,
+which is why `/invoke` takes no context object: there is nothing safe to put in
+one that a resolver cannot obtain for itself.
+
+Where identity must be **proven** rather than passed along — conversation
+ownership, protected nodes — run behind `agent_manager`, which verifies
+signatures before building the context. The engine alone is a conduit; the
+manager is an authority. Both produce the same `RunContext`.
+
+The engine guarantees one property, and there is a test pinning it:
+`inbound_access_token` never enters graph state, so it cannot reach a prompt,
+the model, or a response.
+
+The other half is the plugin author's to keep: a tool that finds no credential
+must **fail**, never fall back to a shared key. That fallback is precisely what
+lets every caller act as an administrator, and no engine can prevent it for you.
 
 ---
 

--- a/docs/mcp-and-tools.mdx
+++ b/docs/mcp-and-tools.mdx
@@ -155,6 +155,28 @@ The docstring becomes the tool description the LLM sees. The engine wraps the fu
   Write clear descriptions and typed parameters. The LLM reads both when deciding how to call a tool. Vague descriptions lead to wrong or missed tool calls.
 </Tip>
 
+### Calling a real system as the user
+
+A tool that reaches your own API should act as the person who asked, so your API applies their permissions. The credential the request arrived with is on the run context — not a parameter, since anything in the signature becomes part of the schema the LLM sees:
+
+```python
+from agent_engine.runtime.hooks import current_run_context
+
+def get_order_status(order_id: str) -> dict:
+    """Get the current status and tracking info for an order. Requires an order ID."""
+    ctx = current_run_context.get()
+    auth = ctx.auth_context if ctx else None
+    if auth is None or not auth.inbound_access_token:
+        return {"error": "No credential for this request; the user must sign in."}
+    return your_api.get(order_id, token=auth.inbound_access_token)
+```
+
+It is filled from the caller's `Authorization` header (see [Identity](/docs/identity)), and never reaches the model.
+
+<Warning>
+  When there is no credential, fail. A fallback to one shared admin key lets every caller do whatever that key can.
+</Warning>
+
 ---
 
 ## Resolvers vs. tools

--- a/docs/runtime-hooks.mdx
+++ b/docs/runtime-hooks.mdx
@@ -155,6 +155,17 @@ research_hooks = "plugins.hooks.research_hooks:ResearchHooksHook"
 
 The YAML never contains an import path, a config block, or a secret — it only says *which* hook runs *where*. `agentctl generate` creates and maintains the `plugins.toml` entry for you.
 
+**`agents.yaml`** — hooks load by import path, so your package has to be importable:
+
+```yaml
+plugins:
+  import_roots: ["."]   # resolved relative to this file
+```
+
+<Warning>
+  Without this, loading fails with `No module named 'plugins'`. Tools are unaffected — they load by file path. See [Making plugins importable](/docs/plugins#making-plugins-importable).
+</Warning>
+
 ### Field reference
 
 <ParamField path="plugin" type="string">

--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -355,8 +355,10 @@ def create_app(
         decision: ApprovalDecision,
         user_id: str | None,
         session_id: str | None,
+        authorization: str | None,
     ) -> InvokeResponse:
         engine = _hitl_engine()
+        auth = _auth_context(authorization)
         try:
             result = await engine.resume(
                 run_id,
@@ -364,6 +366,7 @@ def create_app(
                 decision,
                 caller_user_id=user_id,
                 caller_session_id=_run_context(session_id, run_id=run_id).conversation_id,
+                access_token=auth.inbound_access_token if auth else None,
             )
         except ApprovalError as exc:
             raise _map_approval_error(exc) from exc
@@ -389,13 +392,16 @@ def create_app(
         approval_id: str,
         body: ApprovalDecisionBody,
         x_session_id: str | None = Header(default=None),
+        authorization: str | None = Header(default=None),
     ) -> InvokeResponse:
         # The single free-text → typed decision boundary for the API.
         try:
             decision = parse_decision(body.decision)
         except InvalidDecision as exc:
             raise _map_approval_error(exc) from exc
-        return await _decide(run_id, approval_id, decision, body.user_id, x_session_id)
+        return await _decide(
+            run_id, approval_id, decision, body.user_id, x_session_id, authorization
+        )
 
     @app.post("/runs/{run_id}/approvals/{approval_id}/approve", response_model=InvokeResponse)
     async def approve(
@@ -403,6 +409,7 @@ def create_app(
         approval_id: str,
         body: ApprovalDecisionRequest = _DEFAULT_APPROVAL_REQUEST_BODY,
         x_session_id: str | None = Header(default=None),
+        authorization: str | None = Header(default=None),
     ) -> InvokeResponse:
         return await _decide(
             run_id,
@@ -410,6 +417,7 @@ def create_app(
             ApprovalDecision.ALLOW_ONCE,
             body.user_id,
             x_session_id,
+            authorization,
         )
 
     @app.post("/runs/{run_id}/approvals/{approval_id}/reject", response_model=InvokeResponse)
@@ -418,6 +426,7 @@ def create_app(
         approval_id: str,
         body: ApprovalDecisionRequest = _DEFAULT_APPROVAL_REQUEST_BODY,
         x_session_id: str | None = Header(default=None),
+        authorization: str | None = Header(default=None),
     ) -> InvokeResponse:
         return await _decide(
             run_id,
@@ -425,6 +434,7 @@ def create_app(
             ApprovalDecision.DENY,
             body.user_id,
             x_session_id,
+            authorization,
         )
 
     return app

--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -33,7 +33,7 @@ from agent_engine.engine.langgraph.engine import LangGraphEngine
 from agent_engine.engine.types import PendingApproval
 from agent_engine.logging_config import configure_logging, log, request_id_var
 from agent_engine.parsers.yaml.parser import YAMLParser
-from agent_engine.runtime.hooks import RunContext
+from agent_engine.runtime.hooks import AuthContext, RunContext
 
 logger = logging.getLogger(__name__)
 
@@ -64,15 +64,34 @@ def _preview(text: str, limit: int = 120) -> str:
     return collapsed[:limit] + ("…" if len(collapsed) > limit else "")
 
 
-def _run_context(x_session_id: str | None, *, run_id: str) -> RunContext:
-    """Build a RunContext carrying a run id and the caller's session id.
+def _run_context(
+    x_session_id: str | None, *, run_id: str, authorization: str | None = None
+) -> RunContext:
+    """Build a RunContext carrying a run id, the caller's session id, and the
+    credential the caller sent.
 
     The run id is the resumable identifier returned to the client (also the
     LangGraph checkpoint thread id). The session id flows into tracing metadata
     (the Langfuse session); it is untrusted, so sanitize and cap it.
+
+    ``Authorization`` is forwarded verbatim and never verified: a forged
+    credential just fails at the system that owns it, so this grants nothing.
+    Asserted facts (user id, role) are not accepted — derive those in a
+    resolver, or run behind `agent_manager`, which verifies signatures.
     """
     session_id = _RID_OK.sub("", x_session_id)[:64] if x_session_id else ""
-    return RunContext(run_id=run_id, conversation_id=session_id or None)
+    return RunContext(
+        run_id=run_id,
+        conversation_id=session_id or None,
+        auth_context=_auth_context(authorization),
+    )
+
+
+def _auth_context(authorization: str | None) -> AuthContext | None:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    token = authorization[len("bearer ") :].strip()
+    return AuthContext(inbound_access_token=token) if token else None
 
 
 def _pending_model(pa: PendingApproval | None) -> PendingApprovalModel | None:
@@ -227,6 +246,7 @@ def create_app(
         response: Response,
         x_request_id: str | None = Header(default=None),
         x_session_id: str | None = Header(default=None),
+        authorization: str | None = Header(default=None),
     ) -> InvokeResponse:
         assert _engine is not None
         rid = _begin_request(x_request_id)
@@ -243,7 +263,8 @@ def create_app(
         )
         try:
             result = await _engine.run(
-                body.message, context=_run_context(x_session_id, run_id=run_id)
+                body.message,
+                context=_run_context(x_session_id, run_id=run_id, authorization=authorization),
             )
         except Exception as exc:
             log(logger, logging.ERROR, "request end", status="error", error=str(exc))
@@ -273,10 +294,11 @@ def create_app(
         body: InvokeRequest,
         x_request_id: str | None = Header(default=None),
         x_session_id: str | None = Header(default=None),
+        authorization: str | None = Header(default=None),
     ) -> StreamingResponse:
         assert _engine is not None
         rid = _begin_request(x_request_id)
-        context = _run_context(x_session_id, run_id=uuid4().hex)
+        context = _run_context(x_session_id, run_id=uuid4().hex, authorization=authorization)
         started = time.perf_counter()
         log(
             logger,

--- a/src/agent_engine/engine/engine.py
+++ b/src/agent_engine/engine/engine.py
@@ -66,6 +66,7 @@ class ApprovalEngine(Protocol):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> RunResult: ...
 
 
@@ -95,6 +96,7 @@ class ApprovalStreamingEngine(Protocol):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> AsyncIterator[RunStreamEvent]: ...
 
 

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -68,6 +68,7 @@ from agent_engine.runs.in_memory import InMemoryRunRepository
 from agent_engine.runs.repository import RunRepository
 from agent_engine.runtime.execution import ExecutionLimiter, current_execution
 from agent_engine.runtime.hooks import (
+    AuthContext,
     EngineContext,
     HookManager,
     RunContext,
@@ -593,6 +594,7 @@ class LangGraphEngine(Engine):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> RunResult:
         """Apply a human decision to a pending tool call and resume the same run.
 
@@ -611,6 +613,7 @@ class LangGraphEngine(Engine):
             approval_id=approval_id,
             caller_user_id=caller_user_id,
             caller_session_id=caller_session_id,
+            access_token=access_token,
         )
         approved = kind != ApprovalDecision.DENY
         log(
@@ -659,6 +662,7 @@ class LangGraphEngine(Engine):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> AsyncIterator[RunStreamEvent]:
         """Resume one approval through the same owned stream used by new runs."""
         app, lifecycle = self._require_built("streaming an approval resume")
@@ -669,6 +673,7 @@ class LangGraphEngine(Engine):
             approval_id=approval_id,
             caller_user_id=caller_user_id,
             caller_session_id=caller_session_id,
+            access_token=access_token,
         )
         approved = kind != ApprovalDecision.DENY
 
@@ -709,6 +714,7 @@ class LangGraphEngine(Engine):
         approval_id: str,
         caller_user_id: str | None,
         caller_session_id: str | None,
+        access_token: str | None = None,
     ) -> RunContext:
         """Claim and activate one resume without an interruptible ownership gap.
 
@@ -731,6 +737,13 @@ class LangGraphEngine(Engine):
                 user_id=approval.authorized_user_id,
                 organization_id=approval.organization_id,
                 metadata={"approval_id": approval.approval_id},
+                # The approver's credential as of now, not one captured when the
+                # run started and possibly expired while it waited for a human.
+                auth_context=AuthContext(
+                    user_id=approval.authorized_user_id,
+                    organization_id=approval.organization_id,
+                    inbound_access_token=access_token,
+                ),
             )
             await lifecycle.activate_resume(ctx)
             return ctx

--- a/src/agent_engine/runtime/hooks/models.py
+++ b/src/agent_engine/runtime/hooks/models.py
@@ -59,7 +59,9 @@ class AuthContext:
 
     user_id: str | None = None
     organization_id: str | None = None
-    inbound_access_token: str | None = None
+    #: `repr=False` keeps this out of logs and tracebacks — the same
+    #: protection `Principal.access_token` already has on the manager side.
+    inbound_access_token: str | None = field(default=None, repr=False)
     scopes: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
     metadata: dict[str, object] = field(default_factory=dict)

--- a/src/agent_engine/runtime/hooks/models.py
+++ b/src/agent_engine/runtime/hooks/models.py
@@ -50,9 +50,11 @@ T = TypeVar("T")
 class AuthContext:
     """Identity and authorization facts resolved by the embedding application.
 
-    The platform never populates ``inbound_access_token`` itself — the host app
-    passes it in. Hooks may use it (e.g. to exchange it for an MCP-scoped token)
-    but must never log it.
+    ``inbound_access_token`` is never verified or interpreted by the platform —
+    only forwarded from whatever the caller sent (an HTTP ``Authorization``
+    header, or a value the embedding application chose to pass directly).
+    Hooks may use it (e.g. to exchange it for an MCP-scoped token) but must
+    never log it.
     """
 
     user_id: str | None = None

--- a/src/agent_manager/application/service.py
+++ b/src/agent_manager/application/service.py
@@ -28,7 +28,7 @@ from agent_engine.engine.engine import (
 )
 from agent_engine.engine.types import ChatMessage, RunResult
 from agent_engine.runs.repository import RunRepository
-from agent_engine.runtime.hooks import RunContext
+from agent_engine.runtime.hooks import AuthContext, RunContext
 from agent_engine.runtime.streaming import RunStreamEvent
 from agent_engine.runtime.tool_models import ToolUsageRecord
 from agent_manager.application.context import build_history
@@ -83,6 +83,25 @@ class PreparedConversationTurn:
     user_id: str
     message: str
     history: tuple[ChatMessage, ...]
+    #: Kept on the turn because `stream_turn` executes it with nothing else in
+    #: hand, and the run must still act as whoever asked for it.
+    principal: Principal
+
+
+def _run_context(turn: PreparedConversationTurn) -> RunContext:
+    """The per-run context one turn executes under, carrying the caller's own
+    host credential so tools act as this user rather than share a privileged key."""
+    return RunContext(
+        run_id=turn.run_id,
+        conversation_id=turn.session_id,
+        user_id=turn.user_id,
+        auth_context=AuthContext(
+            user_id=turn.user_id,
+            organization_id=turn.principal.organization_id,
+            roles=turn.principal.roles,
+            inbound_access_token=turn.principal.access_token,
+        ),
+    )
 
 
 class ConversationService:
@@ -172,11 +191,7 @@ class ConversationService:
             result = await self._engine.run(
                 turn.message,
                 history=turn.history,
-                context=RunContext(
-                    run_id=turn.run_id,
-                    conversation_id=turn.session_id,
-                    user_id=turn.user_id,
-                ),
+                context=_run_context(turn),
             )
         except asyncio.CancelledError:
             await self.cancel_turn(turn)
@@ -280,6 +295,7 @@ class ConversationService:
             user_id=user_id,
             message=text,
             history=build_history(prior_context.messages, self._window),
+            principal=principal,
         )
 
     async def complete_turn(
@@ -320,6 +336,7 @@ class ConversationService:
                 decision,
                 caller_user_id=session.user_id,
                 caller_session_id=session.session_id,
+                access_token=principal.access_token,
             )
         except ApprovalAlreadyProcessed:
             recovered = await engine.get_processed_result(
@@ -383,6 +400,7 @@ class ConversationService:
                 decision,
                 caller_user_id=session.user_id,
                 caller_session_id=session.session_id,
+                access_token=principal.access_token,
             )
             try:
                 async for event in engine_stream:
@@ -455,11 +473,7 @@ class ConversationService:
         engine_stream = self._engine.stream(
             turn.message,
             history=turn.history,
-            context=RunContext(
-                run_id=turn.run_id,
-                conversation_id=turn.session_id,
-                user_id=turn.user_id,
-            ),
+            context=_run_context(turn),
         )
         try:
             async for event in engine_stream:

--- a/src/agent_manager/domain/identity.py
+++ b/src/agent_manager/domain/identity.py
@@ -48,6 +48,9 @@ class Principal:
     roles: tuple[str, ...] = ()
     organization_id: str | None = None
     claims: Mapping[str, Any] = field(default_factory=dict)
+    #: What this caller proved themselves with, so tools can act as them. Host
+    #: tokens only; `repr=False` keeps it out of logs and tracebacks.
+    access_token: str | None = field(default=None, repr=False)
 
     @property
     def is_anonymous(self) -> bool:

--- a/src/agent_manager/infrastructure/auth/resolver.py
+++ b/src/agent_manager/infrastructure/auth/resolver.py
@@ -6,6 +6,7 @@ own tokens and `IdentityResolver` only picks between them.
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import uuid
 from collections.abc import Mapping, Sequence
@@ -67,7 +68,9 @@ class HostIdentitySource:
         self._claims = claims or ClaimMapping()
 
     def resolve(self, token: str) -> Principal:
-        return self._claims.to_principal(self._verifier.verify(token))
+        principal = self._claims.to_principal(self._verifier.verify(token))
+        # Carried only once the signature checked out.
+        return dataclasses.replace(principal, access_token=token)
 
 
 class AnonymousIdentitySource:

--- a/tests/agent_manager/test_api.py
+++ b/tests/agent_manager/test_api.py
@@ -51,6 +51,7 @@ class _ApprovalRecordingEngine(RecordingEngine):
             tuple[str, str, ApprovalDecision | str, str | None, str | None]
         ] = []
         self.cancel_calls: list[tuple[str, str, str | None, str | None]] = []
+        self.resume_tokens: list[str | None] = []
         self.completed_results: dict[str, RunResult] = {}
 
     def _pending_result(self, context: RunContext | None) -> RunResult:
@@ -127,8 +128,10 @@ class _ApprovalRecordingEngine(RecordingEngine):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> RunResult:
         self.resume_calls.append((run_id, approval_id, decision, caller_user_id, caller_session_id))
+        self.resume_tokens.append(access_token)
         answer = "The tool request was denied." if decision == ApprovalDecision.DENY else "sent"
         result = RunResult(
             system_name="stub",
@@ -148,8 +151,10 @@ class _ApprovalRecordingEngine(RecordingEngine):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> AsyncIterator[RunStreamEvent]:
         self.resume_calls.append((run_id, approval_id, decision, caller_user_id, caller_session_id))
+        self.resume_tokens.append(access_token)
         answer = "The tool request was denied." if decision == ApprovalDecision.DENY else "sent"
         yield RunStreamEvent(type="resume_started", run_id=run_id)
         yield RunStreamEvent(
@@ -701,6 +706,9 @@ def test_conversation_approval_actions_resume_and_persist(
         ("assistant", expected_answer),
     ]
     assert client.get("/conversations/session-1/usage", headers=headers).json()["used_tokens"] == 7
+    # The approver's credential as of the decision — a run may have waited hours
+    # for a human, by which point the one it started with is long expired.
+    assert engine.resume_tokens == [headers["Authorization"].removeprefix("Bearer ")]
 
 
 def test_conversation_approval_stream_resumes_same_run_and_persists() -> None:
@@ -749,8 +757,9 @@ async def test_closing_approval_stream_cancels_same_run_without_partial_assistan
             *,
             caller_user_id: str | None = None,
             caller_session_id: str | None = None,
+            access_token: str | None = None,
         ) -> AsyncIterator[RunStreamEvent]:
-            del approval_id, decision, caller_user_id, caller_session_id
+            del approval_id, decision, caller_user_id, caller_session_id, access_token
             await runs.transition_if_allowed(run_id, RunStatus.RESUMING)
             await runs.transition_if_allowed(run_id, RunStatus.RUNNING)
             try:
@@ -1068,8 +1077,9 @@ def test_conversation_approval_sanitizes_engine_failure(
             *,
             caller_user_id: str | None = None,
             caller_session_id: str | None = None,
+            access_token: str | None = None,
         ) -> RunResult:
-            del run_id, approval_id, decision, caller_user_id, caller_session_id
+            del run_id, approval_id, decision, caller_user_id, caller_session_id, access_token
             raise RuntimeError("private approval failure")
 
     engine = FailingApprovalEngine()
@@ -1103,8 +1113,9 @@ def test_conversation_approval_sanitizes_typed_approval_failure() -> None:
             *,
             caller_user_id: str | None = None,
             caller_session_id: str | None = None,
+            access_token: str | None = None,
         ) -> RunResult:
-            del run_id, decision, caller_user_id, caller_session_id
+            del run_id, decision, caller_user_id, caller_session_id, access_token
             raise ApprovalNotFound(f"private-{approval_id}")
 
     engine = MissingApprovalEngine()
@@ -1137,6 +1148,7 @@ def test_conversation_approval_retry_recovers_result_without_duplicate_message()
             *,
             caller_user_id: str | None = None,
             caller_session_id: str | None = None,
+            access_token: str | None = None,
         ) -> RunResult:
             if run_id in self.completed_results:
                 raise ApprovalAlreadyProcessed(approval_id, "approved")
@@ -1146,6 +1158,7 @@ def test_conversation_approval_retry_recovers_result_without_duplicate_message()
                 decision,
                 caller_user_id=caller_user_id,
                 caller_session_id=caller_session_id,
+                access_token=access_token,
             )
 
     class FailFirstAssistantWrite(MemoryRepository):

--- a/tests/agent_manager/test_auth.py
+++ b/tests/agent_manager/test_auth.py
@@ -195,6 +195,33 @@ def test_a_visitor_pass_round_trips_but_a_host_token_does_not_become_one() -> No
     assert host_user.external_id == "alice"
 
 
+def test_a_verified_host_token_is_carried_so_tools_can_act_as_that_user() -> None:
+    token = _encode()
+
+    principal = HostIdentitySource(_verifier()).resolve(token)
+
+    assert principal.access_token == token
+
+
+def test_a_visitor_pass_is_never_carried_as_a_host_credential() -> None:
+    """A pass we minted proves nothing to the host."""
+    resolver = build_identity_resolver(
+        _settings(extra_auth_mode=AuthMode.MINT, extra_auth_secret=SECRET)
+    )
+
+    visitor = resolver.resolve(resolver.anonymous.issue().token)
+
+    assert visitor.access_token is None
+
+
+def test_a_carried_token_stays_out_of_the_principal_repr() -> None:
+    """`repr` reaches logs and tracebacks by accident; the credential must not."""
+    principal = HostIdentitySource(_verifier()).resolve(_encode())
+
+    assert principal.access_token is not None
+    assert principal.access_token not in repr(principal)
+
+
 def test_mint_mode_accepts_the_token_our_own_docs_tell_hosts_to_produce() -> None:
     """Pins docs/identity.mdx against the code. The documented snippet signs
     `sub` with `expiresIn`; Node's jsonwebtoken adds `iat` itself. Drop the

--- a/tests/agent_manager/test_service.py
+++ b/tests/agent_manager/test_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from typing import cast
 
@@ -290,6 +291,32 @@ async def test_send_uses_stable_session_and_unique_run_id() -> None:
     assert contexts[0].run_id is not None
     assert contexts[1].run_id is not None
     assert contexts[0].run_id != contexts[1].run_id
+
+
+async def test_a_turn_carries_the_callers_own_credential_to_plugin_code() -> None:
+    service, engine = _service()
+    caller = dataclasses.replace(ALICE, access_token="host-token-abc", roles=("editor",))
+    cid = await service.create(caller, session_id="sess-1")
+
+    await service.send(cid, "hi", caller)
+
+    context = engine.contexts[-1]
+    assert context is not None and context.auth_context is not None
+    auth = context.auth_context
+    assert auth.inbound_access_token == "host-token-abc"
+    assert auth.roles == ("editor",)
+
+
+async def test_a_visitor_turn_carries_no_credential() -> None:
+    """Plugin code gets nothing to act with, and must fail rather than fall back."""
+    service, engine = _service()
+    cid = await service.create(VISITOR, session_id="sess-v")
+
+    await service.send(cid, "hi", VISITOR)
+
+    context = engine.contexts[-1]
+    assert context is not None and context.auth_context is not None
+    assert context.auth_context.inbound_access_token is None
 
 
 async def test_turn_refuses_a_caller_who_does_not_own_the_conversation() -> None:

--- a/tests/api/test_approval_endpoints.py
+++ b/tests/api/test_approval_endpoints.py
@@ -136,6 +136,82 @@ def _trigger_pending_approval(
     return body["run_id"], pending["approval_id"]
 
 
+def _write_token_probe_config(base_dir: Path) -> Path:
+    """A tool that reports whichever credential it sees at call time, so a
+    test can tell a run's original token apart from the approver's."""
+    tools_dir = base_dir / "plugins" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / "send_email.py").write_text(
+        "from agent_engine.runtime.hooks import current_run_context\n\n"
+        "def send_email(message: str) -> str:\n"
+        "    ctx = current_run_context.get()\n"
+        "    auth = ctx.auth_context if ctx else None\n"
+        "    token = auth.inbound_access_token if auth else None\n"
+        "    return f'sent as {token}'\n",
+        encoding="utf-8",
+    )
+    config_path = base_dir / "agents.yaml"
+    config_path.write_text(
+        """
+system:
+  name: Approval Test System
+
+tools:
+  send_email:
+    description: Send an email.
+
+agents:
+  writer:
+    description: Writes and sends emails.
+    model:
+      provider: openai
+      name: gpt-4o-mini
+    tools: [send_email]
+
+graph:
+  writer:
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+@pytest.fixture
+def token_probe_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    from langchain_openai import ChatOpenAI
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setattr(
+        ChatOpenAI, "bind_tools", lambda self, tools, **_: FakeChatModel([t.name for t in tools])
+    )
+    config_path = _write_token_probe_config(tmp_path)
+    app = create_app(str(config_path))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_approval_resumes_with_the_approvers_token_not_the_original_caller(
+    token_probe_client: TestClient,
+) -> None:
+    """A run started by one caller may be approved by another — the tool call
+    that finally executes must act with the approver's credential, not
+    whatever the run happened to start with (extra-org/extra#112 review)."""
+    started = token_probe_client.post(
+        "/invoke", json={"message": "hi"}, headers={"Authorization": "Bearer TOKEN_A"}
+    )
+    assert started.status_code == 200
+    pending = started.json()["pending_approval"]
+    run_id, approval_id = started.json()["run_id"], pending["approval_id"]
+
+    approved = token_probe_client.post(
+        f"/runs/{run_id}/approvals/{approval_id}/approve",
+        headers={"Authorization": "Bearer TOKEN_B"},
+    )
+
+    assert approved.status_code == 200
+    assert "sent as TOKEN_B" in approved.json()["answer"]
+
+
 def test_approve_with_empty_json_body_succeeds(client: TestClient) -> None:
     run_id, approval_id = _trigger_pending_approval(client)
 

--- a/tests/api/test_run_context.py
+++ b/tests/api/test_run_context.py
@@ -1,0 +1,38 @@
+"""The engine's HTTP surface as a credential conduit: `Authorization` is
+forwarded verbatim and verified nowhere, asserted facts are not accepted."""
+
+from __future__ import annotations
+
+from agent_engine.api.app import _run_context
+from agent_engine.engine.langgraph.engine import _state_run_context
+
+TOKEN = "eyJhbGciOiJIUzI1NiJ9.host-token.signature"
+
+
+def test_a_bearer_credential_reaches_plugin_code() -> None:
+    ctx = _run_context(None, run_id="r1", authorization=f"Bearer {TOKEN}")
+
+    assert ctx.auth_context is not None
+    assert ctx.auth_context.inbound_access_token == TOKEN
+
+
+def test_the_scheme_is_matched_case_insensitively() -> None:
+    ctx = _run_context(None, run_id="r1", authorization=f"bearer {TOKEN}")
+
+    assert ctx.auth_context is not None
+    assert ctx.auth_context.inbound_access_token == TOKEN
+
+
+def test_a_caller_who_sends_nothing_gets_no_credential() -> None:
+    """Never a fallback to some ambient key — that is the escalation removed."""
+    for header in (None, "", "Bearer ", "Basic abc123"):
+        ctx = _run_context(None, run_id="r1", authorization=header)
+
+        assert ctx.auth_context is None, header
+
+
+def test_the_credential_never_reaches_the_state_the_model_sees() -> None:
+    """Graph state reaches prompts and callers; a credential there is a leak."""
+    ctx = _run_context(None, run_id="r1", authorization=f"Bearer {TOKEN}")
+
+    assert TOKEN not in repr(_state_run_context(ctx))

--- a/tests/cli/test_chat_command.py
+++ b/tests/cli/test_chat_command.py
@@ -155,8 +155,9 @@ class ApprovalFakeEngine(FakeEngine):
         *,
         caller_user_id: str | None = None,
         caller_session_id: str | None = None,
+        access_token: str | None = None,
     ) -> RunResult:
-        del caller_session_id
+        del caller_session_id, access_token
         assert isinstance(decision, ApprovalDecision)
         self.resume_calls.append((run_id, approval_id, decision, caller_user_id))
         return next(self.results)

--- a/tests/runtime/hooks/test_models.py
+++ b/tests/runtime/hooks/test_models.py
@@ -1,0 +1,20 @@
+"""AuthContext.inbound_access_token must never appear in a repr — reprs reach
+logs and tracebacks by accident, and this is a credential."""
+
+from __future__ import annotations
+
+from agent_engine.runtime.hooks.models import AuthContext, RunContext
+
+TOKEN = "super-secret-token"
+
+
+def test_the_token_is_not_in_auth_context_repr() -> None:
+    auth = AuthContext(inbound_access_token=TOKEN)
+
+    assert TOKEN not in repr(auth)
+
+
+def test_the_token_is_not_in_run_context_repr() -> None:
+    ctx = RunContext(auth_context=AuthContext(inbound_access_token=TOKEN))
+
+    assert TOKEN not in repr(ctx)


### PR DESCRIPTION
## Why

A tool had no way to reach the identity its request arrived with. Any integration acting on a host product therefore had to hold one shared privileged key — which silently grants every caller whatever that key can do. In the Open WebUI example this meant an ordinary user could perform admin actions through chat.

`AuthContext.inbound_access_token` was built for exactly this and documented as *"the host app passes it in"*, but no HTTP path ever reached it, so it was always `None`.

## What

Fill it on each route that has a caller:

- **Manager** attaches the token once its signature verifies, so nothing downstream sees a credential this process did not just check. It rides on the prepared turn, because `stream_turn` executes with nothing else in hand.
- **Engine `/invoke` and `/stream`** forward `Authorization` verbatim, without verifying it. A forged credential fails at the system that owns it, so passing one along grants nothing that direct access would not. Facts the caller merely *asserts* (a user id, a role) get no such treatment and are not accepted — which is why no context object was added to the request body.
- **Both approval resume paths** take the approver's credential as of the decision, not one captured when the run started and possibly expired while it waited for a human.

Visitor passes are never carried: they prove nothing to a host product.

## Boundary

The engine is a conduit; the manager is an authority. Both produce the same `RunContext`. Nothing about how a credential is obtained, refreshed, or exchanged lives here — that is plugin code, reached through the existing `on_run_start` hook, which may already replace the context.

## Safety

- `inbound_access_token` never enters graph state, so it cannot reach a prompt, the model, or a response — pinned by a test.
- `repr=False` keeps it out of logs and tracebacks.
- `Principal` is never serialized wholesale (only `ToolUsageRecord` goes through `asdict`).

## Docs

Two published pages were missing what a user needs to actually do this:

- `mcp-and-tools.mdx` — how a tool acts as the caller, placed right after "Implementing a tool" where someone writing one arrives at the question.
- `runtime-hooks.mdx` — `plugins.import_roots`, without which managed hooks fail to import. The page walked you through registration and stopped one step short; the warning now carries the exact error string.

## Tests

Six added. Token survives resolution; a visitor pass never carries one; it stays out of `repr`; `Bearer` parsing including case and the empty cases; the approver's credential reaches resume; and the graph-state invariant.

`make check` is clean. `tests/cli/test_run_persistence.py::test_agentctl_run_without_session_prints_reusable_generated_session` fails identically on a clean `main` (a click version issue in that test's harness) and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)