### PR TITLE
fix: recover the original result on a duplicate approval decision

### DIFF
--- a/src/agent_engine/api/app.py
+++ b/src/agent_engine/api/app.py
@@ -26,6 +26,7 @@ from agent_engine.api.schemas import (
 )
 from agent_engine.approvals.decision import ApprovalDecision, parse_decision
 from agent_engine.approvals.errors import (
+    ApprovalAlreadyProcessed,
     ApprovalError,
     InvalidDecision,
     approval_http_status,
@@ -311,15 +312,32 @@ def create_app(
     ) -> InvokeResponse:
         engine = _hitl_engine()
         auth = _auth_context(authorization)
+        caller_session_id = _run_context(session_id, run_id=run_id).conversation_id
         try:
             result = await engine.resume(
                 run_id,
                 approval_id,
                 decision,
                 caller_user_id=user_id,
-                caller_session_id=_run_context(session_id, run_id=run_id).conversation_id,
+                caller_session_id=caller_session_id,
                 access_token=auth.inbound_access_token if auth else None,
             )
+        except ApprovalAlreadyProcessed as exc:
+            # A duplicate decision is usually a client retry after a network
+            # timeout, not an error: the decision it is re-sending already
+            # succeeded. Recover the original result so the retry sees the same
+            # answer it would have seen the first time, matching what
+            # ConversationService already does for the same exception. Only fall
+            # through to the 409 when the result is genuinely unavailable.
+            recovered = await engine.get_processed_result(
+                run_id,
+                approval_id,
+                caller_user_id=user_id,
+                caller_session_id=caller_session_id,
+            )
+            if recovered is None:
+                raise _map_approval_error(exc) from exc
+            result = recovered
         except ApprovalError as exc:
             raise _map_approval_error(exc) from exc
         except Exception:

--- a/tests/api/test_approval_endpoints.py
+++ b/tests/api/test_approval_endpoints.py
@@ -230,6 +230,25 @@ def test_approve_with_no_body_at_all_succeeds(client: TestClient) -> None:
     assert response.json()["status"] == "completed"
 
 
+def test_duplicate_approval_recovers_the_original_result(client: TestClient) -> None:
+    """A retried decision returns the first result, not a bare 409.
+
+    A client that times out and retries has no way to read 409 as "your
+    decision already succeeded". ConversationService already recovers via
+    get_processed_result for this case; the HTTP layer must match.
+    """
+    run_id, approval_id = _trigger_pending_approval(client)
+
+    first = client.post(f"/runs/{run_id}/approvals/{approval_id}/approve")
+    assert first.status_code == 200
+
+    duplicate = client.post(f"/runs/{run_id}/approvals/{approval_id}/approve")
+
+    assert duplicate.status_code == 200
+    assert duplicate.json()["status"] == first.json()["status"]
+    assert duplicate.json()["answer"] == first.json()["answer"]
+
+
 def test_reject_with_no_body_at_all_succeeds(client: TestClient) -> None:
     run_id, approval_id = _trigger_pending_approval(client)
 


### PR DESCRIPTION
Closes #109.

## Problem

`/approve`, `/reject` and `/decision` all funnel through `_decide` in `src/agent_engine/api/app.py`, which mapped `ApprovalAlreadyProcessed` straight to a `409` with no recovery. A client that retries after a network timeout has no way to read `409` as "the decision you're re-sending already succeeded", so a successful approval surfaces as an error.

`ConversationService.resume_run` already handles this exact exception by recovering the original result. The HTTP layer was the inconsistent one.

## Change

Catch `ApprovalAlreadyProcessed` ahead of the general `ApprovalError` handler and recover through `engine.get_processed_result(...)`, mirroring the `agent_manager` precedent:

```python
except ApprovalAlreadyProcessed as exc:
    recovered = await engine.get_processed_result(
        run_id, approval_id,
        caller_user_id=user_id,
        caller_session_id=caller_session_id,
    )
    if recovered is None:
        raise _map_approval_error(exc) from exc
    result = recovered
```

The `409` is still returned when the result is genuinely unavailable, so nothing that previously failed now silently succeeds. Every other `ApprovalError` keeps its existing mapping, and session-scoping is unchanged — `get_processed_result` receives the same `caller_session_id` that `resume` did (hoisted into a local so the two calls can't drift).

## Testing

Added `test_duplicate_approval_recovers_the_original_result` in `tests/api/test_approval_endpoints.py`: it approves once, approves again, and asserts the second call returns `200` with the same `status` and `answer` as the first.

Confirmed it guards the change — with the `app.py` hunk stashed it fails on `assert 409 == 200`.

```
pytest tests/api tests/approvals   # 134 passed
ruff check src/agent_engine/api/app.py tests/api/test_approval_endpoints.py   # All checks passed
```
