### PR TITLE
fix(widget): stop the chat history list squashing rows instead of scrolling

### DIFF
--- a/src/agent_manager/api/static/widget.js
+++ b/src/agent_manager/api/static/widget.js
@@ -54345,6 +54345,12 @@ function styles(config) {
       padding: 10px 12px; border-radius: 10px; font-size: 13.5px; color: #3f3f46;
       font-family: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       transition: background .12s; }
+    /* The drawer is a flex column, so its children inherit flex-shrink: 1 and the browser
+       compresses them to fit rather than letting .thread-list overflow. At ~20 conversations the
+       rows fell from their natural 36px to 24.5px with no scrollbar at all, and by 45 they were
+       19px -- padding only, with the titles clipped top and bottom. Opting out restores natural
+       height and lets the list's own overflow-y: auto do its job. */
+    .thread-drawer-head, .thread-new, .thread-item { flex: 0 0 auto; }
     .thread-item:hover { background: #f4f4f5; }
     .thread-item.active { background: #f4f4f5; color: #18181b; font-weight: 600; }
     .thread-empty { color: #a1a1aa; font-size: 13px; text-align: center; padding: 24px 12px; margin: 0; }

--- a/src/agent_manager/api/static/widget/styles/styles.ts
+++ b/src/agent_manager/api/static/widget/styles/styles.ts
@@ -80,6 +80,12 @@ export function styles(config: AgentChatConfig): string {
       padding: 10px 12px; border-radius: 10px; font-size: 13.5px; color: #3f3f46;
       font-family: inherit; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       transition: background .12s; }
+    /* The drawer is a flex column, so its children inherit flex-shrink: 1 and the browser
+       compresses them to fit rather than letting .thread-list overflow. At ~20 conversations the
+       rows fell from their natural 36px to 24.5px with no scrollbar at all, and by 45 they were
+       19px -- padding only, with the titles clipped top and bottom. Opting out restores natural
+       height and lets the list's own overflow-y: auto do its job. */
+    .thread-drawer-head, .thread-new, .thread-item { flex: 0 0 auto; }
     .thread-item:hover { background: #f4f4f5; }
     .thread-item.active { background: #f4f4f5; color: #18181b; font-weight: 600; }
     .thread-empty { color: #a1a1aa; font-size: 13px; text-align: center; padding: 24px 12px; margin: 0; }


### PR DESCRIPTION
Closes #61.

## Change

Exactly the fix the issue proposes, in `widget/styles/styles.ts`:

```css
.thread-drawer-head, .thread-new, .thread-item { flex: 0 0 auto; }
```

`.thread-drawer` is a flex column, so those three inherited `flex-shrink: 1` and the browser compressed them to fit instead of letting `.thread-list` overflow and use the `overflow-y: auto` it already declares.

`src/agent_manager/api/static/widget.js` is rebuilt with `npm run build:widget`, since it's committed and carries the bundled CSS — the fix would otherwise not reach anyone serving the prebuilt widget.

## Measured

I rebuilt your isolated repro rather than taking the numbers on trust: real Chromium via the repo's Playwright, panel at 440x680, CSS read straight out of `styles.ts` so the measurement can't drift from what ships.

| conversations | row height (before) | row height (after) | scrollable before → after |
|---|---|---|---|
| 5 | 34.2px | 34.2px | no → no *(correct — nothing to scroll)* |
| 20 | **24.5px** | 34.2px | **no** → **yes** |
| 45 | **19px** | 34.2px | yes → yes |

That lines up with your table (24.9px / 20px; the ~1px differences are font rendering on this machine). The row height is now constant across 5, 20 and 45 — which is the actual property being fixed: height no longer depends on how many conversations exist.

## Checks

```
npm run build:widget      # bundle rebuilt, carries the rule
npm run typecheck:widget  # clean
npm run test:widget       # widget self-check: OK
pytest tests/api tests/approvals   # 133 passed
```

The `.thread-item` ellipsis behaviour is untouched — this only stops the vertical compression, which is the half `text-overflow` never covered.
