### PR TITLE
feat(engine): resolve prompt variables for orchestrators, not just agents

### DIFF
--- a/docs/SIDECAR_CONTEXT_AUTH.md
+++ b/docs/SIDECAR_CONTEXT_AUTH.md
@@ -77,11 +77,11 @@ Each resolver has a **scope** (`shared` or `agent`) and a return type:
 ```yaml
 resolvers:
   current_date:
-    scope: shared        # generated on BaseResolver, inherited by all agents
+    scope: shared        # generated on BaseResolver, inherited by all nodes
   user_name:
     scope: shared
   experience_level:
-    scope: agent         # generated only on the declaring agent's subclass
+    scope: agent         # generated only on the declaring node's subclass
 
 agents:
   learning_planner_agent:
@@ -161,7 +161,8 @@ automatically.
 
 ### Runtime resolution
 
-1. The runtime loads the agent's resolver class from TOML.
+1. The runtime loads the node's resolver class from TOML (agents and
+   orchestrators alike).
 2. The class is instantiated once with configured dependencies.
 3. Methods are called by resolver id; shared methods resolve via Python
    inheritance.

--- a/docs/YAML_SPEC.md
+++ b/docs/YAML_SPEC.md
@@ -276,8 +276,12 @@ different times and have different trust boundaries.
 
 Resolvers are declared as ids in YAML. Each resolver has a **scope**:
 
-- `shared` — generated once on `SharedResolver`; inherited by all agents.
-- `agent` (default) — generated only on the declaring agent's resolver subclass.
+- `shared` — generated once on `SharedResolver`; inherited by all nodes.
+- `agent` (default) — generated only on the declaring node's resolver subclass.
+
+Orchestrators take resolvers too: both of an orchestrator's prompt files are
+rendered against the same resolved values, so a router's own instructions can
+depend on the request rather than being fixed text.
 
 ```yaml
 resolvers:
@@ -287,10 +291,11 @@ resolvers:
     scope: agent
 ```
 
-Resolvers are generated one file per agent under `plugins/resolvers/`: each
-agent file defines a `Resolver` class, and shared methods live on a
-`SharedResolver` in `plugins/resolvers/shared.py` that agent classes inherit.
-The runtime loads the agent's `Resolver` by file path and instantiates it once.
+Resolvers are generated one file per node under `plugins/resolvers/`: each
+node file defines a `Resolver` class, and shared methods live on a
+`SharedResolver` in `plugins/resolvers/shared.py` that node classes inherit.
+The runtime loads the node's `Resolver` by file path and instantiates it once.
+The instance is reused; the values it returns are resolved again on every run.
 
 The importable refs are catalogued in the single plugin manifest
 `plugins/plugins.toml` (see [RUNTIME_HOOKS.md](RUNTIME_HOOKS.md) →

--- a/docs/plugins.mdx
+++ b/docs/plugins.mdx
@@ -28,7 +28,7 @@ plugins/
   resolvers/
     __init__.py
     shared.py           ← SharedResolver (shared methods)
-    orders_agent.py     ← per-agent Resolver subclass
+    orders_agent.py     ← per-node Resolver subclass
     returns_agent.py
   tools/
     __init__.py
@@ -46,18 +46,18 @@ Run `generate --config agents.yml` (see [Quickstart](/docs/quickstart)) to creat
 
 ## Resolver plugins
 
-Resolvers fill prompt variables. They run before the agent, they're chosen by the engine (not the LLM), and they cost no tokens.
+Resolvers fill prompt variables. They run before the node, they're chosen by the engine (not the LLM), and they cost no tokens. Agents and orchestrators both take them, so a router's own instructions can depend on the request instead of being fixed text.
 
 ### Declaration
 
 ```yaml
 resolvers:
   current_date:
-    scope: shared    # generated once on SharedResolver, all agents inherit it
+    scope: shared    # generated once on SharedResolver, all nodes inherit it
   customer_name:
     scope: shared
   account_tier:
