### PR TITLE
fix: correctly bind async local plugins as coroutines

### DIFF
--- a/src/agent_engine/engine/langgraph/graph/graph_builder.py
+++ b/src/agent_engine/engine/langgraph/graph/graph_builder.py
@@ -255,7 +255,10 @@ class GraphBuilder:
         server_by_tool: dict[str, str] = {}
         for tool_spec in spec.tools:
             function = self._tool_loader.load(tool_spec.id)
-            tools.append(StructuredTool.from_function(function, description=tool_spec.description))
+            if inspect.iscoroutinefunction(function):
+                tools.append(StructuredTool.from_function(coroutine=function, description=tool_spec.description))
+            else:
+                tools.append(StructuredTool.from_function(func=function, description=tool_spec.description))
         for mcp in spec.mcps:
             server_tools = self._mcp_tools.get(mcp.id, [])
             tools.extend(server_tools)

--- a/tests/test_review_regression.py
+++ b/tests/test_review_regression.py
@@ -1,0 +1,39 @@
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from agent_engine.engine.langgraph.engine import LangGraphEngine
+from tests.approvals.test_engine_hitl import _spec as approval_spec
+
+
+class SingleToolCallModel:
+    def __init__(self):
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        if any(isinstance(m, ToolMessage) for m in messages):
+            return AIMessage(content='done')
+        self.calls += 1
+        return AIMessage(content='', tool_calls=[{
+            'name': 'record_value', 'args': {'message': 'reviewed-value'},
+            'id': f'call-{self.calls}', 'type': 'tool_call',
+        }])
+
+
+@pytest.mark.asyncio
+async def test_async_local_tool_executes(tmp_path):
+    output = tmp_path / 'async-executed.txt'
+    tool = tmp_path / 'plugins/tools/record_value.py'
+    tool.parent.mkdir(parents=True)
+    tool.write_text('from pathlib import Path\n'
+                    'async def record_value(message: str) -> str:\n'
+                    f'    Path({str(output)!r}).write_text(message)\n'
+                    '    return message\n')
+    model = SingleToolCallModel()
+    async with LangGraphEngine(tmp_path, model_factory=lambda *a, **kw: model) as engine:
+        await engine.build(approval_spec('record_value', auto_mode=True))
+        result = await engine.run('record a value')
+        print(f'async tool executed={output.exists()}, used_tools={result.used_tools}')
+        assert output.exists()


### PR DESCRIPTION
# Description

##  Problem
Currently, a local plugin implemented as `async def` is accepted during the engine build but never actually executes. The engine records the tool call as `succeeded` and hands the LLM a stringified coroutine object instead of the actual resolved value. This causes a P2 silent no-op.
fixes #141 

The root cause was that `GraphBuilder._build_agent_tools` was passing all functions through `StructuredTool.from_function(function)`. This registers async functions in the synchronous `func` slot, which LangChain's synchronous execution path returns instead of awaiting.

##  Solution
Updated `GraphBuilder._build_agent_tools` to properly detect async functions using `inspect.iscoroutinefunction(function)`. 
- If it is a coroutine, it registers it using `coroutine=function`.
- If it is synchronous, it continues to use `func=function`.

## Testing and Verification
- [x] Added an executable regression test (`tests/test_review_regression.py`) that mocks a model and verifies that the `async def` body physically executes and writes to disk.
- [x] Existing synchronous local tools continue to work perfectly.
- [x] Ran `make check` and verified that formatting, linting, type-checking, and all tests pass locally.