-    scope: agent     # generated per-agent, only agents that declare it get it
+    scope: agent     # generated per-node, only nodes that declare it get it
 ```
 
 ### Implementation

--- a/src/agent_engine/core/plugin_stubs.py
+++ b/src/agent_engine/core/plugin_stubs.py
@@ -27,7 +27,7 @@ from enum import Enum
 from pathlib import Path
 
 from agent_engine.core.errors import ValidationError
-from agent_engine.core.spec import AgentSpec, GraphNode, SystemSpec
+from agent_engine.core.spec import AgentSpec, GraphNode, NodeSpec, SystemSpec
 
 _GENERATE_HINT = "run `agentctl generate` to create the stub"
 
@@ -60,9 +60,9 @@ class _Scanner:
     def walk(self, node: GraphNode) -> None:
         if node.node.protected:
             self.has_protected = True
+        self._check_resolvers(node.node)
         if isinstance(node.node, AgentSpec):
             self._check_tools(node.node)
-            self._check_resolvers(node.node)
             self._check_mcp_auth(node.node)
         self._check_prompts(node)
         for child in node.children:
@@ -90,26 +90,26 @@ class _Scanner:
 
     # -- resolvers -------------------------------------------------------
 
-    def _check_resolvers(self, agent: AgentSpec) -> None:
-        if not agent.resolvers:
+    def _check_resolvers(self, node: NodeSpec) -> None:
+        if not node.resolvers:
             return
-        agent_rel = Path("plugins") / "resolvers" / f"{agent.id}.py"
-        agent_path = self._base_dir / agent_rel
-        if not agent_path.is_file():
+        node_rel = Path("plugins") / "resolvers" / f"{node.id}.py"
+        node_path = self._base_dir / node_rel
+        if not node_path.is_file():
             self._error(
-                f"{agent.id}.resolvers",
-                f"Resolver plugin not found: {agent_rel} — {_GENERATE_HINT}",
+                f"{node.id}.resolvers",
+                f"Resolver plugin not found: {node_rel} — {_GENERATE_HINT}",
             )
             return
         shared_path = self._base_dir / "plugins" / "resolvers" / "shared.py"
-        for resolver in agent.resolvers:
-            verdict = _stub_verdict(agent_path, resolver.id, class_name="Resolver")
+        for resolver in node.resolvers:
+            verdict = _stub_verdict(node_path, resolver.id, class_name="Resolver")
             if verdict is _Verdict.NO_FUNCTION:
                 # Fall back to the conventional shared base class.
                 verdict = _stub_verdict(shared_path, resolver.id, class_name="SharedResolver")
             if verdict is _Verdict.STUB:
                 self._error(
-                    f"{agent.id}.resolvers.{resolver.id}",
+                    f"{node.id}.resolvers.{resolver.id}",
                     f"Resolver '{resolver.id}' is declared but not implemented (generated stub)",
                 )
 

--- a/src/agent_engine/engine/langgraph/engine.py
+++ b/src/agent_engine/engine/langgraph/engine.py
@@ -1013,6 +1013,7 @@ class LangGraphEngine(Engine):
         parent_path: str | None,
     ) -> OrchestratorNode:
         assert isinstance(node.node, OrchestratorSpec)
+        assert self._resolver_loader is not None
         spec = node.node
         path = node_id(node, parent_path)
         model = self._build_model(spec.model)
@@ -1042,6 +1043,7 @@ class LangGraphEngine(Engine):
             model=model,
             children=children,
             filters=self._filters,
+            resolver_loader=self._resolver_loader,
             base_dir=self._base_dir,
             usage_context=self._tool_usage_context,
             usage_tracker=self._tool_usage_tracker,

--- a/src/agent_engine/engine/langgraph/helpers.py
+++ b/src/agent_engine/engine/langgraph/helpers.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from agent_engine.core.spec import AgentSpec, GraphNode, OrchestratorSpec
+from agent_engine.core.spec import AgentSpec, GraphNode, NodeSpec, OrchestratorSpec
+from agent_engine.loaders.resolver_loader import ResolverLoader
 from agent_engine.runtime.execution import ExecutionLimitExceeded, current_execution, log_limit
 from agent_engine.runtime.hooks import current_run_context
 from agent_engine.runtime.state import GraphState
@@ -109,6 +110,20 @@ def render_prompt(template: str, ctx: dict[str, str]) -> str:
         return ctx.get(match.group(1).strip(), match.group(0))
 
     return re.sub(r"\{\{\s*(\w+)\s*\}\}", replace, template)
+
+
+def resolve_prompt_context(loader: ResolverLoader, spec: NodeSpec) -> dict[str, str]:
+    """Run a node's declared resolvers and return the accumulated key→value map.
+
+    Resolvers are invoked in declaration order; each receives the values
+    produced by previous ones so they can build on one another. Resolution
+    happens per run and is never cached — a resolver may answer differently
+    for each caller.
+    """
+    ctx: dict[str, str] = {}
+    for resolver in spec.resolvers:
+        ctx[resolver.id] = str(loader.load(spec.id, resolver.id)(ctx))
+    return ctx
 
 
 def load_file(base_dir: Path, rel_path: str | None) -> str:

--- a/src/agent_engine/engine/langgraph/nodes.py
+++ b/src/agent_engine/engine/langgraph/nodes.py
@@ -35,6 +35,7 @@ from agent_engine.engine.langgraph.helpers import (
     execution_context_refresher,
     load_file,
     render_prompt,
+    resolve_prompt_context,
     run_tool_loop,
 )
 from agent_engine.engine.langgraph.tool_invoker import ToolInvoker
@@ -135,22 +136,11 @@ class AgentNode:
     async def __call__(self, state: GraphState) -> GraphState:
         token = current_invocation.set(uuid.uuid4().hex)
         try:
-            ctx = self._resolve_context()
+            ctx = resolve_prompt_context(self._resolver_loader, self._spec)
             system_prompt = self._build_prompt(ctx)
             return await self._run(system_prompt, state)
         finally:
             current_invocation.reset(token)
-
-    def _resolve_context(self) -> dict[str, str]:
-        """Run every declared resolver and return the accumulated key→value map.
-
-        Resolvers are invoked in declaration order; each receives the values
-        produced by previous resolvers so they can build on one another.
-        """
-        ctx: dict[str, str] = {}
-        for r in self._spec.resolvers:
-            ctx[r.id] = str(self._resolver_loader.load(self._spec.id, r.id)(ctx))
-        return ctx
 
     def _build_prompt(self, ctx: dict[str, str]) -> str:
         """Load the system-prompt template and interpolate resolver values."""
@@ -210,6 +200,7 @@ class OrchestratorNode:
         model: BaseChatModel,
         children: list[ChildEntry],
         filters: list[RouteFilter],
+        resolver_loader: ResolverLoader,
         base_dir: Path,
         usage_context: ToolUsageContextProvider,
         usage_tracker: ToolUsageTracker,
@@ -221,6 +212,7 @@ class OrchestratorNode:
         self._fallback_model = fallback_model
         self._children = children
         self._filters = filters
+        self._resolver_loader = resolver_loader
         self._base_dir = base_dir
         self._usage = usage_tracker
         self._usage_context = usage_context
@@ -230,15 +222,22 @@ class OrchestratorNode:
         token = current_invocation.set(uuid.uuid4().hex)
         try:
             candidates = self._filter_children(state)
-            base_prompt = (
-                load_file(self._base_dir, self._spec.prompts.system) or self._spec.description
-            )
-            orchestrator_content = load_file(self._base_dir, self._spec.prompts.orchestrator)
-            base_prompt = f"{base_prompt}\n\n{orchestrator_content}"
-            system_prompt = f"{base_prompt}\n{_ORCHESTRATOR_CONTRACT}"
+            ctx = resolve_prompt_context(self._resolver_loader, self._spec)
+            system_prompt = f"{self._build_prompt(ctx)}\n{_ORCHESTRATOR_CONTRACT}"
             return await self._run(system_prompt, candidates, state)
         finally:
             current_invocation.reset(token)
+
+    def _build_prompt(self, ctx: dict[str, str]) -> str:
+        """Load both prompt templates and interpolate resolver values.
+
+        Rendered as one template so a variable resolves identically wherever it
+        appears; the engine's own contract is appended afterwards and is never
+        subject to interpolation.
+        """
+        base = load_file(self._base_dir, self._spec.prompts.system) or self._spec.description
+        orchestrator = load_file(self._base_dir, self._spec.prompts.orchestrator)
+        return render_prompt(f"{base}\n\n{orchestrator}", ctx)
 
     def _filter_children(self, state: GraphState) -> list[ChildEntry]:
         """Apply every RouteFilter to narrow down which child tools are available."""

--- a/src/agent_engine/generate/generator.py
+++ b/src/agent_engine/generate/generator.py
@@ -24,8 +24,8 @@ class Generator:
     Never overwrites existing files — only creates missing stubs.
 
     Shared resolvers (scope: shared) are generated once in plugins/resolvers/shared.py
-    as class SharedResolver. Per-agent files inherit from SharedResolver and only
-    include stubs for their agent-scoped resolvers.
+    as class SharedResolver. Per-node files inherit from SharedResolver and only
+    include stubs for their node-scoped resolvers.
     """
 
     def generate(self, spec: SystemSpec, base_dir: Path) -> GenerateResult:
@@ -33,8 +33,8 @@ class Generator:
         (
             tool_ids,
             shared_ids,
-            agent_resolver_ids,
-            agents_with_shared,
+            node_resolver_ids,
+            nodes_with_shared,
             has_protected,
             mcp_plugin_ids,
         ) = _collect(spec.graph)
@@ -58,11 +58,11 @@ class Generator:
                 base_dir,
             )
 
-        for agent_id, agent_only_ids in agent_resolver_ids.items():
-            has_shared = agent_id in agents_with_shared
+        for node_id, node_only_ids in node_resolver_ids.items():
+            has_shared = node_id in nodes_with_shared
             self._write(
-                resolvers_dir / f"{agent_id}.py",
-                _agent_resolver_stub(agent_only_ids, has_shared),
+                resolvers_dir / f"{node_id}.py",
+                _node_resolver_stub(node_only_ids, has_shared),
                 result,
                 base_dir,
             )
@@ -106,7 +106,7 @@ class Generator:
             spec,
             tool_ids,
             shared_ids,
-            agent_resolver_ids,
+            node_resolver_ids,
             hook_methods,
             result,
         )
@@ -118,7 +118,7 @@ class Generator:
         spec: SystemSpec,
         tool_ids: dict[str, str],
         shared_ids: list[str],
-        agent_resolver_ids: dict[str, list[str]],
+        node_resolver_ids: dict[str, list[str]],
         hook_methods: dict[str, list[str]],
         result: GenerateResult,
     ) -> None:
@@ -139,8 +139,8 @@ class Generator:
         resolver_refs: dict[str, str] = {}
         if shared_ids:
             resolver_refs["shared"] = f"{pkg}.resolvers.shared:SharedResolver"
-        for agent_id in agent_resolver_ids:
-            resolver_refs[agent_id] = f"{pkg}.resolvers.{agent_id}:Resolver"
+        for node_id in node_resolver_ids:
+            resolver_refs[node_id] = f"{pkg}.resolvers.{node_id}:Resolver"
 
         tool_refs = {tool_id: f"{pkg}.tools.{tool_id}:{tool_id}" for tool_id in tool_ids}
 
@@ -177,16 +177,16 @@ def _collect(
 ) -> tuple[dict[str, str], list[str], dict[str, list[str]], set[str], bool, list[str]]:
     """Walk the graph and collect:
     - tool_ids: {id: description}
-    - shared_ids: ordered list of shared resolver IDs (deduped across all agents)
-    - agent_resolver_ids: {agent_id: [agent-scoped resolver ids for that agent]}
-    - agents_with_shared: set of agent IDs that reference at least one shared resolver
+    - shared_ids: ordered list of shared resolver IDs (deduped across all nodes)
+    - node_resolver_ids: {node_id: [node-scoped resolver ids for that node]}
+    - nodes_with_shared: set of node IDs that reference at least one shared resolver
     - has_protected: whether any node is protected
     """
     tool_ids: dict[str, str] = {}
     shared_ids: list[str] = []
     seen_shared: set[str] = set()
-    agent_resolver_ids: dict[str, list[str]] = {}
-    agents_with_shared: set[str] = set()
+    node_resolver_ids: dict[str, list[str]] = {}
+    nodes_with_shared: set[str] = set()
     has_protected = False
     mcp_plugin_ids: list[str] = []
     seen_mcp_plugins: set[str] = set()
@@ -195,19 +195,19 @@ def _collect(
         nonlocal has_protected
         if n.node.protected:
             has_protected = True
+        for r in n.node.resolvers:
+            if r.scope == "shared":
+                if r.id not in seen_shared:
+                    shared_ids.append(r.id)
+                    seen_shared.add(r.id)
+                nodes_with_shared.add(n.node.id)
+            else:
+                ids = node_resolver_ids.setdefault(n.node.id, [])
+                if r.id not in ids:
+                    ids.append(r.id)
         if isinstance(n.node, AgentSpec):
             for t in n.node.tools:
                 tool_ids.setdefault(t.id, t.description)
-            for r in n.node.resolvers:
-                if r.scope == "shared":
-                    if r.id not in seen_shared:
-                        shared_ids.append(r.id)
-                        seen_shared.add(r.id)
-                    agents_with_shared.add(n.node.id)
-                else:
-                    ids = agent_resolver_ids.setdefault(n.node.id, [])
-                    if r.id not in ids:
-                        ids.append(r.id)
             for mcp in n.node.mcps:
                 if mcp.auth and mcp.id not in seen_mcp_plugins:
                     mcp_plugin_ids.append(mcp.id)
@@ -217,15 +217,15 @@ def _collect(
 
     walk(node)
 
-    # Agents that only have shared resolvers still need a stub file.
-    for agent_id in agents_with_shared:
-        agent_resolver_ids.setdefault(agent_id, [])
+    # Nodes that only have shared resolvers still need a stub file.
+    for node_id in nodes_with_shared:
+        node_resolver_ids.setdefault(node_id, [])
 
     return (
         tool_ids,
         shared_ids,
-        agent_resolver_ids,
-        agents_with_shared,
+        node_resolver_ids,
+        nodes_with_shared,
         has_protected,
         mcp_plugin_ids,
     )
@@ -255,7 +255,7 @@ def _shared_resolver_stub(resolver_ids: list[str]) -> str:
     )
 
 
-def _agent_resolver_stub(agent_only_ids: list[str], inherits_shared: bool) -> str:
+def _node_resolver_stub(node_only_ids: list[str], inherits_shared: bool) -> str:
     if inherits_shared:
         header = (
             "from __future__ import annotations\n\n"
@@ -267,12 +267,12 @@ def _agent_resolver_stub(agent_only_ids: list[str], inherits_shared: bool) -> st
         header = "from __future__ import annotations\n\n\nclass Resolver:\n"
         init = "    def __init__(self) -> None:\n        pass\n"
 
-    if agent_only_ids:
+    if node_only_ids:
         methods = "\n" + "\n".join(
             f"    def {r_id}(self, ctx: dict) -> str:\n"
             f'        """Returns the value for {{{{{r_id}}}}}"""\n'
             f"        raise NotImplementedError\n"
-            for r_id in agent_only_ids
+            for r_id in node_only_ids
         )
     else:
         methods = ""

--- a/src/agent_engine/loaders/resolver_loader.py
+++ b/src/agent_engine/loaders/resolver_loader.py
@@ -12,14 +12,15 @@ class ResolverLoaderError(RuntimeError):
 
 
 class ResolverLoader:
-    """Loads per-agent resolver classes from plugins/resolvers/{agent_id}.py.
+    """Loads per-node resolver classes from plugins/resolvers/{node_id}.py.
 
     Each file must contain a class named Resolver. The class is instantiated
-    once per agent_id and cached — shared resources (DB connections, clients)
-    are initialized in __init__ and reused across resolver calls.
+    once per node_id and cached — shared resources (DB connections, clients)
+    are initialized in __init__ and reused across resolver calls. Resolved
+    values are never cached; every run resolves again.
 
     If plugins/resolvers/shared.py exists, it is loaded first and registered in
-    sys.modules as "shared" so agent files can inherit from SharedResolver via
+    sys.modules as "shared" so node files can inherit from SharedResolver via
     `from shared import SharedResolver`.
 
     Resolver methods are named after resolver IDs and accept a single ctx dict.
@@ -30,25 +31,25 @@ class ResolverLoader:
         self._instances: dict[str, Any] = {}
         self._shared_loaded = False
 
-    def load(self, agent_id: str, resolver_id: str) -> Callable[[dict[str, Any]], Any]:
-        instance = self._get_or_create(agent_id)
+    def load(self, node_id: str, resolver_id: str) -> Callable[[dict[str, Any]], Any]:
+        instance = self._get_or_create(node_id)
         method = getattr(instance, resolver_id, None)
         if method is None or not callable(method):
             cls_name = type(instance).__name__
             raise ResolverLoaderError(
-                f"Resolver class '{cls_name}' for agent '{agent_id}' has no method '{resolver_id}'"
+                f"Resolver class '{cls_name}' for node '{node_id}' has no method '{resolver_id}'"
             )
         return method
 
-    def _get_or_create(self, agent_id: str) -> Any:
-        if agent_id not in self._instances:
-            self._instances[agent_id] = self._instantiate(agent_id)
-        return self._instances[agent_id]
+    def _get_or_create(self, node_id: str) -> Any:
+        if node_id not in self._instances:
+            self._instances[node_id] = self._instantiate(node_id)
+        return self._instances[node_id]
 
-    def _instantiate(self, agent_id: str) -> Any:
+    def _instantiate(self, node_id: str) -> Any:
         resolvers_dir = self._base_dir / "plugins" / "resolvers"
         self._ensure_shared_module(resolvers_dir)
-        path = resolvers_dir / f"{agent_id}.py"
+        path = resolvers_dir / f"{node_id}.py"
         if not path.is_file():
             raise ResolverLoaderError(
                 f"Resolver plugin not found: {path}\nRun `agentctl generate` to create the stub."
@@ -61,13 +62,13 @@ class ResolverLoader:
             return cls()
         except Exception as exc:
             raise ResolverLoaderError(
-                f"Failed to instantiate Resolver for agent '{agent_id}': {exc}"
+                f"Failed to instantiate Resolver for node '{node_id}': {exc}"
             ) from exc
 
     def _ensure_shared_module(self, resolvers_dir: Path) -> None:
         """Load shared.py once and register it as sys.modules['shared'].
 
-        This lets agent resolver files do `from shared import SharedResolver`
+        This lets node resolver files do `from shared import SharedResolver`
         without needing shared.py on the Python path.
         """
         if self._shared_loaded:

--- a/tests/core/test_plugin_stub_scan.py
+++ b/tests/core/test_plugin_stub_scan.py
@@ -50,13 +50,19 @@ def agent(
     return GraphNode(node=spec)
 
 
-def orchestrator(node_id: str, children: list[GraphNode]) -> GraphNode:
+def orchestrator(
+    node_id: str,
+    children: list[GraphNode],
+    *,
+    resolvers: tuple[ResolverSpec, ...] = (),
+) -> GraphNode:
     spec = OrchestratorSpec(
         id=node_id,
         name=node_id,
         description=f"{node_id} orchestrator",
         model=_MODEL,
         prompts=OrchestratorPromptSet(),
+        resolvers=resolvers,
     )
     return GraphNode(node=spec, children=tuple(children))
 
@@ -213,6 +219,26 @@ def test_missing_resolver_file_is_reported(tmp_path: Path) -> None:
 
     assert len(errors) == 1
     assert "not found" in errors[0]
+
+
+def test_orchestrator_resolver_is_scanned_like_an_agent_one(tmp_path: Path) -> None:
+    # An orchestrator's prompt takes variables too, so an unimplemented stub
+    # behind one is the same defect and must be reported the same way.
+    write(
+        tmp_path,
+        "plugins/resolvers/root.py",
+        "class Resolver:\n"
+        "    def audience(self, ctx: dict) -> str:\n"
+        "        raise NotImplementedError\n",
+    )
+    spec = system(
+        orchestrator("root", [agent("a")], resolvers=(ResolverSpec(id="audience", scope="agent"),))
+    )
+
+    errors = scan(spec, tmp_path)
+
+    assert len(errors) == 1
+    assert "audience" in errors[0]
 
 
 def test_unknown_method_is_skipped_not_flagged(tmp_path: Path) -> None:

--- a/tests/engine/test_engine_flow.py
+++ b/tests/engine/test_engine_flow.py
@@ -36,6 +36,7 @@ from agent_engine.core.spec import (
 from agent_engine.engine.langgraph.engine import LangGraphEngine
 from agent_engine.engine.langgraph.filters import AccessFilter
 from agent_engine.engine.types import RunResult
+from agent_engine.loaders.resolver_loader import ResolverLoader
 from agent_engine.runtime.hooks import AuthContext, RunContext
 from agent_engine.runtime.state import GraphState
 from agent_engine.tool_usage.context import ToolUsageContextProvider
@@ -438,9 +439,29 @@ async def test_orchestrator_fallback_model_execution(tmp_path: Path, model_facto
     assert result.visited == ["root", "root/child"]
 
 
-async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
-    from langchain_core.messages import AIMessage
+class CapturingModel:
+    """Records the system prompt it was handed, and answers without routing."""
 
+    def __init__(self) -> None:
+        self.captured_prompt: Any = None
+
+    def bind_tools(self, tools: list[Any]) -> Any:
+        return self
+
+    async def ainvoke(self, messages: list[Any]) -> Any:
+        from langchain_core.messages import AIMessage
+
+        self.captured_prompt = messages[0].content
+        return AIMessage(content="done")
+
+
+def write_resolver(base_dir: Path, node_id: str, body: str) -> None:
+    resolvers_dir = base_dir / "plugins" / "resolvers"
+    resolvers_dir.mkdir(parents=True, exist_ok=True)
+    (resolvers_dir / f"{node_id}.py").write_text(body, encoding="utf-8")
+
+
+async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
     from agent_engine.core.spec import OrchestratorPromptSet, OrchestratorSpec
     from agent_engine.engine.langgraph.nodes import _ORCHESTRATOR_CONTRACT, OrchestratorNode
 
@@ -449,17 +470,6 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
     orch_path = tmp_path / "orchestrator.md"
     sys_path.write_text("System persona content", encoding="utf-8")
     orch_path.write_text("Orchestrator routing content", encoding="utf-8")
-
-    class CapturingModel:
-        def __init__(self) -> None:
-            self.captured_prompt = None
-
-        def bind_tools(self, tools: list[Any]) -> Any:
-            return self
-
-        async def ainvoke(self, messages: list[Any]) -> AIMessage:
-            self.captured_prompt = messages[0].content
-            return AIMessage(content="done")
 
     # 1. Test both prompts loaded
     spec_both = OrchestratorSpec(
@@ -479,6 +489,7 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         model=cast(Any, model_both),
         children=[],
         filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
         base_dir=tmp_path,
         usage_context=usage_context(),
         usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
@@ -506,6 +517,7 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         model=cast(Any, model_sys),
         children=[],
         filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
         base_dir=tmp_path,
         usage_context=usage_context(),
         usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
@@ -532,6 +544,7 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         model=cast(Any, model_orch),
         children=[],
         filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
         base_dir=tmp_path,
         usage_context=usage_context(),
         usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
@@ -555,6 +568,7 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
         model=cast(Any, model_desc),
         children=[],
         filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
         base_dir=tmp_path,
         usage_context=usage_context(),
         usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
@@ -562,3 +576,148 @@ async def test_orchestrator_loads_both_prompts(tmp_path: Path) -> None:
     await node_desc({"message": "hi", "visited": []})
     expected_desc = f"orch desc\n\n\n{_ORCHESTRATOR_CONTRACT}"
     assert model_desc.captured_prompt == expected_desc
+
+
+async def test_orchestrator_prompts_interpolate_resolver_values(tmp_path: Path) -> None:
+    """A router's prompt can depend on who is asking, not just on the file.
+
+    Both of an orchestrator's prompt files are rendered against the same
+    resolved values, while the engine's own contract text is left alone.
+    """
+    from agent_engine.core.spec import (
+        OrchestratorPromptSet,
+        OrchestratorSpec,
+        ResolverSpec,
+    )
+    from agent_engine.engine.langgraph.nodes import _ORCHESTRATOR_CONTRACT, OrchestratorNode
+
+    (tmp_path / "system.md").write_text("Persona for {{audience}}", encoding="utf-8")
+    (tmp_path / "orchestrator.md").write_text("Routing for {{audience}}", encoding="utf-8")
+    write_resolver(
+        tmp_path,
+        "root",
+        "class Resolver:\n    def audience(self, ctx: dict) -> str:\n        return 'an admin'\n",
+    )
+
+    model = CapturingModel()
+    node = OrchestratorNode(
+        spec=OrchestratorSpec(
+            id="root",
+            name="root",
+            description="root desc",
+            model=_MODEL,
+            resolvers=(ResolverSpec(id="audience", scope="agent"),),
+            prompts=OrchestratorPromptSet(system="system.md", orchestrator="orchestrator.md"),
+        ),
+        node_path="root",
+        model=cast(Any, model),
+        children=[],
+        filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
+        base_dir=tmp_path,
+        usage_context=usage_context(),
+        usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
+    )
+
+    await node({"message": "hi", "visited": []})
+
+    assert model.captured_prompt == (
+        f"Persona for an admin\n\nRouting for an admin\n{_ORCHESTRATOR_CONTRACT}"
+    )
+
+
+async def test_orchestrator_resolvers_run_on_every_call(tmp_path: Path) -> None:
+    """Resolved per run, never cached — one caller's value must not be reused
+    for the next, which is the whole point of resolving from the request."""
+    from agent_engine.core.spec import (
+        OrchestratorPromptSet,
+        OrchestratorSpec,
+        ResolverSpec,
+    )
+    from agent_engine.engine.langgraph.nodes import OrchestratorNode
+
+    (tmp_path / "orchestrator.md").write_text("caller={{caller}}", encoding="utf-8")
+    write_resolver(
+        tmp_path,
+        "root",
+        "class Resolver:\n"
+        "    def __init__(self) -> None:\n"
+        "        self.calls = 0\n"
+        "    def caller(self, ctx: dict) -> str:\n"
+        "        self.calls += 1\n"
+        "        return f'user-{self.calls}'\n",
+    )
+
+    loader = ResolverLoader(tmp_path)
+    spec = OrchestratorSpec(
+        id="root",
+        name="root",
+        description="root desc",
+        model=_MODEL,
+        resolvers=(ResolverSpec(id="caller", scope="agent"),),
+        prompts=OrchestratorPromptSet(orchestrator="orchestrator.md"),
+    )
+    prompts = []
+    for _ in range(2):
+        model = CapturingModel()
+        node = OrchestratorNode(
+            spec=spec,
+            node_path="root",
+            model=cast(Any, model),
+            children=[],
+            filters=[],
+            resolver_loader=loader,
+            base_dir=tmp_path,
+            usage_context=usage_context(),
+            usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),
+        )
+        await node({"message": "hi", "visited": []})
+        prompts.append(model.captured_prompt)
+
+    assert "caller=user-1" in prompts[0]
+    assert "caller=user-2" in prompts[1]
+
+
+async def test_engine_wires_resolvers_into_orchestrator_prompts(tmp_path: Path) -> None:
+    """The same thing through the real engine, so the node's dependency is
+    proven to be wired by `build`, not only by a hand-constructed node."""
+    from agent_engine.core.spec import (
+        OrchestratorPromptSet,
+        OrchestratorSpec,
+        ResolverSpec,
+    )
+
+    (tmp_path / "orchestrator.md").write_text("Routing for {{audience}}", encoding="utf-8")
+    write_resolver(
+        tmp_path,
+        "root",
+        "class Resolver:\n    def audience(self, ctx: dict) -> str:\n        return 'an admin'\n",
+    )
+
+    root = GraphNode(
+        node=OrchestratorSpec(
+            id="root",
+            name="root",
+            description="root desc",
+            model=_MODEL,
+            resolvers=(ResolverSpec(id="audience", scope="agent"),),
+            prompts=OrchestratorPromptSet(orchestrator="orchestrator.md"),
+        ),
+        children=(agent("solo"),),
+    )
+
+    captured: list[str] = []
+
+    def capturing_factory(provider: str, name: str, temperature: float | None) -> Any:
+        model = CapturingModel()
+
+        async def ainvoke(messages: list[Any]) -> Any:
+            captured.append(str(messages[0].content))
+            return await CapturingModel.ainvoke(model, messages)
+
+        model.ainvoke = ainvoke  # type: ignore[method-assign]
+        return model
+
+    await run_message(system(root), tmp_path, capturing_factory, "hi")
+
+    assert any("Routing for an admin" in prompt for prompt in captured)

--- a/tests/engine/test_executed_tools_tool.py
+++ b/tests/engine/test_executed_tools_tool.py
@@ -20,6 +20,7 @@ from agent_engine.engine.langgraph.executed_tools_tool import (
     build_executed_tools_tool,
 )
 from agent_engine.engine.langgraph.nodes import OrchestratorNode
+from agent_engine.loaders.resolver_loader import ResolverLoader
 from agent_engine.runtime.hooks import RunContext, current_run_context
 from agent_engine.tool_usage.context import ToolUsageContextProvider
 from agent_engine.tool_usage.in_memory import InMemoryToolUsageRepository
@@ -185,6 +186,7 @@ async def test_an_orchestrator_with_no_reachable_children_is_bound_no_tools(
         model=cast(Any, model),
         children=[],
         filters=[],
+        resolver_loader=ResolverLoader(tmp_path),
         base_dir=tmp_path,
         usage_context=ToolUsageContextProvider(InMemoryToolUsageRepository()),
         usage_tracker=ToolUsageTracker(InMemoryToolUsageRepository()),


### PR DESCRIPTION
## Why

`resolvers` was accepted on an orchestrator everywhere except where it counts.

The YAML parser read it, `NodeSpec` carried it, and the JSON schema documented it — `$defs.orchestrator.properties.resolvers` reads *"Resolver ids whose values are needed to fill `{{variables}}` in this node's prompts."* But `OrchestratorNode.__call__` loaded its two prompt files, concatenated them, and handed them to the model untouched. No resolver ran, nothing was rendered.

So a declared variable reached the model as the literal text `{{name}}` — silently. Nothing failed, nothing warned; the prompt simply contained braces where a value was meant to be.

That gap decided what a router's prompt could be: fixed text. Anything depending on the request — who is asking, what they are allowed to do — had to be written once for the most-permissive caller and left to the model to disregard for everyone else. That is not a control.

The concrete case this came from: a top-level router whose prompt names an admin-only destination. `protected: true` already hides that node from routing for non-admins, but the router's own prompt still described it to every caller.

## What

`AgentNode` already resolved and rendered correctly, so this shares what it had rather than writing a second copy:

- `resolve_prompt_context(loader, spec)` moves out of `AgentNode` into `helpers.py`, typed on `NodeSpec`. Both node types call it; `AgentNode`'s own method is deleted, not duplicated.
- `OrchestratorNode` takes a `ResolverLoader` (as `AgentNode` already does) and renders **both** of its prompt files against one resolved context, so a variable resolves identically wherever it appears.
- `_ORCHESTRATOR_CONTRACT` is appended *after* rendering. It is engine text, not the client's template, and is never subject to interpolation.

Two other consumers gated the same feature on `AgentSpec` and no longer do:

- **`agentctl generate`** scaffolds an orchestrator's resolver stub and its manifest entry.
- **`agentctl validate`** reports that stub while it is still unimplemented.

Without those two, this worked only for someone who already knew to hand-write `plugins/resolvers/<id>.py` — which is the same half-wired state the runtime was in.

## Safety

- Rendering stays a **single non-recursive pass**. A resolved value that happens to contain `{{x}}` is not expanded again, so a resolver cannot reach past the one slot it fills.
- Values are resolved **per run and never cached** — only the resolver *instance* is reused, exactly as before. One caller's value cannot be served to the next, which is the property that makes per-request prompts safe to build on.
- A resolver that raises fails the run, unchanged from the agent path. Deliberately *not* the access plugin's fail-closed-and-continue behaviour: a missing prompt variable should be loud, not silently shipped to the model.
- Resolver output is trusted plugin code, the same trust boundary agents have had. No new boundary is crossed.

## Compatibility

No behaviour change for a node that declares no resolvers: rendering against an empty context returns the template unchanged. The existing orchestrator prompt-assembly tests assert the composed prompt byte for byte and were not modified.

`OrchestratorNode.__init__` gains a required `resolver_loader`. It is internal and constructed by the engine; the five test call sites are updated in this PR.

Naming inside `generate`/`validate` follows the widened scope (`agent_resolver_ids` → `node_resolver_ids`, `_check_resolvers(agent:)` → `(node:)`, and `ResolverLoader`'s `agent_id` → `node_id`), since those names now describe orchestrators too. Private symbols only — no public API renamed.

## Docs

`YAML_SPEC.md`, `plugins.mdx`, and `SIDECAR_CONTEXT_AUTH.md` said resolvers were an agent thing. They now say node, and `YAML_SPEC.md` states outright that an orchestrator's prompts are rendered against the same resolved values. `ResolverLoader`'s docstring also now pins the instance-cached / values-not-cached distinction.

## Tests

Four added:

- an orchestrator's `{{var}}` is interpolated into **both** prompt files, with the engine contract left alone;
- resolvers re-run on **every** call, so a per-caller value is never reused (the invariant the security argument rests on);
- the same through the real `LangGraphEngine`, proving `build` wires the dependency — not just a hand-constructed node;
- `validate` reports an unimplemented orchestrator resolver stub.

Verified end to end against the CLI outside the test suite: `generate` created `plugins/resolvers/root.py` plus the manifest entry, `validate` then failed with `✗ [root.resolvers.audience] Resolver 'audience' is declared but not implemented (generated stub)`, and passed once implemented.

`make check` is clean — 854 passed (from 850), ruff and mypy green across 218 source files.

> Unrelated: running the ad-hoc combination `pytest tests/engine tests/core tests/generate tests/cli` fails two `tests/cli/test_validate_command.py` cases through cross-test pollution. That reproduces identically on a clean `main` and is not touched by this PR; `make check` (what CI runs) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
